### PR TITLE
Enable Power Tools for  VS 2017 and VS 2015 (also removes support for VS 2010)

### DIFF
--- a/PowerTools.sln
+++ b/PowerTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.20824.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{2AE1B177-580C-44F1-9514-B3F23F4B1433}"
 EndProject

--- a/src/PowerTools/DbContextPackage.cs
+++ b/src/PowerTools/DbContextPackage.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DbContextPackage
     using ConfigurationManager = System.Configuration.ConfigurationManager;
 
     [PackageRegistration(UseManagedResourcesOnly = true)]
-    [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", "0.9.1", IconResourceID = 400)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(GuidList.guidDbContextPackagePkgString)]
     [ProvideAutoLoad("{f1536ef8-92ec-443c-9ed7-fdadf150da82}")]

--- a/src/PowerTools/PowerTools.csproj
+++ b/src/PowerTools/PowerTools.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <TargetFrameworkProfile />
@@ -174,6 +175,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="Properties\Resources.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Resources.cs</LastGenOutput>
@@ -205,6 +207,14 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/PowerTools/PowerTools.csproj
+++ b/src/PowerTools/PowerTools.csproj
@@ -1,11 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -211,10 +213,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.25929-RC2\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/PowerTools/Utilities/CSharpViewGenerator.tt
+++ b/src/PowerTools/Utilities/CSharpViewGenerator.tt
@@ -22,7 +22,7 @@ namespace Edm_EntityMappingGeneratedViews
     /// <summary>
     /// Implements a mapping view cache.
     /// </summary>
-    [GeneratedCode("Entity Framework Power Tools", "0.9.0.0")]
+    [GeneratedCode("Entity Framework 6 Power Tools", "0.9.1.0")]
     internal sealed class ViewsForBaseEntitySets<#= MappingHashValue #> : DbMappingViewCache
     {
         /// <summary>

--- a/src/PowerTools/Utilities/VBViewGenerator.tt
+++ b/src/PowerTools/Utilities/VBViewGenerator.tt
@@ -24,7 +24,7 @@ Namespace Edm_EntityMappingGeneratedViews
     ''' <summary>
     ''' Implements a mapping view cache.
     ''' </summary>
-    <GeneratedCode("Entity Framework Power Tools", "0.9.0.0")>
+    <GeneratedCode("Entity Framework 6 Power Tools", "0.9.1.0")>
     Friend NotInheritable Class ViewsForBaseEntitySets<#= MappingHashValue #>
         Inherits DbMappingViewCache
 

--- a/src/PowerTools/VSPackage.resx
+++ b/src/PowerTools/VSPackage.resx
@@ -118,16 +118,23 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="110" xml:space="preserve">
-    <value>Entity Framework Power Tools</value>
+    <value>Entity Framework 6 Power Tools</value>
   </data>
   <data name="112" xml:space="preserve">
-    <value>Adds useful design-time DbContext features to the Visual Studio Solution Explorer context menu. 
+    <value>Preview of useful design-time DbContext features, added to the Visual Studio Solution Explorer context menu.
+
+When right-clicking on a C# project, the following context menu functions are supported:
+1) Reverse Engineer Code First - Generates POCO classes, derived DbContext and Code First mapping for an existing database.
+2) Customize Reverse Engineer Templates - Adds the default reverse engineer T4 templates to your project for editing.
 
 When right-clicking on a file containing a derived DbContext class, the following context menu functions are supported:
-
-1) View Entity Data Model - Displays the underlying Code First model in the Entity Framework designer.
+1) View Entity Data Model (Read-only) - Displays a read-only view of the Code First model in the Entity Model Designer.
 2) View Entity Data Model XML - Displays the EDMX XML representing the underlying Code First model.
-3) Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.</value>
+3) View Entity Data Model DDL SQL - Displays the DDL SQL corresponding to the SSDL in the underlying EDM Model.
+4) Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.
+
+When right-clicking on an Entity Data Model (*.edmx) file, the following context menu function is supported:
+Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">

--- a/src/PowerTools/packages.config
+++ b/src/PowerTools/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25929-RC2" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/src/PowerTools/packages.config
+++ b/src/PowerTools/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25929-RC2" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/src/PowerTools/source.extension.vsixmanifest
+++ b/src/PowerTools/source.extension.vsixmanifest
@@ -2,17 +2,21 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="2b119c79-9836-46e2-b5ed-eb766cebbf7c" Version="0.9.1.0" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Entity Framework Power Tools Beta 5</DisplayName>
-    <Description xml:space="preserve">Preview of useful design-time features for DbContext.
+    <DisplayName>Entity Framework 6 Power Tools Beta 6</DisplayName>
+    <Description xml:space="preserve">Preview of useful design-time DbContext features, added to the Visual Studio Solution Explorer context menu.
 
-When right-clicking on a C# project, the following context menu function is supported:
-1) Reverse Engineer Code First - Generates POCO classes, derived DbContext and Code First mapping for an existing database. 
+When right-clicking on a C# project, the following context menu functions are supported:
+1) Reverse Engineer Code First - Generates POCO classes, derived DbContext and Code First mapping for an existing database.
+2) Customize Reverse Engineer Templates - Adds the default reverse engineer T4 templates to your project for editing.
 
 When right-clicking on a file containing a derived DbContext class, the following context menu functions are supported:
+1) View Entity Data Model (Read-only) - Displays a read-only view of the Code First model in the Entity Model Designer.
+2) View Entity Data Model XML - Displays the EDMX XML representing the underlying Code First model.
+3) View Entity Data Model DDL SQL - Displays the DDL SQL corresponding to the SSDL in the underlying EDM Model.
+4) Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.
 
-1) View Entity Data Model XML - Displays the EDMX XML representing the underlying Code First model.
-2) View Entity Data Model DDL SQL - Displays the DDL SQL corresponding to the SSDL in the underlying EDM Model.
-3) Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.</Description>
+When right-clicking on an Entity Data Model (*.edmx) file, the following context menu function is supported:
+1) Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.</Description>
     <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=327691</MoreInfo>
     <License>License.rtf</License>
     <GettingStartedGuide>http://go.microsoft.com/fwlink/?LinkId=327692</GettingStartedGuide>

--- a/src/PowerTools/source.extension.vsixmanifest
+++ b/src/PowerTools/source.extension.vsixmanifest
@@ -6,17 +6,17 @@
     <Description xml:space="preserve">Preview of useful design-time DbContext features, added to the Visual Studio Solution Explorer context menu.
 
 When right-clicking on a C# project, the following context menu functions are supported:
-1) Reverse Engineer Code First - Generates POCO classes, derived DbContext and Code First mapping for an existing database.
-2) Customize Reverse Engineer Templates - Adds the default reverse engineer T4 templates to your project for editing.
+1) Reverse Engineer Code First
+2) Customize Reverse Engineer Templates
 
 When right-clicking on a file containing a derived DbContext class, the following context menu functions are supported:
-1) View Entity Data Model (Read-only) - Displays a read-only view of the Code First model in the Entity Model Designer.
-2) View Entity Data Model XML - Displays the EDMX XML representing the underlying Code First model.
-3) View Entity Data Model DDL SQL - Displays the DDL SQL corresponding to the SSDL in the underlying EDM Model.
-4) Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.
+1) View Entity Data Model (Read-only)
+2) View Entity Data Model XML
+3) View Entity Data Model DDL SQL
+4) Generate Views
 
 When right-clicking on an Entity Data Model (*.edmx) file, the following context menu function is supported:
-1) Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.</Description>
+1) Generate Views</Description>
     <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=327691</MoreInfo>
     <License>License.rtf</License>
     <GettingStartedGuide>http://go.microsoft.com/fwlink/?LinkId=327692</GettingStartedGuide>

--- a/src/PowerTools/source.extension.vsixmanifest
+++ b/src/PowerTools/source.extension.vsixmanifest
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
-  <Identifier Id="2b119c79-9836-46e2-b5ed-eb766cebbf7c">
-    <Name>Entity Framework Power Tools Beta 5</Name>
-    <Author>Microsoft</Author>
-    <Version>0.9.0.0</Version>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="2b119c79-9836-46e2-b5ed-eb766cebbf7c" Version="0.9.1.0" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>Entity Framework Power Tools Beta 5</DisplayName>
     <Description xml:space="preserve">Preview of useful design-time features for DbContext.
 
 When right-clicking on a C# project, the following context menu function is supported:
@@ -14,35 +13,23 @@ When right-clicking on a file containing a derived DbContext class, the followin
 1) View Entity Data Model XML - Displays the EDMX XML representing the underlying Code First model.
 2) View Entity Data Model DDL SQL - Displays the DDL SQL corresponding to the SSDL in the underlying EDM Model.
 3) Generate Views - Generates pre-compiled views used by the EF runtime to improve start-up performance. Adds the generated views file to the containing project.</Description>
-    <Locale>1033</Locale>
-    <MoreInfoUrl>http://go.microsoft.com/fwlink/?LinkId=327691</MoreInfoUrl>
+    <MoreInfo>http://go.microsoft.com/fwlink/?LinkId=327691</MoreInfo>
     <License>License.rtf</License>
     <GettingStartedGuide>http://go.microsoft.com/fwlink/?LinkId=327692</GettingStartedGuide>
     <Icon>db.png</Icon>
     <PreviewImage>menu.png</PreviewImage>
-    <InstalledByMsi>false</InstalledByMsi>
-    <SupportedProducts>
-      <VisualStudio Version="10.0">
-        <Edition>Pro</Edition>
-      </VisualStudio>
-      <VisualStudio Version="11.0">
-        <Edition>Pro</Edition>
-      </VisualStudio>
-      <VisualStudio Version="12.0">
-        <Edition>Pro</Edition>
-      </VisualStudio>
-      <VisualStudio Version="14.0">
-        <Edition>Pro</Edition>
-      </VisualStudio>
-    </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.0" />
-  </Identifier>
-  <References>
-    <Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">
-      <Name>Visual Studio MPF</Name>
-    </Reference>
-  </References>
-  <Content>
-    <VsPackage>|%CurrentProject%;PkgdefProjectOutputGroup|</VsPackage>
-  </Content>
-</Vsix>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,16.0)" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0]" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.EntityFramework" Version="[15.0,16.0)" DisplayName="Entity Framework 6 tools" />
+  </Prerequisites>
+</PackageManifest>


### PR DESCRIPTION
Addresses #152

This PR shows what is required to move PowerTools to VS 2017 and VSIX 2/3.

Currently pressing F5 to build and deploy in VS 2015 fails, but it is possible to build a release VSIX using the following command line:

     msbuild PowerTools.sln  /p:configuration=Release /p:DeployExtension=false /v:m

Info about some of the changes is available here: https://docs.microsoft.com/da-dk/visualstudio/extensibility/how-to-migrate-extensibility-projects-to-visual-studio-2017 

I have successfully installed the built release VSIX and tested with VS 2017 RC, see screenshots below:
![powertools1](https://cloud.githubusercontent.com/assets/4169187/21218401/bcc69e0a-c2b0-11e6-9ee3-349add52b496.png)
![powertools2](https://cloud.githubusercontent.com/assets/4169187/21218400/bcc527aa-c2b0-11e6-8307-526f393163ef.png)
