### PR TITLE
Implement DbFunction for Like operator.

### DIFF
--- a/src/EntityFramework/Core/Objects/ELinq/MethodCallTranslator.cs
+++ b/src/EntityFramework/Core/Objects/ELinq/MethodCallTranslator.cs
@@ -207,6 +207,7 @@ namespace System.Data.Entity.Core.Objects.ELinq
                         new MathTruncateTranslator(),
                         new MathPowerTranslator(),
                         new GuidNewGuidTranslator(),
+                        new LikeFunctionTranslator(),
                         new StringContainsTranslator(),
                         new StartsWithTranslator(),
                         new EndsWithTranslator(),
@@ -890,6 +891,36 @@ namespace System.Data.Entity.Core.Objects.ELinq
                         linqArguments = call.Arguments.ToArray();
                     }
                     return parent.TranslateIntoCanonicalFunction(call.Method.Name, call, linqArguments);
+                }
+            }
+
+            internal sealed class LikeFunctionTranslator : CallTranslator
+            {
+                internal LikeFunctionTranslator()
+                    : base(GetMethods())
+                {
+                }
+
+                private static IEnumerable<MethodInfo> GetMethods()
+                {
+                    yield return
+                        typeof(DbFunctions).GetDeclaredMethod(Like, typeof(string), typeof(string));
+                    yield return
+                        typeof(DbFunctions).GetDeclaredMethod(Like, typeof(string), typeof(string), typeof(string));
+#pragma warning disable 612,618
+                    yield return
+                        typeof(EntityFunctions).GetDeclaredMethod(Like, typeof(string), typeof(string));
+                    yield return
+                        typeof(EntityFunctions).GetDeclaredMethod(Like, typeof(string), typeof(string), typeof(string));
+#pragma warning restore 612,618
+                }
+
+                // Translation:
+                // object.Like(likeExpression[, escapeCharacter]) ->  
+                //      object like likeExpression [escape escapeCharacter]
+                internal override CqtExpression Translate(ExpressionConverter parent, MethodCallExpression call)
+                {
+                    return parent.TranslateLike(call);
                 }
             }
 

--- a/src/EntityFramework/Core/Objects/EntityFunctions.cs
+++ b/src/EntityFramework/Core/Objects/EntityFunctions.cs
@@ -1684,6 +1684,44 @@ namespace System.Data.Entity.Core.Objects
         }
 
         /// <summary>
+        /// When used as part of a LINQ to Entities query, this method invokes the canonical Like EDM operator to match an expression.
+        /// </summary>
+        /// <remarks>
+        /// You cannot call this function directly. This function can only appear within a LINQ to Entities query.
+        /// This function is translated to a corresponding function in the database.
+        /// </remarks>
+        /// <param name="searchString"> The string to search. </param>
+        /// <param name="likeExpression"> The expression to match against. </param>
+        /// <returns> True if the searched string matches the expression; otherwise false. </returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "searchString")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "likeExpression")]
+        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        public static bool Like(string searchString, string likeExpression)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+        
+        /// <summary>
+        /// When used as part of a LINQ to Entities query, this method invokes the canonical Like EDM operator to match an expression.
+        /// </summary>
+        /// <remarks>
+        /// You cannot call this function directly. This function can only appear within a LINQ to Entities query.
+        /// This function is translated to a corresponding function in the database.
+        /// </remarks>
+        /// <param name="searchString"> The string to search. </param>
+        /// <param name="likeExpression"> The expression to match against. </param>
+        /// <param name="escapeCharacter"> The string to escape special characters with, must only be a single character. </param>
+        /// <returns> True if the searched string matches the expression; otherwise false. </returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "searchString")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "likeExpression")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "escapeCharacter")]
+        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        public static bool Like(string searchString, string likeExpression, string escapeCharacter)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>
         /// When used as part of a LINQ to Entities query, this method acts as an operator that ensures the input
         /// is treated as a Unicode string.
         /// </summary>

--- a/src/EntityFramework/DbFunctions.cs
+++ b/src/EntityFramework/DbFunctions.cs
@@ -1686,6 +1686,44 @@ namespace System.Data.Entity
         }
 
         /// <summary>
