### PR TITLE
Unblock model defined functions

### DIFF
--- a/src/EntityFramework/Core/SchemaObjectModel/Function.cs
+++ b/src/EntityFramework/Core/SchemaObjectModel/Function.cs
@@ -572,10 +572,6 @@ namespace System.Data.Entity.Core.SchemaObjectModel
         // <param name="reader"> An XmlReader positioned at the Type attribute. </param>
         private void HandleDbSchemaAttribute(XmlReader reader)
         {
-            Debug.Assert(
-                Schema.DataModel == SchemaDataModelOption.ProviderDataModel, "We shouldn't see this attribute unless we are parsing ssdl");
-            DebugCheck.NotNull(reader);
-
             _schema = reader.Value;
         }
 

--- a/src/EntityFramework/Resources/System/Data/EntityModel/System.Data.Resources.CSDLSchema_3.xsd
+++ b/src/EntityFramework/Resources/System/Data/EntityModel/System.Data.Resources.CSDLSchema_3.xsd
@@ -257,6 +257,13 @@
         </xs:sequence>
         <xs:attribute name="Name" type="edm:TSimpleIdentifier" use="required" />
         <xs:attribute name="ReturnType" type="edm:TWrappedFunctionType" use="optional" />
+        <xs:attribute name="Aggregate" type="xs:boolean" use="optional" />
+        <xs:attribute name="BuiltIn" type="xs:boolean" use="optional" />
+        <xs:attribute name="StoreFunctionName" type="xs:string" use="optional" />
+        <xs:attribute name="NiladicFunction" type="xs:boolean" use="optional" />
+        <xs:attribute name="IsComposable" type="xs:boolean" use="optional" default="true" />
+        <xs:attribute name="ParameterTypeSemantics" type="edm:TParameterTypeSemantics" use="optional" default="AllowImplicitConversion" />
+        <xs:attribute name="Schema" type="xs:string" use="optional" />
         <xs:attributeGroup ref="edm:TFacetAttributes" />
         <xs:anyAttribute namespace="##other" processContents="lax" />
     </xs:complexType>
@@ -275,6 +282,7 @@
         </xs:sequence>
         <xs:attribute name="Name" type="edm:TSimpleIdentifier" use="required" />
         <xs:attribute name="Type" type="edm:TWrappedFunctionType" use="optional" />
+        <xs:attribute name="Mode" type="edm:TParameterMode" use="optional" />
         <xs:attributeGroup ref="edm:TFacetAttributes" />
         <xs:anyAttribute namespace="##other" processContents="lax" />
     </xs:complexType>
@@ -993,6 +1001,13 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="TParameterTypeSemantics">
+      <xs:restriction base="xs:token">
+        <xs:enumeration value="ExactMatchOnly" />
+        <xs:enumeration value="AllowImplicitPromotion" />
+        <xs:enumeration value="AllowImplicitConversion" />
+      </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="TAction">
         <xs:restriction base="xs:token">

--- a/test/EntityFramework/FunctionalTests/ProductivityApi/DbFunctionScenarios.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/DbFunctionScenarios.cs
@@ -5,9 +5,11 @@ namespace FunctionalTests.ProductivityApi
     using System;
     using System.Collections.Generic;
     using System.Data.Entity;
+    using System.Data.Entity.Core.Metadata.Edm;
     using System.Data.Entity.Core.Objects;
     using System.Data.Entity.Core.Objects.DataClasses;
     using System.Data.Entity.Infrastructure;
+    using System.Data.Entity.ModelConfiguration.Conventions;
     using System.Data.Entity.TestHelpers;
     using System.Data.Entity.WrappingProvider;
     using System.Data.SqlClient;
@@ -1488,6 +1490,72 @@ namespace FunctionalTests.ProductivityApi
                     Assert.Equal(
                         1, (decimal)GetObjectSet<EntityWithTypes>(context).OrderBy(e => e.Id).Select(
                             e => Math.Truncate(e.Decimal)).First(), 7);
