### PR TITLE
Reduce start up time by loading finished Code First models from a persistent cache

### DIFF
--- a/src/EntityFramework/DbConfiguration.cs
+++ b/src/EntityFramework/DbConfiguration.cs
@@ -770,6 +770,18 @@ namespace System.Data.Entity
         }
 
         /// <summary>
+        /// Sets a singleton model store implementation (persisted model cache).
+        /// </summary>
+        /// <param name="modelStore">The model store implementation.</param>
+        protected internal void SetModelStore(DbModelStore modelStore)
+        {
+            Check.NotNull(modelStore, "modelStore");
+
+            _internalConfiguration.CheckNotLocked("SetModelStore");
+            _internalConfiguration.RegisterSingleton(modelStore);
+        }
+
+        /// <summary>
         /// Call this method from the constructor of a class derived from <see cref="DbConfiguration" /> to register
         /// a database table existence checker for a given provider.
         /// </summary>

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -250,8 +250,11 @@
     <Compile Include="Infrastructure\Annotations\IndexAnnotation.cs" />
     <Compile Include="Infrastructure\Annotations\IndexAnnotationSerializer.cs" />
     <Compile Include="Infrastructure\Annotations\IndexAttributeExtensions.cs" />
+    <Compile Include="Infrastructure\DbModelStore.cs" />
+    <Compile Include="Infrastructure\DefaultDbModelStore.cs" />
     <Compile Include="Infrastructure\DependencyResolution\TransactionContextInitializerResolver.cs" />
     <Compile Include="Infrastructure\DependencyResolution\TransactionHandlerResolver.cs" />
+    <Compile Include="Infrastructure\EdmxReader.cs" />
     <Compile Include="Infrastructure\Design\AppConfigReader.cs" />
     <Compile Include="Infrastructure\Interception\DatabaseLogger.cs" />
     <Compile Include="Infrastructure\Interception\DbConfigurationDispatcher.cs" />

--- a/src/EntityFramework/Infrastructure/DbCompiledModel.cs
+++ b/src/EntityFramework/Infrastructure/DbCompiledModel.cs
@@ -35,6 +35,7 @@ namespace System.Data.Entity.Infrastructure
         private readonly ICachedMetadataWorkspace _workspace;
 
         private readonly DbModelBuilder _cachedModelBuilder;
+        private readonly string _defaultSchema;
 
         // <summary>
         // For mocking.
@@ -43,16 +44,17 @@ namespace System.Data.Entity.Infrastructure
         {
         }
 
-        // <summary>
-        // Creates a model for the given EDM metadata model.
-        // </summary>
-        // <param name="model"> The EDM metadata model. </param>
-        internal DbCompiledModel(DbModel model)
+        internal DbCompiledModel(CodeFirstCachedMetadataWorkspace workspace, DbModelBuilder cachedModelBuilder)
         {
-            DebugCheck.NotNull(model);
+            _workspace = workspace;
+            _cachedModelBuilder = cachedModelBuilder;
+            _defaultSchema = cachedModelBuilder.ModelConfiguration.DefaultSchema;
+        }
 
-            _workspace = new CodeFirstCachedMetadataWorkspace(model.DatabaseMapping);
-            _cachedModelBuilder = model.CachedModelBuilder;
+        internal DbCompiledModel(CodeFirstCachedMetadataWorkspace workspace, string defaultSchema)
+        {
+            _workspace = workspace;
+            _defaultSchema = defaultSchema;
         }
 
         #endregion
@@ -79,7 +81,7 @@ namespace System.Data.Entity.Infrastructure
         // <returns> The default schema of the model. </returns>
         internal string DefaultSchema
         {
-            get { return CachedModelBuilder.ModelConfiguration.DefaultSchema; }
+            get { return _defaultSchema; }
         }
 
         #endregion

--- a/src/EntityFramework/Infrastructure/DbModel.cs
+++ b/src/EntityFramework/Infrastructure/DbModel.cs
@@ -5,6 +5,7 @@ namespace System.Data.Entity.Infrastructure
     using System.Data.Entity.Core.Common;
     using System.Data.Entity.Core.Mapping;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Internal;
     using System.Data.Entity.ModelConfiguration.Edm;
     using System.Data.Entity.Utilities;
     using System.Linq;
@@ -112,7 +113,9 @@ namespace System.Data.Entity.Infrastructure
         /// <returns> The compiled model. </returns>
         public DbCompiledModel Compile()
         {
-            return new DbCompiledModel(this);
+            return new DbCompiledModel(
+                CodeFirstCachedMetadataWorkspace.Create(DatabaseMapping), 
+                CachedModelBuilder);
         }
     }
 }

