### PR TITLE
Handle NewExpression.Members being null

### DIFF
--- a/src/EntityFramework/Utilities/ExpressionExtensions.cs
+++ b/src/EntityFramework/Utilities/ExpressionExtensions.cs
@@ -120,11 +120,12 @@ namespace System.Data.Entity.Utilities
             DebugCheck.NotNull(newExpression);
             DebugCheck.NotNull(propertyPaths);
 
-            return !newExpression.Members
-                                 .Where(
-                                     (t, i) =>
-                                     !string.Equals(t.Name, propertyPaths.ElementAt(i).Last().Name, StringComparison.Ordinal))
-                                 .Any();
+            return newExpression.Members == null
+                   || !newExpression.Members
+                       .Where(
+                           (t, i) =>
+                               !string.Equals(t.Name, propertyPaths.ElementAt(i).Last().Name, StringComparison.Ordinal))
+                       .Any();
         }
 
         private static PropertyPath MatchSimplePropertyAccess(


### PR DESCRIPTION
Issue #132

When doing `a => new { }` the NewExpression can have null Members--possibly when using some version of the Roslyn compiler. Fix is to handle the null.