### PR TITLE
Use separate timer per interception context when DatabaseLogFormatter is used without a context

### DIFF
--- a/src/EntityFramework/Infrastructure/Interception/DatabaseLogFormatter.cs
+++ b/src/EntityFramework/Infrastructure/Interception/DatabaseLogFormatter.cs
@@ -30,6 +30,7 @@ namespace System.Data.Entity.Infrastructure.Interception
     /// </remarks>
     public class DatabaseLogFormatter : IDbCommandInterceptor, IDbConnectionInterceptor, IDbTransactionInterceptor
     {
+        private const string StopwatchStateKey = "__LoggingStopwatch__";
         private readonly WeakReference _context;
         private readonly Action<string> _writeAction;
         private readonly Stopwatch _stopwatch = new Stopwatch();
@@ -99,21 +100,72 @@ namespace System.Data.Entity.Infrastructure.Interception
         }
 
         /// <summary>
-        /// The stop watch used to time executions. This stop watch is started at the end of
-        /// <see cref="NonQueryExecuting" />, <see cref="ScalarExecuting" />, and <see cref="ReaderExecuting" />
-        /// methods and is stopped at the beginning of the <see cref="NonQueryExecuted" />, <see cref="ScalarExecuted" />,
-        /// and <see cref="ReaderExecuted" /> methods. If these methods are overridden and the stop watch is being used
-        /// then the overrides should either call the base method or start/stop the watch themselves.
+        /// This property is obsolete. Using it can result in logging incorrect execution times. Call
+        /// <see cref="GetStopwatch"/> instead.
         /// </summary>
+        [Obsolete("This stopwatch can give incorrect times. Use 'GetStopwatch' instead.")]
         protected internal Stopwatch Stopwatch
         {
             get { return _stopwatch; }
         }
 
         /// <summary>
+        /// The stopwatch used to time executions. This stopwatch is started at the end of
+        /// <see cref="NonQueryExecuting" />, <see cref="ScalarExecuting" />, and <see cref="ReaderExecuting" />
+        /// methods and is stopped at the beginning of the <see cref="NonQueryExecuted" />, <see cref="ScalarExecuted" />,
+        /// and <see cref="ReaderExecuted" /> methods. If these methods are overridden and the stopwatch is being used
+        /// then the overrides should either call the base method or start/stop the stopwatch themselves.
+        /// </summary>
+        /// <param name="interceptionContext">The interception context for which the stopwatch will be obtained.</param>
+        /// <returns>The stopwatch.</returns>
+        protected internal Stopwatch GetStopwatch(DbCommandInterceptionContext interceptionContext)
+        {
+            if (_context != null)
+            {
+                return _stopwatch;
+            }
+
+            var stopwatch = (Stopwatch)((IDbMutableInterceptionContext)interceptionContext).MutableData
+                .FindUserState(StopwatchStateKey);
+
+            if (stopwatch == null)
+            {
+                stopwatch = new Stopwatch();
+                ((IDbMutableInterceptionContext)interceptionContext).MutableData.SetUserState(StopwatchStateKey, stopwatch);
+            }
+
+            return stopwatch;
+        }
+
+        private void RestartStopwatch(DbCommandInterceptionContext interceptionContext)
+        {
+            var stopwatch = GetStopwatch(interceptionContext);
+            stopwatch.Restart();
+
+            // Preseve behavior for any code still using the obsolete Stopwatch property in method overrides.
+            if (!ReferenceEquals(stopwatch, _stopwatch))
+            {
+                _stopwatch.Restart();
+            }
+        }
+
+        private void StopStopwatch(DbCommandInterceptionContext interceptionContext)
+        {
+            var stopwatch = GetStopwatch(interceptionContext);
+            stopwatch.Stop();
+
+            // Preseve behavior for any code still using the obsolete Stopwatch property in method overrides.
+            if (!ReferenceEquals(stopwatch, _stopwatch))
+            {
+                _stopwatch.Stop();
+            }
+        }
+
+        /// <summary>
         /// This method is called before a call to <see cref="DbCommand.ExecuteNonQuery" /> or
         /// one of its async counterparts is made.
