### PR TITLE
SQL Server Migrations: Always drop default constraints before altering columns

### DIFF
--- a/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
@@ -770,11 +770,7 @@ namespace System.Data.Entity.SqlServer
 
             using (var writer = Writer())
             {
-                if ((column.DefaultValue != null)
-                    || !string.IsNullOrWhiteSpace(column.DefaultValueSql))
-                {
-                    DropDefaultConstraint(alterColumnOperation.Table, column.Name, writer);
-                }
+                DropDefaultConstraint(alterColumnOperation.Table, column.Name, writer);
 
                 writer.Write("ALTER TABLE ");
                 writer.Write(Name(alterColumnOperation.Table));

--- a/test/EntityFramework/UnitTests/SqlServer/SqlServerMigrationSqlGeneratorTests.cs
+++ b/test/EntityFramework/UnitTests/SqlServer/SqlServerMigrationSqlGeneratorTests.cs
@@ -1187,7 +1187,14 @@ ALTER TABLE [T] ADD CONSTRAINT [DF_T_C] DEFAULT 'POINT (8 9)' FOR [C]", sql);
             var sql = new SqlServerMigrationSqlGenerator().Generate(new[] { operation }, "2008").Join(s => s.Sql, Environment.NewLine);
 
             Assert.Equal(
-                @"ALTER TABLE [T] ALTER COLUMN [C] [geography] NOT NULL", sql);
+                @"DECLARE @var0 nvarchar(128)
+SELECT @var0 = name
+FROM sys.default_constraints
+WHERE parent_object_id = object_id(N'T')
+AND col_name(parent_object_id, parent_column_id) = 'C';
+IF @var0 IS NOT NULL
+    EXECUTE('ALTER TABLE [T] DROP CONSTRAINT [' + @var0 + ']')
+ALTER TABLE [T] ALTER COLUMN [C] [geography] NOT NULL", sql);
         }
 
         [Fact]
@@ -1206,7 +1213,14 @@ ALTER TABLE [T] ADD CONSTRAINT [DF_T_C] DEFAULT 'POINT (8 9)' FOR [C]", sql);
             var sql = new SqlServerMigrationSqlGenerator().Generate(new[] { operation }, "2008").Join(s => s.Sql, Environment.NewLine);
 
             Assert.Equal(
-                @"ALTER TABLE [T] ALTER COLUMN [C] [geometry] NOT NULL", sql);
+                @"DECLARE @var0 nvarchar(128)
+SELECT @var0 = name
+FROM sys.default_constraints
+WHERE parent_object_id = object_id(N'T')
+AND col_name(parent_object_id, parent_column_id) = 'C';
+IF @var0 IS NOT NULL
+    EXECUTE('ALTER TABLE [T] DROP CONSTRAINT [' + @var0 + ']')
+ALTER TABLE [T] ALTER COLUMN [C] [geometry] NOT NULL", sql);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #54

Note, this is the behavior we use in EF Core.