+        /// When used as part of a LINQ to Entities query, this method invokes the canonical Like EDM operator to match an expression.
+        /// </summary>
+        /// <remarks>
+        /// You cannot call this function directly. This function can only appear within a LINQ to Entities query.
+        /// This function is translated to a corresponding function in the database.
+        /// </remarks>
+        /// <param name="searchString"> The string to search. </param>
+        /// <param name="likeExpression"> The expression to match against. </param>
+        /// <returns> True if the searched string matches the expression; otherwise false. </returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "searchString")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "likeExpression")]
+        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        public static bool Like(this string searchString, string likeExpression)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>
+        /// When used as part of a LINQ to Entities query, this method invokes the canonical Like EDM operator to match an expression.
+        /// </summary>
+        /// <remarks>
+        /// You cannot call this function directly. This function can only appear within a LINQ to Entities query.
+        /// This function is translated to a corresponding function in the database.
+        /// </remarks>
+        /// <param name="searchString"> The string to search. </param>
+        /// <param name="likeExpression"> The expression to match against. </param>
+        /// <param name="escapeCharacter"> The string to escape special characters with, must only be a single character. </param>
+        /// <returns> True if the searched string matches the expression; otherwise false. </returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "searchString")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "likeExpression")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "escapeCharacter")]
+        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        public static bool Like(this string searchString, string likeExpression, string escapeCharacter)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>
         /// When used as part of a LINQ to Entities query, this method acts as an operator that ensures the input
         /// is treated as a Unicode string.
         /// </summary>

--- a/src/EntityFramework/Properties/Resources.cs
+++ b/src/EntityFramework/Properties/Resources.cs
@@ -14029,6 +14029,14 @@ namespace System.Data.Entity.Resources
         {
             return EntityRes.GetString(EntityRes.StoreTypeNotFound, p0, p1);
         }
+
+        // <summary>
+        // A string like "EscapeLikeArgument is not supported by the provider."
+        // </summary>
+        internal static string ProviderDoesNotSupportEscapingLikeArgument
+        {
+            get { return EntityRes.GetString(EntityRes.ProviderDoesNotSupportEscapingLikeArgument); }
+        }
     }
 
     // <summary>
@@ -17430,6 +17438,7 @@ namespace System.Data.Entity.Resources
         internal const string CannotSetBaseTypeCyclicInheritance = "CannotSetBaseTypeCyclicInheritance";
         internal const string CannotDefineKeysOnBothBaseAndDerivedTypes = "CannotDefineKeysOnBothBaseAndDerivedTypes";
         internal const string StoreTypeNotFound = "StoreTypeNotFound";
+        internal const string ProviderDoesNotSupportEscapingLikeArgument = "ProviderDoesNotSupportEscapingLikeArgument";
 
         private static EntityRes loader;
         private readonly ResourceManager resources;

--- a/src/EntityFramework/Properties/Resources.resx
+++ b/src/EntityFramework/Properties/Resources.resx
@@ -5574,4 +5574,7 @@
     <value>The store type '{0}' could not be found in the {1} provider manifest</value>
     <comment>## ExceptionType=InvalidOperationException</comment>
   </data>
+  <data name="ProviderDoesNotSupportEscapingLikeArgument" xml:space="preserve">
+    <value>Escaping within like expressions is not supported by the provider.</value>
+  </data>
 </root>

--- a/test/EntityFramework/FunctionalTests/ProductivityApi/DbFunctionScenarios.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/DbFunctionScenarios.cs
@@ -508,6 +508,52 @@ namespace FunctionalTests.ProductivityApi
             }
 
             [Fact]