-        /// The default implementation calls <see cref="Executing" /> and starts <see cref="Stopwatch"/>.
+        /// The default implementation calls <see cref="Executing" /> and starts the stopwatch returned from
+        /// <see cref="GetStopwatch"/>.
         /// </summary>
         /// <param name="command">The command being executed.</param>
         /// <param name="interceptionContext">Contextual information associated with the call.</param>
@@ -123,13 +175,14 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(interceptionContext, "interceptionContext");
 
             Executing(command, interceptionContext);
-            Stopwatch.Restart();
+            RestartStopwatch(interceptionContext);
         }
 
         /// <summary>
         /// This method is called after a call to <see cref="DbCommand.ExecuteNonQuery" /> or
         /// one of its async counterparts is made.
-        /// The default implementation stops <see cref="Stopwatch"/> and calls <see cref="Executed" />.
+        /// The default implementation stopsthe stopwatch returned from <see cref="GetStopwatch"/> and calls
+        /// <see cref="Executed" />.
         /// </summary>
         /// <param name="command">The command being executed.</param>
         /// <param name="interceptionContext">Contextual information associated with the call.</param>
@@ -138,14 +191,15 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
 
-            Stopwatch.Stop();
+            StopStopwatch(interceptionContext);
             Executed(command, interceptionContext);
         }
 
         /// <summary>
         /// This method is called before a call to <see cref="DbCommand.ExecuteReader(CommandBehavior)" /> or
         /// one of its async counterparts is made.
-        /// The default implementation calls <see cref="Executing" /> and starts <see cref="Stopwatch"/>.
+        /// The default implementation calls <see cref="Executing" /> and starts the stopwatch returned from
+        /// <see cref="GetStopwatch"/>.
         /// </summary>
         /// <param name="command">The command being executed.</param>
         /// <param name="interceptionContext">Contextual information associated with the call.</param>
@@ -155,13 +209,14 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(interceptionContext, "interceptionContext");
 
             Executing(command, interceptionContext);
-            Stopwatch.Restart();
+            RestartStopwatch(interceptionContext);
         }
 
         /// <summary>
         /// This method is called after a call to <see cref="DbCommand.ExecuteReader(CommandBehavior)" /> or
         /// one of its async counterparts is made.
-        /// The default implementation stops <see cref="Stopwatch"/> and calls <see cref="Executed" />.
+        /// The default implementation stopsthe stopwatch returned from <see cref="GetStopwatch"/> and calls
+        /// <see cref="Executed" />.
         /// </summary>
         /// <param name="command">The command being executed.</param>
         /// <param name="interceptionContext">Contextual information associated with the call.</param>
@@ -170,14 +225,15 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
 
-            Stopwatch.Stop();
+            StopStopwatch(interceptionContext);
             Executed(command, interceptionContext);
         }
 
         /// <summary>
         /// This method is called before a call to <see cref="DbCommand.ExecuteScalar" />  or
         /// one of its async counterparts is made.
-        /// The default implementation calls <see cref="Executing" /> and starts <see cref="Stopwatch"/>.
+        /// The default implementation calls <see cref="Executing" /> and starts the stopwatch returned from
+        /// <see cref="GetStopwatch"/>.
         /// </summary>
         /// <param name="command">The command being executed.</param>
         /// <param name="interceptionContext">Contextual information associated with the call.</param>
@@ -187,13 +243,14 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(interceptionContext, "interceptionContext");
 
             Executing(command, interceptionContext);
-            Stopwatch.Restart();
+            RestartStopwatch(interceptionContext);
         }
 
         /// <summary>
         /// This method is called after a call to <see cref="DbCommand.ExecuteScalar" />  or
         /// one of its async counterparts is made.
-        /// The default implementation stops <see cref="Stopwatch"/> and calls <see cref="Executed" />.
+        /// The default implementation stopsthe stopwatch returned from <see cref="GetStopwatch"/> and calls
+        /// <see cref="Executed" />.
         /// </summary>
         /// <param name="command">The command being executed.</param>
         /// <param name="interceptionContext">Contextual information associated with the call.</param>
@@ -202,7 +259,7 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
 
-            Stopwatch.Stop();
+            StopStopwatch(interceptionContext);
             Executed(command, interceptionContext);
         }
 