+                }
+            }
+        }
+
+        public class Custom : FunctionalTestBase
+        {
+            [Fact]
+            public void CustomDbFunction_can_be_configured_in_CSpace()
+            {
+                using (var context = new CustomEntityFunctionContext())
+                {
+                    Assert.Equal(
+                        "Magic Unicorns Rocks",
+                        context.WithTypes
+                            .Where(t => t.String == "Magic Unicorns Rock")
+                            .Select(t => t.String.ConcatenateS())
+                            .First());
+
+                    Assert.Equal(
+                        "Magic Unicorns Rocks",
+                        GetObjectSet<EntityWithTypes>(context)
+                            .Where(t => t.String == "Magic Unicorns Rock")
+                            .Select(t => t.String.ConcatenateS())
+                            .First());
+                }
+            }
+
+            private class CustomEntityFunctionContext : EntityFunctionContext
+            {
+                static CustomEntityFunctionContext()
+                {
+                    Database.SetInitializer<CustomEntityFunctionContext>(new EntityFunctionInitializer());
+                }
+
+                protected override void OnModelCreating(DbModelBuilder modelBuilder)
+                {
+                    modelBuilder.Conventions.Add(new CustomConvention());                    
+                    
+                    base.OnModelCreating(modelBuilder);
+                }
+            }
+
+            private class CustomConvention
+                : IConceptualModelConvention<EdmModel>
+            {
+                public void Apply(EdmModel item, DbModel model)
+                {
+                    var functionPayload = new EdmFunctionPayload() {
+                        IsComposable = true,
+                        CommandText = "v + 's'",
+                        Parameters = new[] { 
+                            FunctionParameter.Create("v", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), ParameterMode.In)
+                        },
+
+                        ReturnParameters = new[] {
+                            FunctionParameter.Create("Result", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), ParameterMode.ReturnValue)
+                        }
+                    };
+
+                    item.AddItem(
+                        EdmFunction.Create(
+                            "ConcatenateS",
+                            "FunctionalTests.ProductivityApi",
+                            DataSpace.CSpace,
+                            functionPayload,
+                            null));
                 }
             }
         }
@@ -3176,6 +3244,15 @@ namespace FunctionalTests.ProductivityApi
             {
                 context.WithTypes.Add(entityWithType);
             }
+        }
+    }
+
+    static class CustomExtension
+    {
+        [DbFunction("FunctionalTests.ProductivityApi", "ConcatenateS")]
+        public static string ConcatenateS(this string baseString)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/EntityFramework/UnitTests/ModelConfiguration/Edm/Serialization/Xsd/System.Data.Resources.CSDLSchema_3.xsd
+++ b/test/EntityFramework/UnitTests/ModelConfiguration/Edm/Serialization/Xsd/System.Data.Resources.CSDLSchema_3.xsd
@@ -235,6 +235,13 @@
         </xs:sequence>
         <xs:attribute name="Name" type="edm:TSimpleIdentifier" use="required" />
         <xs:attribute name="ReturnType" type="edm:TWrappedFunctionType" use="optional" />
+        <xs:attribute name="Aggregate" type="xs:boolean" use="optional" />
+        <xs:attribute name="BuiltIn" type="xs:boolean" use="optional" />
+        <xs:attribute name="StoreFunctionName" type="xs:string" use="optional" />
+        <xs:attribute name="NiladicFunction" type="xs:boolean" use="optional" />
+        <xs:attribute name="IsComposable" type="xs:boolean" use="optional" default="true" />
+        <xs:attribute name="ParameterTypeSemantics" type="edm:TParameterTypeSemantics" use="optional" default="AllowImplicitConversion" />
+        <xs:attribute name="Schema" type="xs:string" use="optional" />
         <xs:attributeGroup ref="edm:TFacetAttributes" />
         <xs:anyAttribute namespace="##other" processContents="lax" />
     </xs:complexType>
@@ -580,6 +587,13 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="TParameterTypeSemantics">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="ExactMatchOnly" />
+            <xs:enumeration value="AllowImplicitPromotion" />
+            <xs:enumeration value="AllowImplicitConversion" />
+        </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="TAction">
         <xs:restriction base="xs:token">


### PR DESCRIPTION
Work Item [#2615](https://entityframework.codeplex.com/workitem/2615) - Unblock creation of model defined functions in conventions 
- Updated CSDL schema to handle existing serialization of model defined functions.
- Removed outdated Debug.Assert and DebugCheck.NotNull. 
- Added tests for new functionality.

Migrated from [CodePlex](https://entityframework.codeplex.com/SourceControl/network/forks/BrandonDahler/EntityFramework/contribution/8302).  Originally assigned to @AndriySvyryd .