--- a/src/EntityFramework/Infrastructure/DbModelStore.cs
+++ b/src/EntityFramework/Infrastructure/DbModelStore.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Infrastructure
+{
+    using System.Data.Entity.ModelConfiguration.Edm;
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// Base class for persisted model cache.
+    /// </summary>
+    public abstract class DbModelStore
+    {
+        /// <summary>
+        /// Loads a model from the store.
+        /// </summary>
+        /// <param name="contextType">The type of context representing the model.</param>
+        /// <returns>The loaded metadata model.</returns>
+        public abstract DbCompiledModel TryLoad(Type contextType);
+
+        /// <summary>
+        /// Retrieves an edmx XDocument version of the model from the store.
+        /// </summary>
+        /// <param name="contextType">The type of context representing the model.</param>
+        /// <returns>The loaded XDocument edmx.</returns>
+        public abstract XDocument TryGetEdmx(Type contextType);
+
+        /// <summary>
+        /// Saves a model to the store.
+        /// </summary>
+        /// <param name="contextType">The type of context representing the model.</param>
+        /// <param name="model">The metadata model to save.</param>
+        public abstract void Save(Type contextType, DbModel model);
+
+        /// <summary>
+        /// Gets the default database schema used by a model.
+        /// </summary>
+        /// <param name="contextType">The type of context representing the model.</param>
+        /// <returns>The default database schema.</returns>
+        protected virtual string GetDefaultSchema(Type contextType)
+        {
+            return EdmModelExtensions.DefaultSchema;
+        }
+    }
+}

--- a/src/EntityFramework/Infrastructure/DefaultDbModelStore.cs
+++ b/src/EntityFramework/Infrastructure/DefaultDbModelStore.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Infrastructure
+{
+    using System.Data.Entity.Utilities;
+    using System.IO;
+    using System.Xml;
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// Loads or saves models from/into .edmx files at a specified location.
+    /// </summary>
+    public class DefaultDbModelStore : DbModelStore
+    {
+        private const string FileExtension = ".edmx";
+
+        private readonly string _location;
+
+        /// <summary>
+        /// Initializes a new DefaultDbModelStore instance.
+        /// </summary>
+        /// <param name="location">The parent directory for the .edmx files.</param>
+        public DefaultDbModelStore(string location)
+        {
+            Check.NotEmpty(location, "location");
+
+            _location = location;
+        }
+
+        /// <summary>
+        /// Gets the location of the .edmx files.
+        /// </summary>
+        public string Location
+        {
+            get { return _location; }
+        }
+
+        /// <summary>
+        /// Loads a model from the store.
+        /// </summary>
+        /// <param name="contextType">The type of context representing the model.</param>
+        /// <returns>The loaded metadata model.</returns>
+        public override DbCompiledModel TryLoad(Type contextType)
+        {
+            return LoadXml(
+                contextType,
+                reader =>
+                {
+                    var defaultSchema = GetDefaultSchema(contextType);
+                    return EdmxReader.Read(reader, defaultSchema);
+                });
+        }
+
+        /// <summary>
+        /// Retrieves an edmx XDocument version of the model from the store.
+        /// </summary>
+        /// <param name="contextType">The type of context representing the model.</param>
+        /// <returns>The loaded XDocument edmx.</returns>
+        public override XDocument TryGetEdmx(Type contextType)
+        {
+            return LoadXml(contextType, XDocument.Load);
+        }
+
+        internal T LoadXml<T>(Type contextType, Func<XmlReader, T> xmlReaderDelegate)
+        {
+            var filePath = GetFilePath(contextType);
+
+            if (!File.Exists(filePath))
+            {
+                return default(T);
+            }
+
+            if (!FileIsValid(contextType, filePath))
+            {
+                File.Delete(filePath);
+                return default(T);
+            }
+
+            using (var reader = XmlReader.Create(filePath))
+            {
+                return xmlReaderDelegate(reader);
+            }
+        }
+
+        /// <summary>
+        /// Saves a model to the store.
+        /// </summary>
+        /// <param name="contextType">The type of context representing the model.</param>
+        /// <param name="model">The metadata model to save.</param>
+        public override void Save(Type contextType, DbModel model)
+        {
+            using (var writer = XmlWriter.Create(GetFilePath(contextType), 
+                new XmlWriterSettings
+                    {
+                        Indent = true
+                    }))
+            {
+                EdmxWriter.WriteEdmx(model, writer);
+            }
+        }
+
+        /// <summary>
+        /// Gets the path of the .edmx file corresponding to the specified context type.
+        /// </summary>
+        /// <param name="contextType">A context type.</param>
+        /// <returns>The .edmx file path.</returns>
+        protected virtual string GetFilePath(Type contextType)
+        {
+            var fileName = contextType.FullName + FileExtension;
+
+            return Path.Combine(_location, fileName);
+        }
+
+        /// <summary>
+        /// Validates the model store is valid.
+        /// The default implementation verifies that the .edmx file was last 
+        /// written after the context assembly was last written.
+        /// </summary>
+        /// <param name="contextType">The type of context representing the model.</param>
+        /// <param name="filePath">The path of the stored model.</param>
+        /// <returns>Whether the edmx file should be invalidated.</returns>
+        protected virtual bool FileIsValid(Type contextType, string filePath)
+        {
+            var contextCreated =
+                File.GetLastWriteTimeUtc(contextType.Assembly.Location);
+            var storeCreated = File.GetLastWriteTimeUtc(filePath);
+            return storeCreated >= contextCreated;
+        }
+    }
+}