@@ -230,7 +287,7 @@ namespace System.Data.Entity.Infrastructure.Interception
         /// <summary>
         /// Called whenever a command has completed executing. The default implementation of this method
         /// filters by <see cref="DbContext" /> set into <see cref="Context" />, if any, and then calls
-        /// <see cref="LogResult" />. This method would typically only be overridden to change the context
+        /// <see cref="LogResult" />.  This method would typically only be overridden to change the context
         /// filtering behavior.
         /// </summary>
         /// <typeparam name="TResult">The type of the operation's results.</typeparam>
@@ -352,15 +409,29 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
 
+            var stopwatch = _stopwatch;
+            if (_context == null)
+            {
+                var safeStopwatch = (Stopwatch)((IDbMutableInterceptionContext)interceptionContext).MutableData
+                     .FindUserState(StopwatchStateKey);
+
+                // If overriding methods still use obsolete Stopwatch, then preserve this behavior to avoid
+                // breaking change.
+                if (safeStopwatch != null)
+                {
+                    stopwatch = safeStopwatch;
+                }
+            }
+
             if (interceptionContext.Exception != null)
             {
                 Write(
                     Strings.CommandLogFailed(
-                        Stopwatch.ElapsedMilliseconds, interceptionContext.Exception.Message, Environment.NewLine));
+                        stopwatch.ElapsedMilliseconds, interceptionContext.Exception.Message, Environment.NewLine));
             }
             else if (interceptionContext.TaskStatus.HasFlag(TaskStatus.Canceled))
             {
-                Write(Strings.CommandLogCanceled(Stopwatch.ElapsedMilliseconds, Environment.NewLine));
+                Write(Strings.CommandLogCanceled(stopwatch.ElapsedMilliseconds, Environment.NewLine));
             }
             else
             {
@@ -370,8 +441,9 @@ namespace System.Data.Entity.Infrastructure.Interception
                     : (result is DbDataReader)
                         ? result.GetType().Name
                         : result.ToString();
-                Write(Strings.CommandLogComplete(Stopwatch.ElapsedMilliseconds, resultString, Environment.NewLine));
+                Write(Strings.CommandLogComplete(stopwatch.ElapsedMilliseconds, resultString, Environment.NewLine));
             }
+
             Write(Environment.NewLine);
         }
 

--- a/src/EntityFramework/Infrastructure/Interception/DbCommandInterceptionContext`.cs
+++ b/src/EntityFramework/Infrastructure/Interception/DbCommandInterceptionContext`.cs
@@ -102,10 +102,35 @@ namespace System.Data.Entity.Infrastructure.Interception
         /// <summary>
         /// Gets or sets a value containing arbitrary user-specified state information associated with the operation.
         /// </summary>
+        [Obsolete("Not safe when multiple interceptors are in use. Use SetUserState and FindUserState instead.")]
         public object UserState
         {
             get { return _mutableData.UserState; }
             set { _mutableData.UserState = value; }
+        }
+
+        /// <summary>
+        /// Gets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <returns>The user state set, or null if none was found for the given key.</returns>
+        public object FindUserState(string key)
+        {
+            Check.NotNull(key, "key");
+
+            return _mutableData.FindUserState(key);
+        }
+
+        /// <summary>
+        /// Sets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <param name="value">The state to set.</param>
+        public void SetUserState(string key, object value)
+        {
+            Check.NotNull(key, "key");
+
+            _mutableData.SetUserState(key, value);
         }
 
         /// <summary>

--- a/src/EntityFramework/Infrastructure/Interception/DbCommandTreeInterceptionContext.cs
+++ b/src/EntityFramework/Infrastructure/Interception/DbCommandTreeInterceptionContext.cs
@@ -81,10 +81,35 @@ namespace System.Data.Entity.Infrastructure.Interception
         /// <summary>
         /// Gets or sets a value containing arbitrary user-specified state information associated with the operation.
         /// </summary>
+        [Obsolete("Not safe when multiple interceptors are in use. Use SetUserState and FindUserState instead.")]
         public object UserState
         {
             get { return _mutableData.UserState; }
             set { _mutableData.UserState = value; }
+        }
+
+        /// <summary>
+        /// Gets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <returns>The user state set, or null if none was found for the given key.</returns>
+        public object FindUserState(string key)
+        {
+            Check.NotNull(key, "key");
+
+            return _mutableData.FindUserState(key);
+        }
+
+        /// <summary>
+        /// Sets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <param name="value">The state to set.</param>
+        public void SetUserState(string key, object value)
+        {
+            Check.NotNull(key, "key");
+
+            _mutableData.SetUserState(key, value);
         }
 
         /// <inheritdoc />