+            public void Like_can_be_used_in_DbQuery_or_ObjectQuery()
+            {
+                using (var context = new EntityFunctionContext())
+                {
+                    Assert.Equal(
+                        "Magic Unicorns Roll",
+                        context.WithTypes.OrderBy(e => e.Id).Where(e => DbFunctions.Like(e.String, "Magic%Roll")).Select(e => e.String).First());
+
+                    Assert.Equal(
+                        "Magic Unicorns Roll",
+                        GetObjectSet<EntityWithTypes>(context).OrderBy(e => e.Id).Where(e => DbFunctions.Like(e.String, "Magic%Roll%")).Select(e => e.String).First());
+
+                    Assert.Equal(
+                        "Magic Unicorns Roll",
+                        context.WithTypes.OrderBy(e => e.Id).Where(e => e.String.Like("Magic%Roll")).Select(e => e.String).First());
+
+                    Assert.Equal(
+                        "Magic Unicorns Roll",
+                        GetObjectSet<EntityWithTypes>(context).OrderBy(e => e.Id).Where(e => e.String.Like("Magic%Roll%")).Select(e => e.String).First());
+                }
+            }
+            
+            [Fact]
+            public void Like_with_string_escapeCharacter_can_be_used_in_DbQuery_or_ObjectQuery()
+            {
+                using (var context = new EntityFunctionContext())
+                {
+                    Assert.Equal(
+                        "Magic Unicorns Roll",
+                        context.WithTypes.OrderBy(e => e.Id).Where(e => DbFunctions.Like(e.String, "Magic%Roll", "~")).Select(e => e.String).First());
+
+                    Assert.Equal(
+                        "Magic Unicorns Roll",
+                        GetObjectSet<EntityWithTypes>(context).OrderBy(e => e.Id).Where(e => DbFunctions.Like(e.String, "Magic%Roll", "~")).Select(e => e.String).First());
+
+                    Assert.Equal(
+                        "Magic Unicorns Roll",
+                        context.WithTypes.OrderBy(e => e.Id).Where(e => e.String.Like("Magic%Roll", "~")).Select(e => e.String).First());
+
+                    Assert.Equal(
+                        "Magic Unicorns Roll",
+                        GetObjectSet<EntityWithTypes>(context).OrderBy(e => e.Id).Where(e => e.String.Like("Magic%Roll", "~")).Select(e => e.String).First());
+                }
+            }
+
+            [Fact]
             public void AsUnicode_can_be_used_in_DbQuery_or_ObjectQuery()
             {
                 using (var context = new EntityFunctionContext())
@@ -2074,6 +2120,36 @@ namespace FunctionalTests.ProductivityApi
                         Assert.Equal(
                             "kcoR snrocinU cigaM",
                             GetObjectSet<EntityWithTypes>(context).OrderBy(e => e.Id).Select(e => EntityFunctions.Reverse(e.String)).First());
+                    }
+                }
+
+                [Fact]
+                public void Like_can_be_used_in_DbQuery_or_ObjectQuery()
+                {
+                    using (var context = new EntityFunctionContext())
+                    {
+                        Assert.Equal(
+                            "Magic Unicorns Roll",
+                            context.WithTypes.OrderBy(e => e.Id).Where(e => EntityFunctions.Like(e.String, "Magic%Roll")).Select(e => e.String).First());
+
+                        Assert.Equal(
+                            "Magic Unicorns Roll",
+                            GetObjectSet<EntityWithTypes>(context).OrderBy(e => e.Id).Where(e => EntityFunctions.Like(e.String, "Magic%Roll%")).Select(e => e.String).First());
+                    }
+                }
+                
+                [Fact]
+                public void Like_with_string_escapeCharacter_can_be_used_in_DbQuery_or_ObjectQuery()
+                {
+                    using (var context = new EntityFunctionContext())
+                    {
+                        Assert.Equal(
+                            "Magic Unicorns Roll",
+                            context.WithTypes.OrderBy(e => e.Id).Where(e => EntityFunctions.Like(e.String, "Magic%Roll", "~")).Select(e => e.String).First());
+
+                        Assert.Equal(
+                            "Magic Unicorns Roll",
+                            GetObjectSet<EntityWithTypes>(context).OrderBy(e => e.Id).Where(e => EntityFunctions.Like(e.String, "Magic%Roll", "~")).Select(e => e.String).First());
                     }
                 }
 

--- a/test/EntityFramework/FunctionalTests/Query/LinqToEntities/FunctionsTests.cs
+++ b/test/EntityFramework/FunctionalTests/Query/LinqToEntities/FunctionsTests.cs
@@ -27,6 +27,26 @@ namespace System.Data.Entity.Query.LinqToEntities
             }
 
             [Fact]
+            public void String_Like_properly_translated_to_function()
+            {
+                using (var context = new ArubaContext())
+                {
+                    var query = context.Owners.Select(o => o.LastName.Like("%LAST_%NAME[0-1]%"));
+                    Assert.Contains("LIKE N'%LAST_%NAME[0-1]%'", query.ToString().ToUpperInvariant());
+                }
+            }
+            
+            [Fact]
+            public void String_Like_with_string_escape_properly_translated_to_function()
+            {
+                using (var context = new ArubaContext())
+                {
+                    var query = context.Owners.Select(o => o.LastName.Like(@"%\%LAST_\_%NAME\[[0-1]%", "\\"));
+                    Assert.Contains(@"LIKE N'%\%LAST_\_%NAME\[[0-1]%' ESCAPE N'\'", query.ToString().ToUpperInvariant());
+                }
+            }
+
+            [Fact]
             public void String_Contains_properly_translated_to_function()
             {
                 using (var context = new ArubaContext())

--- a/test/EntityFramework/UnitTests/Core/Objects/ELinq/ExpressionConverterTests.cs
+++ b/test/EntityFramework/UnitTests/Core/Objects/ELinq/ExpressionConverterTests.cs
@@ -59,6 +59,15 @@ namespace System.Data.Entity.Core.Objects.ELinq
         }
 
         [Fact]
