### PR TITLE
Deal with Bad Migration When Extending Persisted Entity

### DIFF
--- a/EntityFramework.sln.DotSettings
+++ b/EntityFramework.sln.DotSettings
@@ -63,6 +63,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/EntityFramework/Migrations/Infrastructure/EdmModelDiffer.cs
+++ b/src/EntityFramework/Migrations/Infrastructure/EdmModelDiffer.cs
@@ -84,7 +84,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
                 {
                     EdmItemCollection = storageMappingItemCollection.EdmItemCollection,
                     StoreItemCollection = storageMappingItemCollection.StoreItemCollection,
-                    StoreEntityContainer 
+                    StoreEntityContainer
                         = storageMappingItemCollection.StoreItemCollection.GetItems<EntityContainer>().Single(),
                     EntityContainerMapping
                         = storageMappingItemCollection.GetItems<EntityContainerMapping>().Single(),
@@ -109,11 +109,11 @@ namespace System.Data.Entity.Migrations.Infrastructure
                 };
 
             return Diff(
-                source, 
-                target, 
-                modificationCommandTreeGenerator, 
-                migrationSqlGenerator, 
-                sourceModelVersion, 
+                source,
+                target,
+                modificationCommandTreeGenerator,
+                migrationSqlGenerator,
+                sourceModelVersion,
                 targetModelVersion);
         }
 
@@ -328,6 +328,27 @@ namespace System.Data.Entity.Migrations.Infrastructure
                     / (entityType1.DeclaredMembers.Count + entityType2.DeclaredMembers.Count)) > 0.80;
         }
 
+        private bool SourceAndTargetMatch(EntityType sourceEntityType, EntityTypeMapping sourceEntityTypeMapping, EntityType targetEntityType, EntityTypeMapping targetEntityTypeMapping)
+        {
+            return (sourceEntityTypeMapping.EntityType != null
+                    && targetEntityTypeMapping.EntityType != null
+                    && sourceEntityType == sourceEntityTypeMapping.EntityType
+                    && targetEntityType == targetEntityTypeMapping.EntityType)
+                   || (sourceEntityTypeMapping.EntityType == null
+                       && targetEntityTypeMapping.EntityType == null
+                       && sourceEntityTypeMapping.IsOfTypes.Contains(sourceEntityType)
+                       && targetEntityTypeMapping.IsOfTypes.Contains(targetEntityType)
+                       && sourceEntityTypeMapping.IsOfTypes.Except(new[] { sourceEntityType }).Select(et => et.Name)
+                           .SequenceEqual(targetEntityTypeMapping.IsOfTypes.Except(new[] { targetEntityType }).Select(et => et.Name)));
+        }
+
+        private bool MappingTypesAreIdentical(EntityTypeMapping sourceEntityTypeMapping, EntityTypeMapping targetEntityTypeMapping)
+        {
+            var canonicalSourceEntityMappingType = sourceEntityTypeMapping.EntityType ?? sourceEntityTypeMapping.IsOfTypes.First();
+            var canonicalTargetEntityMappingType = targetEntityTypeMapping.EntityType ?? targetEntityTypeMapping.IsOfTypes.First();
+            return canonicalSourceEntityMappingType.FullName == canonicalTargetEntityMappingType.FullName;
+        }
+
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         private IEnumerable<Tuple<MappingFragment, MappingFragment>> FindMappingFragmentPairs(
             ICollection<Tuple<EntityType, EntityType>> entityTypePairs)
@@ -337,36 +358,42 @@ namespace System.Data.Entity.Migrations.Infrastructure
             // Zip the two models together. Our goal here is to match mapping fragments across
             // the source and target input models.
 
-            var targetEntityTypeMappings 
+            var targetEntityTypeMappings
                 = _target.EntityContainerMapping.EntitySetMappings
                     .SelectMany(esm => esm.EntityTypeMappings)
                     .ToList();
 