--- a/src/EntityFramework/Infrastructure/EdmxReader.cs
+++ b/src/EntityFramework/Infrastructure/EdmxReader.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Infrastructure
+{
+    using System.Data.Entity.Internal;
+    using System.Data.Entity.Utilities;
+    using System.Xml;
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// Utility class for reading a metadata model from .edmx.
+    /// </summary>
+    public static class EdmxReader
+    {
+        /// <summary>
+        /// Reads a metadata model from .edmx.
+        /// </summary>
+        /// <param name="reader">XML reader for the .edmx</param>
+        /// <param name="defaultSchema">Default database schema used by the model.</param>
+        /// <returns>The loaded metadata model.</returns>
+        public static DbCompiledModel Read(XmlReader reader, string defaultSchema)
+        {
+            Check.NotNull(reader, "reader");
+
+            var document = XDocument.Load(reader);
+
+            DbProviderInfo providerInfo;
+            var mappingItemCollection = document.GetStorageMappingItemCollection(out providerInfo);
+
+            return new DbCompiledModel(
+                CodeFirstCachedMetadataWorkspace.Create(mappingItemCollection, providerInfo),
+                defaultSchema);
+        }
+    }
+}

--- a/src/EntityFramework/Infrastructure/EdmxWriter.cs
+++ b/src/EntityFramework/Infrastructure/EdmxWriter.cs
@@ -3,7 +3,9 @@
 namespace System.Data.Entity.Infrastructure
 {
     using System.Data.Entity.Core.Objects;
+    using System.Data.Entity.Infrastructure.DependencyResolution;
     using System.Data.Entity.Internal;
+    using System.Data.Entity.Migrations.History;
     using System.Data.Entity.ModelConfiguration.Edm.Serialization;
     using System.Data.Entity.Resources;
     using System.Data.Entity.Utilities;
@@ -51,6 +53,17 @@ namespace System.Data.Entity.Infrastructure
                 throw Error.EdmxWriter_EdmxFromModelFirstNotSupported();
             }
 
+            var modelStore = DbConfiguration.DependencyResolver.GetService<DbModelStore>();
+            if (modelStore != null)
+            {
+                var storedModel = modelStore.TryGetEdmx(context.GetType());
+                if (storedModel != null)
+                {
+                    storedModel.WriteTo(writer);
+                    return;
+                }
+            }
+            
             var builder = compiledModel.CachedModelBuilder.Clone();
 
             WriteEdmx(

--- a/src/EntityFramework/Internal/CodeFirstCachedMetadataWorkspace.cs
+++ b/src/EntityFramework/Internal/CodeFirstCachedMetadataWorkspace.cs
@@ -4,6 +4,7 @@ namespace System.Data.Entity.Internal
 {
     using System.Collections.Generic;
     using System.Data.Common;
+    using System.Data.Entity.Core.Mapping;
     using System.Data.Entity.Core.Metadata.Edm;
     using System.Data.Entity.Infrastructure;
     using System.Data.Entity.ModelConfiguration.Edm;
@@ -12,6 +13,8 @@ namespace System.Data.Entity.Internal
     using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
+    using System.Xml;
+    using System.Xml.Linq;
 
     // <summary>
     // Implements ICachedMetadataWorkspace for a Code First model.
@@ -25,21 +28,13 @@ namespace System.Data.Entity.Internal
         private readonly DbProviderInfo _providerInfo;
         private readonly string _defaultContainerName;
 
-        // <summary>
-        // Builds and stores the workspace based on the given code first configuration.
-        // </summary>
-        // <param name="databaseMapping"> The code first EDM model. </param>
-        public CodeFirstCachedMetadataWorkspace(DbDatabaseMapping databaseMapping)
+        private CodeFirstCachedMetadataWorkspace(MetadataWorkspace metadataWorkspace, 
+            IEnumerable<Assembly> assemblies, DbProviderInfo providerInfo, string defaultContainerName)
         {
-            DebugCheck.NotNull(databaseMapping);
-
-            _providerInfo = databaseMapping.ProviderInfo;
-            _metadataWorkspace = databaseMapping.ToMetadataWorkspace();
-            _assemblies = databaseMapping.Model.GetClrTypes().Select(t => t.Assembly()).Distinct().ToList();
-
-            Debug.Assert(databaseMapping.Model.Containers.Count() == 1, "Expecting Code First to create only one container.");
-
-            _defaultContainerName = databaseMapping.Model.Containers.First().Name;
+            _metadataWorkspace = metadataWorkspace;
+            _assemblies = assemblies;
+            _providerInfo = providerInfo;
+            _defaultContainerName = defaultContainerName;
         }
 
         #endregion
@@ -93,5 +88,30 @@ namespace System.Data.Entity.Internal
         }
 
         #endregion
+
+        public static CodeFirstCachedMetadataWorkspace Create(DbDatabaseMapping databaseMapping)
+        {
+            var conceptualModel = databaseMapping.Model;
+
+            return new CodeFirstCachedMetadataWorkspace(
+                databaseMapping.ToMetadataWorkspace(),
+                conceptualModel.GetClrTypes().Select(t => t.Assembly()).Distinct().ToArray(),
+                databaseMapping.ProviderInfo,
+                conceptualModel.Container.Name);
+        }
+
+        public static CodeFirstCachedMetadataWorkspace Create(
+            StorageMappingItemCollection mappingItemCollection, DbProviderInfo providerInfo)
+        {
+            var conceptualModel = mappingItemCollection.EdmItemCollection;
+            var entityClrTypes = conceptualModel.GetItems<EntityType>().Select(et => et.GetClrType());
+            var complexClrTypes = conceptualModel.GetItems<ComplexType>().Select(ct => ct.GetClrType());
+
+            return new CodeFirstCachedMetadataWorkspace(
+                mappingItemCollection.Workspace,
+                entityClrTypes.Union(complexClrTypes).Select(t => t.Assembly()).Distinct().ToArray(),
+                providerInfo,
+                conceptualModel.GetItems<EntityContainer>().Single().Name);
+        }
     }
 }

