### PR TITLE
Implement script generation support in migrate.exe - fixes codeplex/251

### DIFF
--- a/src/EntityFramework/Properties/Resources.Migrate.cs
+++ b/src/EntityFramework/Properties/Resources.Migrate.cs
@@ -3,9 +3,9 @@
 namespace System.Data.Entity.Migrations.Console.Resources
 {
     using System.CodeDom.Compiler;
-    using System.Data.Entity.Utilities;
     using System.Globalization;
     using System.Resources;
+    using System.Reflection;
     using System.Threading;
 
     // <summary>
@@ -293,6 +293,22 @@ namespace System.Data.Entity.Migrations.Console.Resources
         {
             return EntityRes.GetString(EntityRes.MissingCommandLineParameter, p0, p1, p2);
         }
+
+        // <summary>
+        // A string like "Specifies the output file where to write the SQL script being generated. Specifying this option will not apply changes to the database."
+        // </summary>
+        internal static string ScriptFileDescription
+        {
+            get { return EntityRes.GetString(EntityRes.ScriptFileDescription); }
+        }
+
+        // <summary>
+        // A string like "Specifies the name of a particular migration to update the database from. If omitted, the current model will be used."
+        // </summary>
+        internal static string SourceMigrationDescription
+        {
+            get { return EntityRes.GetString(EntityRes.SourceMigrationDescription); }
+        }
     }
 
     // <summary>
@@ -401,6 +417,8 @@ namespace System.Data.Entity.Migrations.Console.Resources
         internal const string InvalidCommandLineArgument = "InvalidCommandLineArgument";
         internal const string InvalidCommandLineCommand = "InvalidCommandLineCommand";
         internal const string MissingCommandLineParameter = "MissingCommandLineParameter";
+        internal const string ScriptFileDescription = "ScriptFileDescription";
+        internal const string SourceMigrationDescription = "SourceMigrationDescription";
 
         private static EntityRes loader;
         private readonly ResourceManager resources;
@@ -408,7 +426,12 @@ namespace System.Data.Entity.Migrations.Console.Resources
         private EntityRes()
         {
             resources = new ResourceManager(
-                "System.Data.Entity.Properties.Resources.Migrate", typeof(System.Data.Entity.DbContext).Assembly);
+                "System.Data.Entity.Properties.Resources.Migrate",
+#if NET40
+                typeof(System.Data.Entity.DbContext).Assembly);
+#else
+                typeof(System.Data.Entity.DbContext).GetTypeInfo().Assembly);
+#endif
         }
 
         private static EntityRes GetLoader()

--- a/src/EntityFramework/Properties/Resources.Migrate.resx
+++ b/src/EntityFramework/Properties/Resources.Migrate.resx
@@ -226,4 +226,10 @@
   <data name="MissingCommandLineParameter" xml:space="preserve">
     <value>Missing required parameter {0} "{1}" in command line "{2}"</value>
   </data>
+  <data name="ScriptFileDescription" xml:space="preserve">
+    <value>Specifies the output file where to write the SQL script being generated. Specifying this option will not apply changes to the database.</value>
+  </data>
+  <data name="SourceMigrationDescription" xml:space="preserve">
+    <value>Specifies the name of a particular migration to update the database from. If omitted, the current model will be used.</value>
+  </data>
 </root>

--- a/src/Migrate/Arguments.cs
+++ b/src/Migrate/Arguments.cs
@@ -42,6 +42,16 @@ namespace System.Data.Entity.Migrations.Console
         public string WorkingDirectory { get; set; }
 
         [CommandLineParameter(
+            Command = "scriptFile",
+            DescriptionResourceId = EntityRes.ScriptFileDescription)]
+        public string ScriptFile { get; set; }
+
+        [CommandLineParameter(
+            Command = "sourceMigration",
+            DescriptionResourceId = EntityRes.SourceMigrationDescription)]
+        public string SourceMigration { get; set; }
+
+        [CommandLineParameter(
             Command = "startUpConfigurationFile",
             DescriptionResourceId = EntityRes.ConfigurationFileDescription)]
         public string ConfigurationFile { get; set; }

--- a/src/Migrate/Program.cs
+++ b/src/Migrate/Program.cs
@@ -8,6 +8,7 @@ namespace System.Data.Entity.Migrations.Console
     using System.Diagnostics;
     using System.IO;
     using System.Reflection;
+    using System.Text;
     using CmdLine;
     using Console = System.Console;
 
@@ -77,8 +78,22 @@ namespace System.Data.Entity.Migrations.Console
         {
             using (var facade = CreateFacade())
             {
-                facade.Update(_arguments.TargetMigration, _arguments.Force);
+                if (!String.IsNullOrEmpty(_arguments.ScriptFile)) 
+                {
+                    ScriptUpdate(facade, _arguments);
+                } 
+                else 
+                {
+                    facade.Update(_arguments.TargetMigration, _arguments.Force);
+                }
             }
+        }
+
+        private static void ScriptUpdate(ToolingFacade facade, Arguments arguments)
+        {
+            string scriptContents = facade.ScriptUpdate(arguments.SourceMigration, arguments.TargetMigration, arguments.Force);
+
+            File.WriteAllText(arguments.ScriptFile, scriptContents, Encoding.UTF8);
         }
 
         private static Assembly ResolveAssembly(object sender, ResolveEventArgs args)


### PR DESCRIPTION
As per Codeplex [issue#251](http://entityframework.codeplex.com/workitem/251), implemented support for script generation via Entity Framework' migrate.exe.

This enables build automation regarding migration script, for example, generate migration scripts in the build server to include in a deployment. 

As part of this commit, in order to add new resources, `Resources.Migrate.cs` is also re-generated. Since the generated code is apparently out-of-date since the last time the T4 file was changes, the changes in that file are somewhat bigger than I'd like them to be.