--- a/src/EntityFramework/Infrastructure/Interception/InterceptionContextMutableData.cs
+++ b/src/EntityFramework/Infrastructure/Interception/InterceptionContextMutableData.cs
@@ -2,18 +2,52 @@
 
 namespace System.Data.Entity.Infrastructure.Interception
 {
+    using System.Collections.Generic;
     using System.Data.Entity.Resources;
     using System.Threading.Tasks;
 
     internal class InterceptionContextMutableData
     {
+        private const string LegacyUserState = "__LegacyUserState__";
+
         private Exception _exception;
         private bool _isSuppressed;
+        private IDictionary<string, object> _userStateMap;
 
         public bool HasExecuted { get; set; }
         public Exception OriginalException { get; set; }
         public TaskStatus TaskStatus { get; set; }
-        public object UserState { get; set; }
+
+        private IDictionary<string, object> UserStateMap
+        {
+            get
+            {
+                if (_userStateMap == null)
+                {
+                    _userStateMap = new Dictionary<string, object>(StringComparer.Ordinal);
+                }
+
+                return _userStateMap;
+            }
+        }
+
+        [Obsolete("Not safe when multiple interceptors are in use. Use SetUserState and FindUserState instead.")]
+        public object UserState
+        {
+            get { return FindUserState(LegacyUserState); }
+            set { SetUserState(LegacyUserState, value); }
+        }
+
+        public object FindUserState(string key)
+        {
+            object value;
+            return _userStateMap != null && UserStateMap.TryGetValue(key, out value) ? value : null;
+        }
+
+        public void SetUserState(string key, object value)
+        {
+            UserStateMap[key] = value;
+        }
 
         public bool IsExecutionSuppressed
         {

--- a/src/EntityFramework/Infrastructure/Interception/MutableInterceptionContext.cs
+++ b/src/EntityFramework/Infrastructure/Interception/MutableInterceptionContext.cs
@@ -110,10 +110,35 @@ namespace System.Data.Entity.Infrastructure.Interception
         /// <summary>
         /// Gets or sets a value containing arbitrary user-specified state information associated with the operation.
         /// </summary>
+        [Obsolete("Not safe when multiple interceptors are in use. Use SetUserState and FindUserState instead.")]
         public object UserState
         {
             get { return _mutableData.UserState; }
             set { _mutableData.UserState = value; }
+        }
+
+        /// <summary>
+        /// Gets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <returns>The user state set, or null if none was found for the given key.</returns>
+        public object FindUserState(string key)
+        {
+            Check.NotNull(key, "key");
+
+            return _mutableData.FindUserState(key);
+        }
+
+        /// <summary>
+        /// Sets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <param name="value">The state to set.</param>
+        public void SetUserState(string key, object value)
+        {
+            Check.NotNull(key, "key");
+
+            _mutableData.SetUserState(key, value);
         }
 
         /// <summary>

--- a/src/EntityFramework/Infrastructure/Interception/MutableInterceptionContext`.cs
+++ b/src/EntityFramework/Infrastructure/Interception/MutableInterceptionContext`.cs
@@ -92,10 +92,35 @@ namespace System.Data.Entity.Infrastructure.Interception
         /// <summary>
         /// Gets or sets a value containing arbitrary user-specified state information associated with the operation.
         /// </summary>
+        [Obsolete("Not safe when multiple interceptors are in use. Use SetUserState and FindUserState instead.")]
         public object UserState
         {
             get { return _mutableData.UserState; }
             set { _mutableData.UserState = value; }
+        }
+
+        /// <summary>
+        /// Gets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <returns>The user state set, or null if none was found for the given key.</returns>
+        public object FindUserState(string key)
+        {
+            Check.NotNull(key, "key");
+
+            return _mutableData.FindUserState(key);
+        }
+
+        /// <summary>
+        /// Sets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <param name="value">The state to set.</param>
+        public void SetUserState(string key, object value)
+        {
+            Check.NotNull(key, "key");
+
+            _mutableData.SetUserState(key, value);
         }
 
         /// <summary>

--- a/src/EntityFramework/Infrastructure/Interception/PropertyInterceptionContext.cs
+++ b/src/EntityFramework/Infrastructure/Interception/PropertyInterceptionContext.cs
@@ -65,10 +65,35 @@ namespace System.Data.Entity.Infrastructure.Interception
         /// <summary>
         /// Gets or sets a value containing arbitrary user-specified state information associated with the operation.
         /// </summary>
+        [Obsolete("Not safe when multiple interceptors are in use. Use SetUserState and FindUserState instead.")]
         public object UserState
         {
             get { return _mutableData.UserState; }
             set { _mutableData.UserState = value; }
+        }
+
+        /// <summary>
+        /// Gets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <returns>The user state set, or null if none was found for the given key.</returns>
+        public object FindUserState(string key)
+        {
+            Check.NotNull(key, "key");
+
+            return _mutableData.FindUserState(key);
+        }
+
+        /// <summary>
+        /// Sets a value containing arbitrary user-specified state information associated with the operation.
+        /// </summary>
+        /// <param name="key">A key used to identify the user state.</param>
+        /// <param name="value">The state to set.</param>
+        public void SetUserState(string key, object value)
+        {
+            Check.NotNull(key, "key");
+
+            _mutableData.SetUserState(key, value);
         }
 
         /// <summary>

--- a/test/EntityFramework/UnitTests/Infrastructure/Interception/DbConnectionInterceptionContextTests.cs
+++ b/test/EntityFramework/UnitTests/Infrastructure/Interception/DbConnectionInterceptionContextTests.cs
@@ -5,6 +5,7 @@ namespace System.Data.Entity.Infrastructure.Interception
     using System.Data.Entity.Core.Objects;
     using System.Threading.Tasks;
     using Xunit;
+    using Xunit.Extensions;
 
     public class DbConnectionInterceptionContextTests : TestBase
     {
@@ -18,8 +19,10 @@ namespace System.Data.Entity.Infrastructure.Interception
                     Assert.Throws<ArgumentNullException>(() => new DbConnectionInterceptionContext<int>(null)).ParamName);
             }
 
-            [Fact]
-            public void Initially_has_no_state()
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Initially_has_no_state(bool useObsoleteState)
             {
                 var interceptionContext = new DbConnectionInterceptionContext<int>();
 
@@ -32,11 +35,23 @@ namespace System.Data.Entity.Infrastructure.Interception
                 Assert.Equal(0, interceptionContext.OriginalResult);
                 Assert.Equal(0, interceptionContext.Result);
                 Assert.Equal((TaskStatus)0, interceptionContext.TaskStatus);
-                Assert.Null(interceptionContext.UserState);
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    Assert.Null(interceptionContext.UserState);
+#pragma warning restore 618
+                }
+                else
+                {
+                    Assert.Null(interceptionContext.FindUserState("A"));
+                    Assert.Null(interceptionContext.FindUserState("B"));
+                }
             }
 
-            [Fact]
-            public void Cloning_the_interception_context_preserves_contextual_information_but_not_mutable_state()
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Cloning_the_interception_context_preserves_contextual_information_but_not_mutable_state(bool useObsoleteState)
             {
                 var objectContext = new ObjectContext();
                 var dbContext = DbContextMockHelper.CreateDbContext(objectContext);
@@ -44,7 +59,17 @@ namespace System.Data.Entity.Infrastructure.Interception
                 var interceptionContext = new DbConnectionInterceptionContext<int>();
                 interceptionContext.Exception = new Exception("Cheez Whiz");
                 interceptionContext.Result = 23;
-                interceptionContext.UserState = "Red Windsor";
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    interceptionContext.UserState = "Cheddar";
+#pragma warning restore 618
+                }
+                else
+                {
+                    interceptionContext.SetUserState("A", "AState");
+                    interceptionContext.SetUserState("B", "BState");
+                }
 
                 interceptionContext = interceptionContext
                     .WithDbContext(dbContext)
@@ -60,7 +85,17 @@ namespace System.Data.Entity.Infrastructure.Interception
                 Assert.Null(interceptionContext.Exception);
                 Assert.Null(interceptionContext.OriginalException);
                 Assert.False(interceptionContext.IsExecutionSuppressed);
-                Assert.Null(interceptionContext.UserState);
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    Assert.Null(interceptionContext.UserState);
+#pragma warning restore 618
+                }
+                else
+                {
+                    Assert.Null(interceptionContext.FindUserState("A"));
+                    Assert.Null(interceptionContext.FindUserState("B"));
+                }
             }
 
             [Fact]
