### PR TITLE
Update tests to current default LocalDb instance

### DIFF
--- a/test/EntityFramework/FunctionalTests/App.config
+++ b/test/EntityFramework/FunctionalTests/App.config
@@ -12,7 +12,7 @@
   </system.data>
   <connectionStrings>
     <add name="Scenario_Use_AppConfig_connection_string" providerName="System.Data.SqlClient" connectionString="Server=.\SQLEXPRESS;Integrated Security=True;Database=Scenario_Use_AppConfig;MultipleActiveResultSets=True;" />
-    <add name="Scenario_Use_AppConfig_LocalDb_connection_string" providerName="System.Data.SqlClient" connectionString="Data Source=(localdb)\v11.0;Integrated Security=True;Database=Scenario_Use_AppConfig_LocalDb;MultipleActiveResultSets=True;" />
+    <add name="Scenario_Use_AppConfig_LocalDb_connection_string" providerName="System.Data.SqlClient" connectionString="Data Source=(localdb)\mssqllocaldb;Integrated Security=True;Database=Scenario_Use_AppConfig_LocalDb;MultipleActiveResultSets=True;" />
     <add name="Scenario_Use_SqlCe_AppConfig_connection_string" providerName="System.Data.SqlServerCe.4.0" connectionString="Data Source=Scenario_Use_AppConfig.sdf" />
     <add name="Scenario_Use_SqlCeLegacy_AppConfig_connection_string" providerName="System.Data.SqlServerCe.3.5" connectionString="Data Source=Scenario_Use_AppConfig_Legacy.sdf" />
     <add name="SimpleModelInAppConfig" providerName="System.Data.SqlClient" connectionString="Server=.\SQLEXPRESS;Integrated Security=True;Database=SimpleModel.SimpleModel;MultipleActiveResultSets=True;" />

--- a/test/EntityFramework/FunctionalTests/ProductivityApi/DatabaseTests.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/DatabaseTests.cs
@@ -1212,7 +1212,7 @@ END");
         [Fact]
         public void If_connection_is_changed_to_point_to_different_server_then_operations_that_use_OriginalConnectionString_pick_up_this_change()
         {
-            var changedServer = DatabaseTestHelpers.IsLocalDb(SimpleConnectionString("")) ? @".\SQLEXPRESS" : @"(localdb)\v11.0";
+            var changedServer = DatabaseTestHelpers.IsLocalDb(SimpleConnectionString("")) ? @".\SQLEXPRESS" : @"(localdb)\mssqllocaldb";
             var changedConnectionString = string.Format(
                 CultureInfo.InvariantCulture,
                 @"Data Source={0};Initial Catalog=MutatingConnectionContext4;Integrated Security=True", changedServer);

--- a/test/EntityFramework/FunctionalTests/ProductivityApi/SimpleScenariosForLocalDb.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/SimpleScenariosForLocalDb.cs
@@ -24,7 +24,7 @@ namespace ProductivityApiTests
             _previousDataDirectory = AppDomain.CurrentDomain.GetData("DataDirectory");
 
             AppDomain.CurrentDomain.SetData("DataDirectory", Path.GetTempPath());
-            MutableResolver.AddResolver<IDbConnectionFactory>(k => new LocalDbConnectionFactory("v11.0"));
+            MutableResolver.AddResolver<IDbConnectionFactory>(k => new LocalDbConnectionFactory("mssqllocaldb"));
         }
 
         public void Dispose()
@@ -139,7 +139,7 @@ namespace ProductivityApiTests
                 Assert.Same(category, product.Category);
                 Assert.True(category.Products.Contains(product));
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 
@@ -161,7 +161,7 @@ namespace ProductivityApiTests
                 Assert.NotEqual(0, product.Id);
                 Assert.Equal(EntityState.Unchanged, GetStateEntry(context, product).State);
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 
@@ -180,7 +180,7 @@ namespace ProductivityApiTests
                 Assert.Equal("iSnack 2.0", product.Name);
                 Assert.Equal(EntityState.Unchanged, GetStateEntry(context, product).State);
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 
@@ -195,7 +195,7 @@ namespace ProductivityApiTests
                 Assert.Equal(7, products.Count);
                 Assert.True(products.TrueForAll(p => GetStateEntry(context, p).State == EntityState.Unchanged));
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 
@@ -226,7 +226,7 @@ namespace ProductivityApiTests
                 Assert.Same(category, product.Category);
                 Assert.True(category.Products.Contains(product));
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 
@@ -250,7 +250,7 @@ namespace ProductivityApiTests
                 Assert.Equal(EntityState.Unchanged, GetStateEntry(context, product).State);
                 Assert.Equal("Foods", product.CategoryId);
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 
@@ -293,7 +293,7 @@ namespace ProductivityApiTests
             Assert.Same(category, product.Category);
             Assert.True(category.Products.Contains(product));
 
-            Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+            Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
         }
 
         private void InsertIntoCleanContext(SimpleLocalDbModelContextWithNoData context)
@@ -311,7 +311,7 @@ namespace ProductivityApiTests
                     });
             context.SaveChanges();
 
-            Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+            Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
         }
 
         [ExtendedFact(SkipForSqlAzure = true)]
@@ -334,7 +334,7 @@ namespace ProductivityApiTests
                 Assert.Same(login, context.Logins.Find(login.Id));
                 Assert.Equal(EntityState.Unchanged, GetStateEntry(context, login).State);
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
 
             using (var context = new SimpleLocalDbModelContext())
@@ -358,7 +358,7 @@ namespace ProductivityApiTests
                 Assert.Same(category, product.Category);
                 Assert.True(category.Products.Contains(product));
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 
@@ -393,7 +393,7 @@ namespace ProductivityApiTests
                     Assert.NotNull(product.Category);
                 }
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 
@@ -411,7 +411,7 @@ namespace ProductivityApiTests
                     Assert.NotNull(product.Category);
                 }
 
-                Assert.Equal(@"(localdb)\v11.0", context.Database.Connection.DataSource);
+                Assert.Equal(@"(localdb)\mssqllocaldb", context.Database.Connection.DataSource);
             }
         }
 


### PR DESCRIPTION
The LocalDb tests currently depend on (localdb)\v11.0 which was the default instance name created when installing an earlier version of VS. Nowadays the instance is (localdb)\mssqllocaldb and should remain that way for future versions of VS.
All tests in SimpleScenariosForLocalDb now pass on a machine without v11.0.

I've already updated our CI to have the new instance name available.