+        public void LikeTranslator_finds_all_expected_methods()
+        {
+            var methods = new ExpressionConverter.MethodCallTranslator.LikeFunctionTranslator().Methods;
+
+            Assert.Equal(4, methods.Count());
+            Assert.True(methods.All(m => m != null));
+        }
+
+        [Fact]
         public void AsUnicodeFunctionTranslator_finds_all_expected_methods()
         {
             var methods = new ExpressionConverter.MethodCallTranslator.AsUnicodeFunctionTranslator().Methods;

--- a/test/EntityFramework/UnitTests/Core/Objects/EntityFunctionsTests.cs
+++ b/test/EntityFramework/UnitTests/Core/Objects/EntityFunctionsTests.cs
@@ -10,14 +10,14 @@ namespace System.Data.Entity.Core.Objects
     public class EntityFunctionsTests : TestBase
     {
         [Fact]
-        public void All_EntityFunctions_are_attributed_with_DbFunctionAttribute_except_unicode_methods()
+        public void All_EntityFunctions_are_attributed_with_DbFunctionAttribute_except_like_and_unicode_methods()
         {
 #pragma warning disable 612,618
             var entityFunctions = typeof(EntityFunctions).GetDeclaredMethods();
 #pragma warning restore 612,618
-            Assert.True(entityFunctions.Count() >= 93); // Just make sure Reflection is returning what we expect
+            Assert.True(entityFunctions.Count() >= 95); // Just make sure Reflection is returning what we expect
 
-            foreach (var function in entityFunctions.Where(f => f.IsPublic && f.Name != "AsUnicode" && f.Name != "AsNonUnicode"))
+            foreach (var function in entityFunctions.Where(f => f.IsPublic && f.Name != "Like" && f.Name != "AsUnicode" && f.Name != "AsNonUnicode"))
             {
                 Assert.NotNull(function.GetCustomAttributes<DbFunctionAttribute>(inherit: false).FirstOrDefault());
             }
@@ -32,7 +32,7 @@ namespace System.Data.Entity.Core.Objects
 #pragma warning restore 612,618
 
             Assert.Equal(dbFunctions.Count(), entityFunctions.Count());
-            Assert.True(dbFunctions.Count() >= 93); // Just make sure Reflection is returning what we expect
+            Assert.True(dbFunctions.Count() >= 95); // Just make sure Reflection is returning what we expect
 
             foreach (var function in dbFunctions)
             {

--- a/test/EntityFramework/UnitTests/DbFunctionsTests.cs
+++ b/test/EntityFramework/UnitTests/DbFunctionsTests.cs
@@ -10,12 +10,12 @@ namespace System.Data.Entity
     public class DbFunctionsTests : TestBase
     {
         [Fact]
-        public void All_DbFunctions_are_attributed_with_DbFunctionAttribute_except_unicode_methods()
+        public void All_DbFunctions_are_attributed_with_DbFunctionAttribute_except_like_and_unicode_methods()
         {
             var entityFunctions = typeof(DbFunctions).GetDeclaredMethods().Where(f => f.IsPublic);
-            Assert.True(entityFunctions.Count() >= 93); // Just make sure Reflection is returning what we expect
+            Assert.True(entityFunctions.Count() >= 95); // Just make sure Reflection is returning what we expect
 
-            foreach (var function in entityFunctions.Where(f => f.Name != "AsUnicode" && f.Name != "AsNonUnicode"))
+            foreach (var function in entityFunctions.Where(f => f.Name != "Like" && f.Name != "AsUnicode" && f.Name != "AsNonUnicode"))
             {
                 Assert.NotNull(function.GetCustomAttributes<DbFunctionAttribute>(inherit: false).FirstOrDefault());
             }


### PR DESCRIPTION
Implementation for CodePlex Issues [#2388](https://entityframework.codeplex.com/workitem/2388) and [#1323](https://entityframework.codeplex.com/workitem/1323). 

It implements it by 
1. Providing an extension method/static method on DbFunctions and a static method in EntityFunctions for backwards compatibility. 
2. Providing a new CallTranslator (LikeTranslator) to handle these functions being called within expressions. 
3. Providing a TranslateLike helper method that turns the static method invocation into a LikeExpression 
4. Providing a means to turn a character parameter into a single-character string. Doing this allows Like to have both Like(string, string, char) and Like(string, string, string) signatures that are exactly equivalent. 
5. Handling the case where a provider specifies that it does not accept a like operator escape character by throwing an ProviderIncompatibleException with a newly created message. I found it important to have both Like(string, string, char) and Like(string, string, string) because char allows us to enforce the single-character string escape requirement when specifying a literal, while string gives more freedom to your escapeCharacter expression to use a dynamic escape character. 

Tests have been added to match similar tests of DbFunctions.AsUnicode(...). 

Note: I am not a part of the EF team, I cannot provide information about when/if this pull request will be accepted nor when/if it would be actually released. 

This request was migrated from CodePlex Contribution [#7723](https://entityframework.codeplex.com/SourceControl/network/forks/BrandonDahler/EntityFramework/contribution/7723)

Brandon Dahler