@@ -86,8 +121,10 @@ namespace System.Data.Entity.Infrastructure.Interception
                     Assert.Throws<ArgumentNullException>(() => new DbConnectionInterceptionContext(null)).ParamName);
             }
 
-            [Fact]
-            public void Initially_has_no_state()
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Initially_has_no_state(bool useObsoleteState)
             {
                 var interceptionContext = new DbConnectionInterceptionContext();
 
@@ -98,11 +135,23 @@ namespace System.Data.Entity.Infrastructure.Interception
                 Assert.Empty(interceptionContext.ObjectContexts);
                 Assert.Null(interceptionContext.OriginalException);
                 Assert.Equal((TaskStatus)0, interceptionContext.TaskStatus);
-                Assert.Null(interceptionContext.UserState);
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    Assert.Null(interceptionContext.UserState);
+#pragma warning restore 618
+                }
+                else
+                {
+                    Assert.Null(interceptionContext.FindUserState("A"));
+                    Assert.Null(interceptionContext.FindUserState("B"));
+                }
             }
 
-            [Fact]
-            public void Cloning_the_interception_context_preserves_contextual_information_but_not_mutable_state()
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Cloning_the_interception_context_preserves_contextual_information_but_not_mutable_state(bool useObsoleteState)
             {
                 var objectContext = new ObjectContext();
                 var dbContext = DbContextMockHelper.CreateDbContext(objectContext);
@@ -111,7 +160,17 @@ namespace System.Data.Entity.Infrastructure.Interception
 
                 var mutableData = ((IDbMutableInterceptionContext)interceptionContext).MutableData;
                 mutableData.SetExceptionThrown(new Exception("Cheez Whiz"));
-                mutableData.UserState = "Red Leicester";
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    interceptionContext.UserState = "Cheddar";
+#pragma warning restore 618
+                }
+                else
+                {
+                    interceptionContext.SetUserState("A", "AState");
+                    interceptionContext.SetUserState("B", "BState");
+                }
 
                 interceptionContext = interceptionContext
                     .WithDbContext(dbContext)