--- a/src/EntityFramework/Migrations/Infrastructure/ModificationCommandTreeGenerator.cs
+++ b/src/EntityFramework/Migrations/Infrastructure/ModificationCommandTreeGenerator.cs
@@ -43,7 +43,7 @@ namespace System.Data.Entity.Migrations.Infrastructure
         {
             DebugCheck.NotNull(model);
 
-            _compiledModel = new DbCompiledModel(model);
+            _compiledModel = model.Compile();
             _connection = connection;
 
             using (var context = CreateContext())

--- a/test/EntityFramework/FunctionalTests/FunctionalTests.csproj
+++ b/test/EntityFramework/FunctionalTests/FunctionalTests.csproj
@@ -245,6 +245,7 @@
     <Compile Include="ProductivityApi\DbContextTests.cs" />
     <Compile Include="ProductivityApi\DbFunctionScenarios.cs" />
     <Compile Include="ProductivityApi\DeadlockTests.cs" />
+    <Compile Include="ProductivityApi\DefaultDbModelStoreTests.cs" />
     <Compile Include="ProductivityApi\SimpleScenariosForSqlCe35.cs" />
     <Compile Include="ProductivityApi\TemplateTests.cs" />
     <Compile Include="Query\Bug2612.cs" />

--- a/test/EntityFramework/FunctionalTests/ProductivityApi/DefaultDbModelStoreTests.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/DefaultDbModelStoreTests.cs
@@ -1,0 +1,330 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace ProductivityApiTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.Entity;
+    using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Infrastructure;
+    using System.Data.Entity.Infrastructure.DependencyResolution;
+    using System.Data.Entity.ModelConfiguration.Conventions;
+    using System.IO;
+    using System.Linq;
+    using System.Xml;
+    using Xunit;
+
+    /// <summary>
+    /// Functional tests for DefaultDbModelStore methods.
+    /// </summary>
+    public class DefaultDbModelStoreTests : FunctionalTestBase
+    {
+        private readonly string _location;
+        private readonly DefaultDbModelStore _store;
+
+        public DefaultDbModelStoreTests()
+        {
+            _location = Path.GetTempPath();
+
+            _store = new DefaultDbModelStore(_location);
+        }
+
+        [Fact]
+        public void TryLoad_returns_null_when_file_does_not_exist()
+        {
+            Assert.False(File.Exists(_location + typeof(DbContext).FullName + ".edmx"));
+
+            Assert.Null(_store.TryLoad(typeof(DbContext)));
+        }
+
+        [Fact]
+        public void TryGetEdmx_returns_null_when_file_does_not_exist()
+        {
+            Assert.False(File.Exists(_location + typeof(DbContext).FullName + ".edmx"));
+
+            Assert.Null(_store.TryGetEdmx(typeof(DbContext)));
+        }
+
+        #region Edmx file invalidation
+        [Fact]
+        public void TryLoad_deletes_edmx_if_context_lastWriteTimeUtc_is_later_edmx_lastwrite()
+        {
+            var edmxFilePath = WriteMockContextEdmx();
+
+            var assemblyCreationTime = File.GetLastWriteTimeUtc(typeof(MockContext).Assembly.Location);
+
+            //set assembly lastWriteTime later than assembly creation time
+            File.SetLastWriteTimeUtc(edmxFilePath, assemblyCreationTime.AddMilliseconds(1));
+
+            var loadedFile = _store.TryLoad(typeof(MockContext));
+            Assert.NotNull(loadedFile);
+
+            Assert.True(File.Exists(edmxFilePath), "edmx should remain");
+
+            //set assembly lastWriteTime earlier than assembly creation time
+            File.SetLastWriteTimeUtc(edmxFilePath, assemblyCreationTime.AddMilliseconds(-1));
+
+            loadedFile = _store.TryLoad(typeof(MockContext));
+            Assert.Null(loadedFile);
+
+            Assert.False(File.Exists(edmxFilePath), "edmx should have been deleted");
+        }
+
+        [Fact]
+        public void TryGetEdmx_deletes_edmx_if_context_lastWriteTimeUtc_later_edmx_lastwrite()
+        {
+            MutableResolver.ClearResolvers();
+
+            var edmxFilePath = WriteMockContextEdmx();
+
+            var assemblyCreationTime = File.GetLastWriteTimeUtc(typeof(MockContext).Assembly.Location);
+
+            //set assembly lastWriteTime later than assembly creation time
+            File.SetLastWriteTimeUtc(edmxFilePath, assemblyCreationTime.AddMilliseconds(1));
+
+            var compiledModelFromCache = _store.TryGetEdmx(typeof(MockContext));
+            Assert.NotNull(compiledModelFromCache);
+
+            Assert.True(File.Exists(edmxFilePath), "edmx should remain");
+
+            //set assembly lastWriteTime earlier than assembly creation time
+            File.SetLastWriteTimeUtc(edmxFilePath, assemblyCreationTime.AddMilliseconds(-1));
+
+            compiledModelFromCache = _store.TryGetEdmx(typeof(MockContext));
+            Assert.Null(compiledModelFromCache);
+
+            Assert.False(File.Exists(edmxFilePath), "edmx should have been deleted");
+        }
+
+        private string WriteMockContextEdmx()
+        {
+            var edmxFilePath = _location + typeof(MockContext).FullName + ".edmx";
+            using (var context = new MockContext())
+            {
+                context.Database.Initialize(false);
+
+                using (var writer = XmlWriter.Create(edmxFilePath))
+                {
+                    EdmxWriter.WriteEdmx(new MockContext(), writer);
+                }
+            }
+            return edmxFilePath;
+        }
+
+        public class MockContext : DbContext
+        {
+        }
+        #endregion
+
+        [Fact]
+        public void DefaultDbModelStore_saves_and_loads_DbContext_with_DropCreateAlwaysInitializer()
+        {
+            try
+            {
+                var dependencyResolver = new SingletonDependencyResolver<DbModelStore>(_store);
+                MutableResolver.AddResolver<DbModelStore>(dependencyResolver);
+
+                Assert.False(File.Exists(_location + typeof(ModelContext).FullName + ".edmx"), "edmx should not exist yet");
+
+                using (var context = new ModelContext())
+                {
+                    context.Database.Initialize(true);
+                }
+
+                Assert.True(File.Exists(_location + typeof(ModelContext).FullName + ".edmx"), "edmx should have been written to _location");
+
+                var xdocFromStore = _store.TryGetEdmx(typeof(ModelContext));
+                Assert.NotNull(xdocFromStore);
+
+                var compiledModelFromCache = _store.TryLoad(typeof(ModelContext));
+                Assert.NotNull(compiledModelFromCache);
+
+                using (var context = new ModelContext(compiledModelFromCache))
+                {
+                    Assert.False(context.Models.Any(prd => true), "should access without error");
+                }
+            }
+            finally //clean up
+            {
+                MutableResolver.ClearResolvers();
+                if (File.Exists(_location + typeof(ModelContext).FullName + ".edmx"))
+                {
+                    File.Delete(_location + typeof(ModelContext).FullName + ".edmx");
+                }
+            }
+        }
+
+        [Fact]
+        public void DefaultDbModelStore_saves_and_loads_DbContext_with_DbFunction_StoreModelConvention()
+        {
+            try
+            {
+                var dependencyResolver = new SingletonDependencyResolver<DbModelStore>(_store);
+                MutableResolver.AddResolver<DbModelStore>(dependencyResolver);
+
+                Assert.False(File.Exists(_location + typeof(ScalarFunctionDbContext).FullName + ".edmx"), "edmx should not exist yet");
+
+                using (var context = new ScalarFunctionDbContext())
+                {
+                    context.Models.Add(new Model { Id = 1 });
+                    context.SaveChanges();
+
+                    Assert.True(
+                        context.Set<Model>().Any(model => ScalarFunction.GetSomething("inValue") == "inValue"),
+                        "Value passed in should be returned from db function without error");
+                }
+
+                Assert.True(
+                    File.Exists(_location + typeof(ScalarFunctionDbContext).FullName + ".edmx"), "edmx should be written to _location");
+
+                var xdocFromStore = _store.TryGetEdmx(typeof(ScalarFunctionDbContext));
+                Assert.NotNull(xdocFromStore);
+
+                var compiledModelFromCache = _store.TryLoad(typeof(ScalarFunctionDbContext));
+                Assert.NotNull(compiledModelFromCache);
+                using (var context = new ScalarFunctionDbContext(compiledModelFromCache))
+                {
+                    Assert.True(
+                        context.Set<Model>().Any(prd => ScalarFunction.GetSomething("inValue") == "inValue"),
+                        "Value passed in should be returned from db function without error");
+                }
+            }
+            finally //clean up
+            {
+                MutableResolver.ClearResolvers();
+                if (File.Exists(_location + typeof(ScalarFunctionDbContext).FullName + ".edmx"))
+                {
+                    File.Delete(_location + typeof(ScalarFunctionDbContext).FullName + ".edmx");
+                }
+            }
+        }
+
+        #region ScalarFunctionDbContext
+        public class ScalarFunctionDbContextInitializer : CreateDatabaseIfNotExists<ScalarFunctionDbContext>
+        {
+            protected override void Seed(ScalarFunctionDbContext context)
+            {
+                context.Database.ExecuteSqlCommand(CreateFunctionScript);
+            }
+
+            private const string CreateFunctionScript =
+                @"CREATE FUNCTION [dbo].[GetSomething]
+                    (
+	                    @inValue varchar(100)
+                    )
+                    RETURNS varchar(100)
+                    AS BEGIN
+                        RETURN @inValue;
+                    END";
+        }
+        public class ScalarFunctionDbContext : DbContext
+        {
+            public ScalarFunctionDbContext()
+            {
+                Database.SetInitializer(new ScalarFunctionDbContextInitializer());
+                Configuration.AutoDetectChangesEnabled = false;
+                Configuration.LazyLoadingEnabled = false;
+                Configuration.ProxyCreationEnabled = false;
+            }
+
+            public ScalarFunctionDbContext(DbCompiledModel model)
+                : base(model)
+            {
+                Database.SetInitializer(new ScalarFunctionDbContextInitializer());
+                Configuration.AutoDetectChangesEnabled = false;
+                Configuration.LazyLoadingEnabled = false;
+                Configuration.ProxyCreationEnabled = false;
+            }
+
+            public DbSet<Model> Models { get; set; }
+
+            protected override void OnModelCreating(DbModelBuilder modelBuilder)
+            {
+                modelBuilder.Conventions.Add(new ScalarFunctionConvention());
+                base.OnModelCreating(modelBuilder);
+            }
+        }
+
+        public static class ScalarFunction
+        {
+            [DbFunction("CodeFirstDatabaseSchema", "GetSomething")]
+            public static string GetSomething(string inValue)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public class ScalarFunctionConvention : IStoreModelConvention<EdmModel>
+        {
+            private DbModel _model;
+
+            public void Apply(EdmModel item, DbModel model)
+            {
+                _model = model;
+
+                var attribute = typeof(ScalarFunction)
+                    .GetMethod("GetSomething")
+                    .GetCustomAttributes(false).OfType<DbFunctionAttribute>().FirstOrDefault();
+                
+                MapScalarFunction(attribute);
+            }
+
+            private void MapScalarFunction(DbFunctionAttribute dbfuncAttr)
+            {
+                var stringType = _model
+                    .ProviderManifest
+                    .GetStoreType(
+                        TypeUsage.CreateDefaultTypeUsage(
+                            PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String))).EdmType;
+                
+                var edmParams = new List<FunctionParameter>
+                {
+                    FunctionParameter.Create("inValue", stringType, ParameterMode.In)
+                };
+
+                var edmReturnParams = new List<FunctionParameter>
+                {
+                    FunctionParameter.Create("result", stringType, ParameterMode.ReturnValue)
+                };
+
+                var functionPayload = new EdmFunctionPayload
+                {
+                    StoreFunctionName = dbfuncAttr.FunctionName,
+                    Parameters = edmParams,
+                    ReturnParameters = edmReturnParams,
+                    Schema = "dbo"
+                };
+
+                var function = EdmFunction.Create(dbfuncAttr.FunctionName, dbfuncAttr.NamespaceName,
+                    _model.StoreModel.DataSpace, functionPayload, null);
+
+                _model.StoreModel.AddItem(function);
+            }
+        }
+
+        #endregion
+
+        #region ModelContext
+        public class Model
+        {
+            public int Id { get; set; }
+        }
+
+        public class ModelContext : DbContext
+        {
+            public ModelContext()
+            {
+                Database.SetInitializer(new DropCreateDatabaseAlways<ModelContext>());
+            }
+
+            public ModelContext(DbCompiledModel model)
+                : base(model)
+            {
+                Database.SetInitializer(new DropCreateDatabaseAlways<ModelContext>());
+            }
+
+            public DbSet<Model> Models { get; set; }
+        }
+        #endregion
+    }
+}