-            foreach (var etm1
-                in _source.EntityContainerMapping.EntitySetMappings.SelectMany(esm => esm.EntityTypeMappings))
+            var sourceEntityTypeMappings = _source.EntityContainerMapping.EntitySetMappings.SelectMany(esm => esm.EntityTypeMappings);
+
+            var matchedTargets = new List<EntityTypeMapping>();
+
+            foreach (var etm1 in sourceEntityTypeMappings)
             {
                 foreach (var etm2 in targetEntityTypeMappings)
                 {
-                    if (entityTypePairs
-                        .Any(
-                            t => (etm1.EntityType != null
-                                  && etm2.EntityType != null
-                                  && t.Item1 == etm1.EntityType
-                                  && t.Item2 == etm2.EntityType)
-                                 || (etm1.EntityType == null
-                                     && etm2.EntityType == null
-                                     && etm1.IsOfTypes.Contains(t.Item1)
-                                     && etm2.IsOfTypes.Contains(t.Item2)
-                                     && etm1.IsOfTypes.Except(new[] { t.Item1 }).Select(et => et.Name)
-                                         .SequenceEqual(etm2.IsOfTypes.Except(new[] { t.Item2 }).Select(et => et.Name)))))
+                    if (matchedTargets.Contains(etm2))
                     {
-                        foreach (var t in etm1.MappingFragments.Zip(etm2.MappingFragments, Tuple.Create))
-                        {
-                            yield return t;
-                        }
-
-                        break;
+                        continue;
                     }
+
+                    var sourceAndTargetMatch = entityTypePairs.Any(t => SourceAndTargetMatch(t.Item1, etm1, t.Item2, etm2));
+                    if (!sourceAndTargetMatch)
+                    {
+                        sourceAndTargetMatch = MappingTypesAreIdentical(etm1, etm2);
+                    }
+
+                    if (!sourceAndTargetMatch)
+                    {
+                        continue;
+                    }
+
+                    matchedTargets.Add(etm2);
+                    foreach (var t in etm1.MappingFragments.Zip(etm2.MappingFragments, Tuple.Create))
+                    {
+                        yield return t;
+                    }
+
+                    break;
                 }
             }
         }
@@ -1190,7 +1217,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var parameter1 = parameterBinding1.Parameter;
             var parameter2 = parameterBinding2.Parameter;