@@ -125,7 +184,17 @@ namespace System.Data.Entity.Infrastructure.Interception
                 Assert.Null(interceptionContext.Exception);
                 Assert.Null(interceptionContext.OriginalException);
                 Assert.False(interceptionContext.IsExecutionSuppressed);
-                Assert.Null(interceptionContext.UserState);
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    Assert.Null(interceptionContext.UserState);
+#pragma warning restore 618
+                }
+                else
+                {
+                    Assert.Null(interceptionContext.FindUserState("A"));
+                    Assert.Null(interceptionContext.FindUserState("B"));
+                }
             }
 
             [Fact]

--- a/test/EntityFramework/UnitTests/Infrastructure/Interception/DbTransactionInterceptionContextTests.cs
+++ b/test/EntityFramework/UnitTests/Infrastructure/Interception/DbTransactionInterceptionContextTests.cs
@@ -7,6 +7,7 @@ namespace System.Data.Entity.Infrastructure.Interception
     using System.Threading.Tasks;
     using Moq;
     using Xunit;
+    using Xunit.Extensions;
 
     public class DbTransactionInterceptionContextTests : TestBase
     {
@@ -20,8 +21,10 @@ namespace System.Data.Entity.Infrastructure.Interception
                     Assert.Throws<ArgumentNullException>(() => new DbTransactionInterceptionContext<int>(null)).ParamName);
             }
 