--- a/test/EntityFramework/FunctionalTests/ProductivityApi/WriteEdmxTests.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/WriteEdmxTests.cs
@@ -6,6 +6,7 @@ namespace ProductivityApiTests
     using System.Data.Entity;
     using System.Data.Entity.Core.EntityClient;
     using System.Data.Entity.Infrastructure;
+    using System.Data.Entity.Infrastructure.DependencyResolution;
     using System.Data.Entity.ModelConfiguration;
     using System.IO;
     using System.Linq;
@@ -40,6 +41,27 @@ namespace ProductivityApiTests
         public void EDMX_can_be_written_after_context_is_initialized()
         {
             EDMX_can_be_written(initializeContext: true);
+        }
+
+        [Fact]
+        public void EDMX_can_be_read_from_DbModelStore_after_context_is_initialized()
+        {
+            var location = Path.GetTempPath();
+            try
+            {
+                var store = new DefaultDbModelStore(location);
+                var dependencyResolver = new SingletonDependencyResolver<DbModelStore>(store);
+                MutableResolver.AddResolver<DbModelStore>(dependencyResolver);
+                EDMX_can_be_written(initializeContext: true);
+            }
+            finally //clean up
+            {
+                MutableResolver.ClearResolvers();
+                if (File.Exists(location + typeof(SimpleModelContext).FullName + ".edmx"))
+                {
+                    File.Delete(location + typeof(SimpleModelContext).FullName + ".edmx");
+                }
+            }
         }
 
         private void EDMX_can_be_written(bool initializeContext)

