### PR TITLE
Fix for #139: PowerTools: setting |datadirectory| path fails if using non-default output path

### DIFF
--- a/src/PowerTools/DbContextPackage.cs
+++ b/src/PowerTools/DbContextPackage.cs
@@ -518,9 +518,10 @@ namespace Microsoft.DbContextPackage
 
             AppDomain.CurrentDomain.SetData(
                 "DataDirectory",
-                project.IsWebProject()
-                    ? Path.Combine(project.GetProjectDir(), "App_Data")
-                    : project.GetTargetDir());
+                Path.GetFullPath(
+                    project.IsWebProject()
+                        ? Path.Combine(project.GetProjectDir(), "App_Data")
+                        : project.GetTargetDir()));
         }
 
         private static IEnumerable<CodeElement> FindClassesInCodeModel(CodeElements codeElements)


### PR DESCRIPTION
Setting an output path that not a child of the directory containing the project will result in a target directory that contains path traversals, e.g. C:\EfTestProg\EfTestProg\..\Output\Debug\ but SqlClient isn't happy with those. Fix is to add a call to Path.GetFullPath() when computing the data directory.

Verification: smoke testing.