-            [Fact]
-            public void Initially_has_no_state()
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Initially_has_no_state(bool useObsoleteState)
             {
                 var interceptionContext = new DbTransactionInterceptionContext<int>();
 
@@ -34,11 +37,23 @@ namespace System.Data.Entity.Infrastructure.Interception
                 Assert.Equal(0, interceptionContext.OriginalResult);
                 Assert.Equal(0, interceptionContext.Result);
                 Assert.Equal((TaskStatus)0, interceptionContext.TaskStatus);
-                Assert.Null(interceptionContext.UserState);
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    Assert.Null(interceptionContext.UserState);
+#pragma warning restore 618
+                }
+                else
+                {
+                    Assert.Null(interceptionContext.FindUserState("A"));
+                    Assert.Null(interceptionContext.FindUserState("B"));
+                }
             }
 
-            [Fact]
-            public void Cloning_the_interception_context_preserves_contextual_information_but_not_mutable_state()
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Cloning_the_interception_context_preserves_contextual_information_but_not_mutable_state(bool useObsoleteState)
             {
                 var objectContext = new ObjectContext();
                 var dbContext = DbContextMockHelper.CreateDbContext(objectContext);
@@ -46,7 +61,17 @@ namespace System.Data.Entity.Infrastructure.Interception
                 var interceptionContext = new DbTransactionInterceptionContext<int>();
                 interceptionContext.Exception = new Exception("Cheez Whiz");
                 interceptionContext.Result = 23;
-                interceptionContext.UserState = "Norwegian Jarlsberg";
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    interceptionContext.UserState = "Cheddar";
+#pragma warning restore 618
+                }
+                else
+                {
+                    interceptionContext.SetUserState("A", "AState");
+                    interceptionContext.SetUserState("B", "BState");
+                }
 
                 interceptionContext = interceptionContext
                     .WithDbContext(dbContext)
@@ -62,7 +87,17 @@ namespace System.Data.Entity.Infrastructure.Interception
                 Assert.Null(interceptionContext.Exception);
                 Assert.Null(interceptionContext.OriginalException);
                 Assert.False(interceptionContext.IsExecutionSuppressed);
-                Assert.Null(interceptionContext.UserState);
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    Assert.Null(interceptionContext.UserState);
+#pragma warning restore 618
+                }
+                else
+                {
+                    Assert.Null(interceptionContext.FindUserState("A"));
+                    Assert.Null(interceptionContext.FindUserState("B"));
+                }
             }
 
             [Fact]
@@ -89,8 +124,10 @@ namespace System.Data.Entity.Infrastructure.Interception
                     Assert.Throws<ArgumentNullException>(() => new DbTransactionInterceptionContext(null)).ParamName);
             }
 
-            [Fact]
-            public void Initially_has_no_state()
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Initially_has_no_state(bool useObsoleteState)
             {
                 var interceptionContext = new DbTransactionInterceptionContext();
 
@@ -102,11 +139,23 @@ namespace System.Data.Entity.Infrastructure.Interception
                 Assert.Empty(interceptionContext.ObjectContexts);
                 Assert.Null(interceptionContext.OriginalException);
                 Assert.Equal((TaskStatus)0, interceptionContext.TaskStatus);
-                Assert.Null(interceptionContext.UserState);
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    Assert.Null(interceptionContext.UserState);
+#pragma warning restore 618
+                }
+                else
+                {
+                    Assert.Null(interceptionContext.FindUserState("A"));
+                    Assert.Null(interceptionContext.FindUserState("B"));
+                }
             }
 
-            [Fact]
-            public void Cloning_the_interception_context_preserves_contextual_information_but_not_mutable_state()
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void Cloning_the_interception_context_preserves_contextual_information_but_not_mutable_state(bool useObsoleteState)
             {
                 var objectContext = new ObjectContext();
                 var dbContext = DbContextMockHelper.CreateDbContext(objectContext);
@@ -116,7 +165,17 @@ namespace System.Data.Entity.Infrastructure.Interception
 
                 var mutableData = ((IDbMutableInterceptionContext)interceptionContext).MutableData;
                 mutableData.SetExceptionThrown(new Exception("Cheez Whiz"));
-                mutableData.UserState = "Caerphilly";
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    interceptionContext.UserState = "Cheddar";
+#pragma warning restore 618
+                }
+                else
+                {
+                    interceptionContext.SetUserState("A", "AState");
+                    interceptionContext.SetUserState("B", "BState");
+                }
 
                 interceptionContext = interceptionContext
                     .WithDbContext(dbContext)