--- a/test/EntityFramework/UnitTests/DbConfigurationTests.cs
+++ b/test/EntityFramework/UnitTests/DbConfigurationTests.cs
@@ -1036,6 +1036,40 @@ namespace System.Data.Entity
             }
         }
 
+        public class SetModelStore
+        {
+            [Fact]
+            public void Throws_if_given_a_null_modelstore()
+            {
+                Assert.Equal(
+                    "modelStore",
+                    Assert.Throws<ArgumentNullException>(
+                        () => new DbConfiguration().SetModelStore(null)).ParamName);
+            }
+
+            [Fact]
+            public void Throws_if_the_configuation_is_locked()
+            {
+                var configuration = CreatedLockedConfiguration();
+                var mockModelStore = new Mock<DbModelStore>();
+
+                Assert.Equal(
+                    Strings.ConfigurationLocked("SetModelStore"),
+                    Assert.Throws<InvalidOperationException>(() => configuration.SetModelStore(mockModelStore.Object)).Message);
+            }
+
+            [Fact]
+            public void Delegates_to_internal_configuration()
+            {
+                var mockInternalConfiguration = new Mock<InternalConfiguration>(null, null, null, null, null);
+                var mockModelStore = new Mock<DbModelStore>();
+
+                new DbConfiguration(mockInternalConfiguration.Object).SetModelStore(mockModelStore.Object);
+
+                mockInternalConfiguration.Verify(m => m.RegisterSingleton(mockModelStore.Object));
+            }
+        }
+
         public class SetTableExistenceChecker
         {
             [Fact]

--- a/test/EntityFramework/UnitTests/EdmxReaderTests.cs
+++ b/test/EntityFramework/UnitTests/EdmxReaderTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Infrastructure
+{
+    using System;
+    using System.Data.Entity;
+    using System.IO;
+    using System.Xml;
+    using SimpleModel;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for EdmxReader methods.
+    /// </summary>
+    public class EdmxReaderTests : TestBase
+    {
+        [Fact]
+        public void Read_throws_when_given_null_reader()
+        {
+            Assert.Equal(
+                "reader",
+                Assert.Throws<ArgumentNullException>(() => EdmxReader.Read(null, "defaultSchema")).ParamName);
+        }
+
+        [Fact]
+        public void Read_loads_edmx_from_EdmxWriter_into_DbCompiledModel()
+        {
+            var stream = new MemoryStream();
+            var xmlWriter = XmlWriter.Create(stream);
+
+            using (var context = new EmptyContext())
+            {
+                EdmxWriter.WriteEdmx(context, xmlWriter);
+            }
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var defaultSchema = "default";
+            var xmlReader = XmlReader.Create(stream);
+            var readModel = EdmxReader.Read(xmlReader, defaultSchema);
+
+            Assert.IsType<DbCompiledModel>(readModel);
+
+            Assert.Equal(defaultSchema, readModel.DefaultSchema);
+            Assert.NotNull(readModel.ProviderInfo);
+        }
+    }
+}

--- a/test/EntityFramework/UnitTests/Infrastructure/DbModelStoreTests.cs
+++ b/test/EntityFramework/UnitTests/Infrastructure/DbModelStoreTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Infrastructure
+{
+    using Xunit;
+    using System.Data.Entity.ModelConfiguration.Edm;
+    using System.Xml.Linq;
+
+    public class DbModelStoreTests : TestBase
+    {
+        [Fact]
+        public void GetDefaultSchema_returns_EdmModelExtensions_DefaultSchema()
+        {
+            var modelStore = new TestableDbModelStore();
+            var defaultSchema = modelStore.CallGetDefaultSchema(typeof(DbContext));
+            Assert.Equal(EdmModelExtensions.DefaultSchema, defaultSchema);
+        }
+
+        internal class TestableDbModelStore : DbModelStore
+        {
+            public string CallGetDefaultSchema(Type contextType)
+            {
+                return GetDefaultSchema(contextType);
+            }
+
+            public override DbCompiledModel TryLoad(Type contextType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override XDocument TryGetEdmx(Type contextType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Save(Type contextType, DbModel model)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/EntityFramework/UnitTests/Infrastructure/DbModelTests.cs
+++ b/test/EntityFramework/UnitTests/Infrastructure/DbModelTests.cs
@@ -6,7 +6,7 @@ namespace System.Data.Entity.Infrastructure
     using System.Data.Entity.Core.Metadata.Edm;
     using Xunit;
 
-    public class DbModelTests
+    public class DbModelTests : TestBase
     {
         [Fact]
         public void Can_retrieve_entity_container_mapping()
@@ -19,6 +19,22 @@ namespace System.Data.Entity.Infrastructure
             model.DatabaseMapping.AddEntityContainerMapping(containerMapping);
 
             Assert.Same(containerMapping, model.ConceptualToStoreMapping);
+        }
+
+        [Fact]
+        public void Compile_builds_populated_DbCompiledModel()
+        {
+            var defaultSchema = "mySchema";
+            var modelBuilder = new DbModelBuilder();
+            modelBuilder.ModelConfiguration.DefaultSchema = defaultSchema;
+            var model = modelBuilder.Build(ProviderRegistry.Sql2008_ProviderInfo);
+            
+            var compiled = model.Compile();
+
+            Assert.IsType<DbCompiledModel>(compiled);
+            Assert.Same(model.CachedModelBuilder, compiled.CachedModelBuilder);
+            Assert.Equal(defaultSchema, compiled.DefaultSchema);
+            Assert.Equal(ProviderRegistry.Sql2008_ProviderInfo, compiled.ProviderInfo);
         }
     }
 }

--- a/test/EntityFramework/UnitTests/Infrastructure/DefaultDbModelStoreTests.cs
+++ b/test/EntityFramework/UnitTests/Infrastructure/DefaultDbModelStoreTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Infrastructure
+{
+    using Xunit;
+    using System.Data.Entity.Resources;
+
+    public class DefaultDbModelStoreTests : TestBase
+    {
+        [Fact]
+        public void Constructor_location_cannot_be_null()
+        {
+            Assert.Equal(Strings.ArgumentIsNullOrWhitespace("location"),
+                Assert.Throws<ArgumentException>(() => new DefaultDbModelStore(null)).Message);
+        }
+
+        [Fact]
+        public void Constructor_location_cannot_be_empty()
+        {
+            
+            Assert.Equal(Strings.ArgumentIsNullOrWhitespace("location"),
+                Assert.Throws<ArgumentException>(() => new DefaultDbModelStore(string.Empty)).Message);
+        }
+
+        [Fact]
+        public void Constructor_sets_Location()
+        {
+            var location = "zz:\\filelocation";
+            var modelStore = new DefaultDbModelStore(location);
+            Assert.Equal(location, modelStore.Location);
+        }
+    }
+}

--- a/test/EntityFramework/UnitTests/UnitTests.csproj
+++ b/test/EntityFramework/UnitTests/UnitTests.csproj
@@ -310,6 +310,8 @@
     <Compile Include="Infrastructure\Annotations\CompatibilityResultTests.cs" />
     <Compile Include="Infrastructure\Annotations\IndexAnnotationSerializerTests.cs" />
     <Compile Include="Infrastructure\Annotations\IndexAnnotationTests.cs" />
+    <Compile Include="Infrastructure\DbModelStoreTests.cs" />
+    <Compile Include="Infrastructure\DefaultDbModelStoreTests.cs" />
     <Compile Include="Infrastructure\DependencyResolution\TransactionContextInitializerResolverTests.cs" />
     <Compile Include="Infrastructure\DependencyResolution\TransactionHandlerResolverTests.cs" />
     <Compile Include="Infrastructure\Design\AppConfigReaderTests.cs" />
@@ -783,6 +785,7 @@
     <Compile Include="Validation\ValidationAttributeValidatorTests.cs" />
     <Compile Include="Validation\ValidationContextTests.cs" />
     <Compile Include="Validation\ValidationProviderTests.cs" />
+    <Compile Include="EdmxReaderTests.cs" />
     <Compile Include="WriteEdmxTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Ported from [CodePlex Pull Request 8468](http://entityframework.codeplex.com/SourceControl/network/forks/jEdge/CodeFirstCache/contribution/8468)
Fix for CodePlex Work Items [#1876](http://entityframework.codeplex.com/workitem/1876) and [#2631](http://entityframework.codeplex.com/workitem/2631)
Reduce start up time by loading finished Code First models from a persistent cache
Incorporates DbModelStore persistent cache to reduce Code First Startup Time

With these changes, first AppDomain calls to context.Database.Initialize for a model with just over 600 models and a null initializer dropped from 12-14 seconds to about 1.9 seconds after the edmx was written, saving 10-12 seconds on initialization. The first call to write the edmx still ran in 12-14 seconds (no noticeable delay added).

Includes code from the patch by emilcicos attached to work item [#1876](http://entityframework.codeplex.com/workitem/1876), with modifications to fix known issues.

Code changed after applying the patch:
- DefaultDbModelStore invalidates (deletes) the persistent store based on comparing context dll and edmx file last updated timestamps.
- EdmxWriter was updated to read from the DbModelStore when available. This fixed a null reference when using DropCreateAlways initializer with a DbModelStore (compiledModel.CachedModelBuilder is null when the model is loaded from the store). Added function DbModelStore.TryGetEdmx to allow the EdmxWriter to read the edmx directly from storage.
- LazyInternalContext.ModelMatches changes in the patch were removed as they were unnecessary after the EdmxWriter fix.
- Added unit and functional test coverage for code changes including the patch code. DefaultDbModelStoreTests functional test covers the end-to-end functionality of using a DbModelStore.
