### PR TITLE
Fix AddOrUpdate for nullable identifiers

### DIFF
--- a/src/EntityFramework/Migrations/DbSetMigrationsExtensions.cs
+++ b/src/EntityFramework/Migrations/DbSetMigrationsExtensions.cs
@@ -133,7 +133,7 @@ namespace System.Data.Entity.Migrations
                     = identifyingProperties.Select(
                         pi => Expression.Equal(
                             Expression.Property(parameter, pi.Single()),
-                            Expression.Constant(pi.Last().GetValue(entity, null))))
+                            Expression.Constant(pi.Last().GetValue(entity, null), pi.Last().PropertyType)))
                                            .Aggregate<BinaryExpression, Expression>(
                                                null,
                                                (current, predicate)

--- a/test/EntityFramework/FunctionalTests.Transitional/Migrations/TestModel/TestModels.cs
+++ b/test/EntityFramework/FunctionalTests.Transitional/Migrations/TestModel/TestModels.cs
@@ -33,6 +33,8 @@ namespace System.Data.Entity.Migrations
 
         [MaxLength(1024)]
         public byte[] Photo { get; set; }
+
+        public int? Narf { get; set; }
     }
 
     public class SpecialCustomer : MigrationsCustomer

--- a/test/EntityFramework/UnitTests/Migrations/DbSetMigrationsExtensionsTests.cs
+++ b/test/EntityFramework/UnitTests/Migrations/DbSetMigrationsExtensionsTests.cs
@@ -257,6 +257,48 @@ namespace System.Data.Entity.Migrations
         }
 
         [MigrationsTheory]
+        public void AddOrUpdate_should_be_able_to_add_new_data_by_nullable_identifier()
+        {
+            ResetDatabase();
+
+            CreateMigrator<ShopContext_v1>().Update();
+
+            using (var context = CreateContext<ShopContext_v1>())
+            {
+                context.Customers.AddOrUpdate
+                    (
+                        c => new
+                        {
+                            c.FullName,
+                            c.Narf
+                        },
+                        new MigrationsCustomer
+                        {
+                            FullName = "Andrew Peters",
+                            CustomerNumber = 123
+                        },
+                        new MigrationsCustomer
+                        {
+                            FullName = "Brice Lambson",
+                            CustomerNumber = 456
+                        },
+                        new MigrationsCustomer
+                        {
+                            FullName = "Rowan Miller",
+                            CustomerNumber = 789
+                        }
+                    );
+
+                context.SaveChanges();
+            }
+
+            using (var context = CreateContext<ShopContext_v1>())
+            {
+                Assert.Equal(3, context.Customers.Count());
+            }
+        }
+
+        [MigrationsTheory]
         public void AddOrUpdate_should_be_able_to_update_existing_data_by_custom_identifier()
         {
             ResetDatabase();
@@ -317,6 +359,70 @@ namespace System.Data.Entity.Migrations
                     123,
                     context.Customers
                         .Single(c => c.FullName == "Andrew Peters" && c.Name == "Andrew2").CustomerNumber);
+            }
+        }
+
+        [MigrationsTheory]
+        public void AddOrUpdate_should_be_able_to_update_existing_data_by_nullable_identifier()
+        {
+            ResetDatabase();
+
+            CreateMigrator<ShopContext_v1>().Update();
+
+            using (var context = CreateContext<ShopContext_v1>())
+            {
+                context.Customers.AddOrUpdate
+                    (
+                        new MigrationsCustomer
+                        {
+                            FullName = "Andrew Peters",
+                            Narf = 1,
+                            CustomerNumber = 123
+                        },
+                        new MigrationsCustomer
+                        {
+                            FullName = "Andrew Peters",
+                            Narf = 2,
+                            CustomerNumber = 123
+                        }
+                    );
+
+                context.SaveChanges();
+            }
+
+            using (var context = CreateContext<ShopContext_v1>())
+            {
+                Assert.Equal(2, context.Customers.Count());
+
+                context.Customers.AddOrUpdate
+                    (
+                        c => new
+                        {
+                            c.FullName,
+                            c.Narf
+                        },
+                        new MigrationsCustomer
+                        {
+                            FullName = "Andrew Peters",
+                            Narf = 1,
+                            CustomerNumber = 456
+                        }
+                    );
+
+                context.SaveChanges();
+            }
+
+            using (var context = CreateContext<ShopContext_v1>())
+            {
+                Assert.Equal(2, context.Customers.Count());
+                Assert.Equal(
+                    456L,
+                    context.Customers
+                        .Single(c => c.FullName == "Andrew Peters" && c.Narf == 1).CustomerNumber);
+                Assert.Equal(
+                    123,
+                    context.Customers
+                        .Single(c => c.FullName == "Andrew Peters" && c.Narf == 2).CustomerNumber);
             }
         }
     }


### PR DESCRIPTION
_Note:_ many tests fail on my machine. Thus, I only verified those within `DbSetMigrationsExtensions`. Maybe my modification of `MigrationsCustomer` has some unwanted side effect regarding other tests?

Fixes #9