-            
+
             if (!parameter1.Name.EqualsOrdinal(parameter2.Name))
             {
                 return false;
@@ -1213,7 +1240,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             {
                 return false;
             }
-            
+
             if (_source.ProviderInfo.Equals(_target.ProviderInfo))
             {
                 return parameter1.TypeName.EqualsIgnoreCase(parameter2.TypeName)
@@ -1499,7 +1526,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
         private IEnumerable<MigrationOperation> FindAlteredPrimaryKeys(
             ICollection<Tuple<EntitySet, EntitySet>> tablePairs,
-            ICollection<RenameColumnOperation> renamedColumns, 
+            ICollection<RenameColumnOperation> renamedColumns,
             ICollection<AlterColumnOperation> alteredColumns)
         {
             DebugCheck.NotNull(tablePairs);
@@ -1666,18 +1693,18 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             return dropForeignKeyOperation;
         }
-        
+
         private static void BuildForeignKeyOperation(
-            ReferentialConstraint referentialConstraint, 
-            ForeignKeyOperation foreignKeyOperation, 
+            ReferentialConstraint referentialConstraint,
+            ForeignKeyOperation foreignKeyOperation,
             ModelMetadata modelMetadata)
         {
             DebugCheck.NotNull(referentialConstraint);
             DebugCheck.NotNull(foreignKeyOperation);
             DebugCheck.NotNull(modelMetadata);
 
-            foreignKeyOperation.PrincipalTable 
-                = GetSchemaQualifiedName( 
+            foreignKeyOperation.PrincipalTable
+                = GetSchemaQualifiedName(
                     modelMetadata.StoreEntityContainer.EntitySets
                     .Single(es => es.ElementType == referentialConstraint.PrincipalEnd.GetEntityType()));
 
@@ -1860,7 +1887,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
         private static bool IndexesEqual(
             ConsolidatedIndex consolidatedIndex1,
-            ConsolidatedIndex consolidatedIndex2, 
+            ConsolidatedIndex consolidatedIndex2,
             ICollection<RenameColumnOperation> renamedColumns)
         {
             DebugCheck.NotNull(consolidatedIndex1);
@@ -1977,7 +2004,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var targetAnnotations = BuildAnnotationPairs(
                 GetAnnotations(sourceProperty), GetAnnotations(targetProperty));
-            
+
             var sourceAnnotations = targetAnnotations
                 .ToDictionary(a => a.Key, a => new AnnotationValues(a.Value.NewValue, a.Value.OldValue));
 

--- a/src/EntityFramework/Migrations/Infrastructure/EdmModelDiffer.cs
+++ b/src/EntityFramework/Migrations/Infrastructure/EdmModelDiffer.cs
@@ -330,16 +330,37 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
         private bool SourceAndTargetMatch(EntityType sourceEntityType, EntityTypeMapping sourceEntityTypeMapping, EntityType targetEntityType, EntityTypeMapping targetEntityTypeMapping)
         {
-            return (sourceEntityTypeMapping.EntityType != null
-                    && targetEntityTypeMapping.EntityType != null
-                    && sourceEntityType == sourceEntityTypeMapping.EntityType
+            if (sourceEntityTypeMapping.EntityType != null
+                && targetEntityTypeMapping.EntityType != null)
+            {
+                if (sourceEntityType == sourceEntityTypeMapping.EntityType
                     && targetEntityType == targetEntityTypeMapping.EntityType)
-                   || (sourceEntityTypeMapping.EntityType == null
-                       && targetEntityTypeMapping.EntityType == null
-                       && sourceEntityTypeMapping.IsOfTypes.Contains(sourceEntityType)
-                       && targetEntityTypeMapping.IsOfTypes.Contains(targetEntityType)
-                       && sourceEntityTypeMapping.IsOfTypes.Except(new[] { sourceEntityType }).Select(et => et.Name)
-                           .SequenceEqual(targetEntityTypeMapping.IsOfTypes.Except(new[] { targetEntityType }).Select(et => et.Name)));
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                var sourceTypes = sourceEntityTypeMapping.IsOfTypes;
+
+                if (sourceTypes.Contains(sourceEntityType))
+                {
+                    var targetTypes = targetEntityTypeMapping.IsOfTypes;
+
+                    if (targetTypes.Contains(targetEntityType))
+                    {
+                        var sourceTypeNames = sourceTypes.Except(new[] { sourceEntityType }).Select(et => et.Name);
+                        var targetTypeNames = targetTypes.Except(new[] { targetEntityType }).Select(et => et.Name);
+
+                        if (sourceTypeNames.SequenceEqual(targetTypeNames))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
 
         private bool MappingTypesAreIdentical(EntityTypeMapping sourceEntityTypeMapping, EntityTypeMapping targetEntityTypeMapping)

--- a/src/EntityFramework/Migrations/Infrastructure/EdmModelDiffer.cs
+++ b/src/EntityFramework/Migrations/Infrastructure/EdmModelDiffer.cs
@@ -328,7 +328,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
                     / (entityType1.DeclaredMembers.Count + entityType2.DeclaredMembers.Count)) > 0.80;
         }
 
-        private bool SourceAndTargetMatch(EntityType sourceEntityType, EntityTypeMapping sourceEntityTypeMapping, EntityType targetEntityType, EntityTypeMapping targetEntityTypeMapping)
+        private static bool SourceAndTargetMatch(EntityType sourceEntityType, EntityTypeMapping sourceEntityTypeMapping, EntityType targetEntityType, EntityTypeMapping targetEntityTypeMapping)
         {
             if (sourceEntityTypeMapping.EntityType != null
                 && targetEntityTypeMapping.EntityType != null)
@@ -363,7 +363,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             return false;
         }
 
-        private bool MappingTypesAreIdentical(EntityTypeMapping sourceEntityTypeMapping, EntityTypeMapping targetEntityTypeMapping)
+        private static bool MappingTypesAreIdentical(EntityTypeMapping sourceEntityTypeMapping, EntityTypeMapping targetEntityTypeMapping)
         {
             var canonicalSourceEntityMappingType = sourceEntityTypeMapping.EntityType ?? sourceEntityTypeMapping.IsOfTypes.First();
             var canonicalTargetEntityMappingType = targetEntityTypeMapping.EntityType ?? targetEntityTypeMapping.IsOfTypes.First();

--- a/test/EntityFramework/UnitTests/App.config
+++ b/test/EntityFramework/UnitTests/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <configuration>
   <configSections>
@@ -13,9 +13,9 @@
   </system.data>
   <entityFramework codeConfigurationType="System.Data.Entity.TestHelpers.FunctionalTestsConfiguration, EntityFramework.FunctionalTests.Transitional">
     <providers>
-      <provider invariantName="System.Data.FakeSqlClient" type="System.Data.Entity.ModelConfiguration.Internal.UnitTests.FakeSqlProviderServices, EntityFramework.UnitTests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
-      <provider invariantName="System.Data.SqlServerCe.4.0" type="System.Data.Entity.SqlServerCompact.SqlCeProviderServices, EntityFramework.SqlServerCompact"/>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="System.Data.FakeSqlClient" type="System.Data.Entity.ModelConfiguration.Internal.UnitTests.FakeSqlProviderServices, EntityFramework.UnitTests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      <provider invariantName="System.Data.SqlServerCe.4.0" type="System.Data.Entity.SqlServerCompact.SqlCeProviderServices, EntityFramework.SqlServerCompact" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
   <connectionStrings>
@@ -42,7 +42,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="EnvDTE" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="7.0.3300.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/EntityFramework/UnitTests/Migrations/Infrastructure/EdmModelDifferTests.cs
+++ b/test/EntityFramework/UnitTests/Migrations/Infrastructure/EdmModelDifferTests.cs
@@ -19,8 +19,12 @@ namespace System.Data.Entity.Migrations.Infrastructure
     using System.Data.Entity.ModelConfiguration.Conventions;
     using System.Data.Entity.SqlServer;
     using System.Data.Entity.Utilities;
+    using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Xml.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
     using Xunit;
     using Order = System.Data.Entity.Migrations.Order;
 
@@ -45,7 +49,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             modelBuilder.Entity<ManyManySelfRef>();
 
             var model1 = modelBuilder.Build(ProviderInfo);
-            
+
             modelBuilder.Entity<ManyManySelfRef>().ToTable("Renamed");
 
             var model2 = modelBuilder.Build(ProviderInfo);
@@ -72,7 +76,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             var tableRename = (RenameTableOperation)operations.Single();
@@ -99,7 +103,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations= new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
+            var operations = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.IsType<RenameTableOperation>(operations.Single());
         }
@@ -640,7 +644,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             Assert.Equal(3, operations.Count());
 
-            var tableRename 
+            var tableRename
                 = operations.OfType<RenameTableOperation>().Single();
 
             Assert.Equal("dbo.B1A1", tableRename.Name);
@@ -710,9 +714,9 @@ namespace System.Data.Entity.Migrations.Infrastructure
         }
 
         #endregion
-        
+
         #region Table Moves
-        
+
         [MigrationsTheory]
         public void Can_detect_moved_tables()
         {
@@ -726,12 +730,12 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(1, operations.Count());
 
-            var moveTableOperation 
+            var moveTableOperation
                 = operations.OfType<MoveTableOperation>().Single();
 
             Assert.Equal("dbo.MigrationsCustomers", moveTableOperation.Name);
@@ -751,7 +755,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             var moveTableOperation
@@ -841,7 +845,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             Assert.Equal("foo.Join", moveTableOperation.Name);
             Assert.Equal("bar", moveTableOperation.NewSchema);
         }
-        
+
         #endregion
 
         #region Added Tables
@@ -923,14 +927,14 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer()
                     .Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(7, operations.Count());
             Assert.Equal(2, operations.OfType<AddForeignKeyOperation>().Count());
 
-            var ordersCreateTableOperation 
+            var ordersCreateTableOperation
                 = operations.OfType<CreateTableOperation>()
                     .Single(t => t.Name == "ordering.Orders");
 
@@ -1045,7 +1049,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             var createTableOperation = operations.OfType<CreateTableOperation>().Single();
@@ -1069,7 +1073,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
                 .HasTableAnnotation("AT1", "VT1")
                 .Property(e => e.OrderId)
                 .HasColumnAnnotation("AP1", "VP1");
-            
+
             var model1 = modelBuilder.Build(ProviderInfo);
 
             modelBuilder = new DbModelBuilder();
@@ -1077,7 +1081,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
                 .HasTableAnnotation("AT1", "VT2")
                 .Property(e => e.OrderId)
                 .HasColumnAnnotation("AP1", "VP1");
-            
+
             var model2 = modelBuilder.Build(ProviderInfo);
 
             var operations = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
@@ -1447,7 +1451,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(2, operations.Count());
@@ -1457,7 +1461,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             Assert.Equal("dbo.MigrationsCustomers", renameColumnOperation.Table);
             Assert.Equal("Name", renameColumnOperation.Name);
             Assert.Equal("col_Name", renameColumnOperation.NewName);
-            
+
             var alterColumnOperation = (AlterColumnOperation)operations.Last();
 
             Assert.Equal("dbo.MigrationsCustomers", alterColumnOperation.Table);
@@ -1528,7 +1532,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(1, operations.Count());
@@ -1561,7 +1565,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(2, operations.Count());
@@ -1601,7 +1605,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(3, operations.Count());
@@ -1637,7 +1641,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             var renameColumnOperation = operations.OfType<RenameColumnOperation>().Single();
@@ -1665,7 +1669,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             var renameColumnOperation = operations.OfType<RenameColumnOperation>().Single();
@@ -1703,7 +1707,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             Assert.Equal("Parent_Id", renameColumnOperation.Name);
             Assert.Equal("NewName", renameColumnOperation.NewName);
         }
-        
+
         [MigrationsTheory]
         public void Can_detect_discriminator_column_rename_when_ospace_type_renamed()
         {
@@ -1869,7 +1873,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             modelBuilder = new DbModelBuilder();
 
             modelBuilder.Entity<Renamed_ia_pk_v2.Dependent>();
-            
+
             var model2 = modelBuilder.Build(ProviderInfo);
 
             var operations
@@ -1878,7 +1882,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             Assert.Equal(8, operations.Count());
             Assert.Equal("Principal_Id", operations.OfType<DropForeignKeyOperation>().First().DependentColumns.Single());
         }
-        
+
         [MigrationsTheory]
         public void Should_introduce_temp_column_renames_when_transitive_dependencies()
         {
@@ -1962,7 +1966,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(2, operations.Count());
@@ -2031,7 +2035,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(2, operations.Count());
@@ -2058,7 +2062,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(2, operations.Count());
@@ -2085,7 +2089,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(4, operations.Count());
@@ -2103,7 +2107,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
                 .Property(e => e.OrderId)
                 .HasColumnAnnotation("A1", "V1")
                 .HasColumnAnnotation(IndexAnnotation.AnnotationName, new IndexAnnotation(new IndexAttribute("Bella")));
-            
+
             var model2 = modelBuilder.Build(ProviderInfo);
 
             modelBuilder = new DbModelBuilder();
@@ -2143,7 +2147,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             var addColumnOperation = (AddColumnOperation)operations.Single();
@@ -2166,7 +2170,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model1 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(1, operations.Count());
@@ -2253,7 +2257,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var operations = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
             Assert.Equal(2, operations.Count);
-            
+
             var dropColumnOperation = operations.OfType<DropColumnOperation>().Single();
 
             Assert.Equal("ordering.Orders", dropColumnOperation.Table);
@@ -2293,7 +2297,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             var alterColumnOperation = (AlterColumnOperation)operations.Single();
@@ -2472,7 +2476,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             Assert.Equal("dbo.MigrationsCustomers", dropIndexOperation.Table);
             Assert.Equal(new List<string> { "CustomerNumber" }, dropIndexOperation.Columns);
         }
-        
+
         [MigrationsTheory]
         public void Can_detect_changed_columns_when_renamed()
         {
@@ -2490,7 +2494,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(2, operations.Count());
@@ -2521,7 +2525,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(4, operations.Count());
@@ -2601,7 +2605,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model2.GetModel(), model1.GetModel());
 
             Assert.Equal(4, operations.Count());
@@ -2636,7 +2640,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             Assert.Equal("dbo.OrderLines", inverse.DependentTable);
             Assert.Equal("OrderId", inverse.DependentColumns.Single());
         }
-        
+
         [MigrationsTheory]
         public void Should_not_detect_duplicate_dropped_foreign_keys()
         {
@@ -2708,12 +2712,12 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(2, operations.Count());
             Assert.Equal(1, operations.OfType<DropForeignKeyOperation>().Count());
-            
+
             var addForeignKeyOperation = operations.OfType<AddForeignKeyOperation>().Single();
 
             Assert.Equal("ordering.Orders", addForeignKeyOperation.PrincipalTable);
@@ -2736,7 +2740,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(0, operations.Count());
@@ -2766,7 +2770,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(3, operations.Count());
@@ -2798,7 +2802,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(1, operations.Count());
@@ -2826,7 +2830,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(4, operations.Count());
@@ -2865,7 +2869,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(4, operations.Count());
@@ -3141,7 +3145,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(0, operations.Count());
@@ -3344,7 +3348,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(0, operations.Count());
@@ -3365,7 +3369,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(ProviderInfo);
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(1, operations.Count());
@@ -3386,7 +3390,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             var model2 = modelBuilder.Build(new DbProviderInfo(DbProviders.SqlCe, "4"));
 
-            var operations 
+            var operations
                 = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(0, operations.Count());
@@ -3416,7 +3420,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
             public virtual Hat2 Hat { get; set; }
             public virtual Bracelet2 Bracelet { get; set; }
         }
-        
+
         public class Bracelet2
         {
             public int Id { get; set; }
@@ -3548,9 +3552,9 @@ namespace System.Data.Entity.Migrations.Infrastructure
             var model1 = modelBuilder.Build(ProviderInfo);
 
             modelBuilder = new DbModelBuilder();
-            
+
             modelBuilder.Entity<Bug2433_v2.Foob>();
-            
+
             var model2 = modelBuilder.Build(ProviderInfo);
 
             var operations = new EdmModelDiffer().Diff(model1.GetModel(), model2.GetModel());
@@ -3641,13 +3645,100 @@ namespace System.Data.Entity.Migrations.Infrastructure
 
             modelBuilder.Entity<Nav_prop_rename_v2.Table>();
 
-           var model2 = modelBuilder.Build(ProviderInfo);
+            var model2 = modelBuilder.Build(ProviderInfo);
 
             var operations
                 = new EdmModelDiffer()
                     .Diff(model1.GetModel(), model2.GetModel());
 
             Assert.Equal(0, operations.Count);
+        }
+
+        public interface IPlatformEntity
+        {
+            long Id { get; set; }
+        }
+
+        [Table("PlatformUser")]
+        public class PlatformUser : IPlatformEntity
+        {
+            public long Id { get; set; }
+
+            public string UserName { get; set; }
+        }
+
+        public class TypeGenerator
+        {
+            public byte[] Create()
+            {
+                var references = new List<MetadataReference>
+                {
+                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(PlatformUser).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(TableAttribute).Assembly.Location),
+                };
+
+                var classDefinition = @"
+                    namespace System.Data.Entity.Migrations.Infrastructure
+                    {
+                        [System.ComponentModel.DataAnnotations.Schema.TableAttribute(""PlatformUserExtended"")]
+                        public class PlatformUserExtended : EdmModelDifferTests.PlatformUser
+                        {
+                            public string FirstName { get; set; }
+                        }
+                    }";
+                var compilation = CSharpCompilation.Create(
+                "Extended.Library",
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+                syntaxTrees: new List<SyntaxTree> { SyntaxFactory.ParseSyntaxTree(classDefinition) },
+                references: references);
+
+                byte[] assembly;
+                using (var stream = new MemoryStream())
+                {
+                    var compileResult = compilation.Emit(stream);
+                    if (!compileResult.Success)
+                    {
+                        throw new Exception("Failed to compile extended entities extension.");
+                    }
+                    assembly = stream.GetBuffer();
+                }
+
+                return assembly;
+            }
+        }
+
+        [MigrationsTheory]
+        public void Extended_Table_Is_Added_And_Base_Table_Is_Left_Alone()
+        {
+            var modelBuilder = new DbModelBuilder();
+            modelBuilder.Entity<PlatformUser>().Map(configuration => { });
+            var built1 = modelBuilder.Build(ProviderInfo);
+            var model1 = built1.GetModel();
+
+            var typeGenerator = new TypeGenerator();
+            var assembly = typeGenerator.Create();
+            var loadedAssembly = Assembly.Load(assembly);
+            var extendedType = loadedAssembly.GetTypes().First();
+
+            modelBuilder = new DbModelBuilder();
+            modelBuilder.Entity<PlatformUser>();
+            modelBuilder.Entity(extendedType);
+            var built2 = modelBuilder.Build(ProviderInfo);
+            var model2 = built2.GetModel();
+
+            var operations = new EdmModelDiffer().Diff(model1, model2);
+
+            Assert.Equal(3, operations.Count);
+            var createTableOperation = (CreateTableOperation)operations.First(o => o is CreateTableOperation);
+            Assert.Equal("dbo.PlatformUserExtended", createTableOperation.Name);
+            var createIndexOperation = (CreateIndexOperation)operations.First(o => o is CreateIndexOperation);
+            Assert.Equal("IX_Id", createIndexOperation.Name);
+            Assert.Equal("dbo.PlatformUserExtended", createIndexOperation.Table);
+            var addForeignKeyOperation = (AddForeignKeyOperation)operations.First(o => o is AddForeignKeyOperation);
+            Assert.Equal("FK_dbo.PlatformUserExtended_dbo.PlatformUser_Id", addForeignKeyOperation.Name);
+            Assert.Equal("dbo.PlatformUserExtended", addForeignKeyOperation.DependentTable);
+            Assert.Equal("dbo.PlatformUser", addForeignKeyOperation.PrincipalTable);
         }
 
         #endregion

--- a/test/EntityFramework/UnitTests/UnitTests.csproj
+++ b/test/EntityFramework/UnitTests/UnitTests.csproj
@@ -81,23 +81,7 @@
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
@@ -146,7 +130,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>UnitTestResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Compile Include="AssemblyTests.cs" />
     <Compile Include="CommandLine\CommandLineWriteLineColorTests.cs" />
     <Compile Include="CommandLine\CommandLineArgumentInvalidExceptionTests.cs" />
@@ -888,10 +874,6 @@
     <EmbeddedResource Include="TestDataFiles\SqlOperation_Batch.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/test/EntityFramework/UnitTests/UnitTests.csproj
+++ b/test/EntityFramework/UnitTests/UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,6 +15,8 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -78,7 +81,23 @@
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualBasic" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
@@ -870,6 +889,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
@@ -882,6 +905,12 @@ if not exist "$(TargetDir)amd64" md "$(TargetDir)amd64"
 xcopy /s /y /d "$(SolutionDir)packages\Microsoft.SqlServer.Compact.4.0.8876.1\NativeBinaries\amd64\*.*" "$(TargetDir)amd64"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/EntityFramework/UnitTests/packages.config
+++ b/test/EntityFramework/UnitTests/packages.config
@@ -1,8 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net45" />
   <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework/UnitTests/packages.config
+++ b/test/EntityFramework/UnitTests/packages.config
@@ -1,20 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net45" />
   <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" />
-  <package id="System.Collections" version="4.0.0" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
-  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net45" />
-  <package id="System.Globalization" version="4.0.0" targetFramework="net45" />
-  <package id="System.Linq" version="4.0.0" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net45" />
-  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net45" />
-  <package id="System.Runtime" version="4.0.0" targetFramework="net45" />
-  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net45" />
-  <package id="System.Threading" version="4.0.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
Added a test to demonstrate the behavior, have to jump through some hoops to get there but that might be useful in the future.

Fix uses the IsOfType as the type if the type is not specified and there is not a prior match using the old logic. That is not enough as the matching is more eager than before so also keep track of matches made and don't reuse a target fragment that has already been matched.