@@ -132,7 +191,17 @@ namespace System.Data.Entity.Infrastructure.Interception
                 Assert.Null(interceptionContext.Exception);
                 Assert.Null(interceptionContext.OriginalException);
                 Assert.False(interceptionContext.IsExecutionSuppressed);
-                Assert.Null(interceptionContext.UserState);
+                if (useObsoleteState)
+                {
+#pragma warning disable 618
+                    Assert.Null(interceptionContext.UserState);
+#pragma warning restore 618
+                }
+                else
+                {
+                    Assert.Null(interceptionContext.FindUserState("A"));
+                    Assert.Null(interceptionContext.FindUserState("B"));
+                }
             }
 
             [Fact]

--- a/test/EntityFramework/UnitTests/Infrastructure/Interception/InterceptionContextMutableDataTests.cs
+++ b/test/EntityFramework/UnitTests/Infrastructure/Interception/InterceptionContextMutableDataTests.cs
@@ -5,6 +5,7 @@ namespace System.Data.Entity.Infrastructure.Interception
     using System.Data.Entity.Resources;
     using System.Threading.Tasks;
     using Xunit;
+    using Xunit.Extensions;
 
     public class InterceptionContextMutableDataTests : TestBase
     {
@@ -160,24 +161,74 @@ namespace System.Data.Entity.Infrastructure.Interception
             Assert.False(data.IsExecutionSuppressed);
         }
 
-        [Fact]
-        public void UserState_can_be_changed()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void UserState_can_be_changed(bool useObsoleteState)
         {
             var data = new InterceptionContextMutableData();
 
-            Assert.Null(data.UserState);
+            if (useObsoleteState)
+            {
+#pragma warning disable 618
+                Assert.Null(data.UserState);
+#pragma warning restore 618
+            }
+            else
+            {
+                Assert.Null(data.FindUserState("A"));
+                Assert.Null(data.FindUserState("B"));
+            }
 
-            var firstUserState = new object();
+            if (useObsoleteState)
+            {
+#pragma warning disable 618
+                data.UserState = "Cheddar";
+#pragma warning restore 618
+            }
+            else
+            {
+                data.SetUserState("A", "AState");
+                data.SetUserState("B", "BState");
+            }
 
-            data.UserState = firstUserState;
+            if (useObsoleteState)
+            {
+#pragma warning disable 618
+                Assert.Equal("Cheddar", data.UserState);
+#pragma warning restore 618
+            }
+            else
+            {
+                Assert.Equal("AState", data.FindUserState("A"));
+                Assert.Equal("BState", data.FindUserState("B"));
+                Assert.Null(data.FindUserState("C"));
+            }
 
-            Assert.Same(firstUserState, data.UserState);
+            if (useObsoleteState)
+            {
+#pragma warning disable 618
+                data.UserState = "Cheddar2";
+#pragma warning restore 618
+            }
+            else
+            {
+                data.SetUserState("A", "AState2");
+                data.SetUserState("B", "BState2");
+            }
 
-            var secondUserState = new object();
-
-            data.UserState = secondUserState;
-
-            Assert.Same(secondUserState, data.UserState);
+            if (useObsoleteState)
+            {
+#pragma warning disable 618
+                Assert.Equal("Cheddar2", data.UserState);
+#pragma warning restore 618
+            }
+            else
+            {
+                Assert.Equal("AState2", data.FindUserState("A"));
+                Assert.Equal("BState2", data.FindUserState("B"));
+                Assert.Null(data.FindUserState("C"));
+            }
         }
     }
 }


### PR DESCRIPTION
Issue #22

In the most common use, the DatabaseLogFormatter is used for a single DbContext, which means that there can be no interleaving between starting and finishing an execution. However, if the formatter is being used for multiple contexts, then these calls can be interleaved, which means that each pair needs its own timing.

Since each call has its own interception context, this can be used to store the timer. We accepted a pull request to store this kind of data, but I realized that if there are multiple interceptors and each want to use this data slot, the result would be one clobbering the other. Therefore, I obsoleted that mechanism in favor of a mechanism that can be used by multiple interceptors.

The change required that Stopwatch be obsoleted. However, the existing functionality has been retained so that an in-place update or ignoring of the obsolete warning will not make working code break.