### PR TITLE
Fix #13 - Migrate.exe runs all the migrations even if they are alread…

### DIFF
--- a/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
@@ -45,6 +45,15 @@ namespace System.Data.Entity.SqlServer
         private int _variableCounter;
 
         /// <summary>
+        /// Determines if a provider specific exception corresponds to a database-level permission denied error.
+        /// </summary>
+        /// <param name="exception">The database exception.</param>
+        public override bool IsPermissionDeniedError(Exception exception)
+        {
+            return (exception as SqlException)?.Number == 229;
+        }
+
+        /// <summary>
         /// Converts a set of migration operations into Microsoft SQL Server specific SQL.
         /// </summary>
         /// <param name="migrationOperations"> The operations to be converted. </param>

--- a/src/EntityFramework/Migrations/DbMigrator.cs
+++ b/src/EntityFramework/Migrations/DbMigrator.cs
@@ -166,7 +166,8 @@ namespace System.Data.Entity.Migrations
                         _historyContextFactory,
                         schemas: new[] { _defaultSchema }.Concat(GetHistorySchemas()),
                         contextForInterception: _usersContext,
-                        initialExistence: _existenceState);
+                        initialExistence: _existenceState,
+                        permissionDeniedDetector: e => SqlGenerator.IsPermissionDeniedError(e));
 
                 _providerManifestToken
                     = context.InternalContext.ModelProviderInfo != null

--- a/src/EntityFramework/Migrations/Sql/MigrationSqlGenerator.cs
+++ b/src/EntityFramework/Migrations/Sql/MigrationSqlGenerator.cs
@@ -49,6 +49,15 @@ namespace System.Data.Entity.Migrations.Sql
         }
 
         /// <summary>
+        /// Determines if a provider specific exception corresponds to a database-level permission denied error.
+        /// </summary>
+        /// <param name="exception">The database exception.</param>
+        public virtual bool IsPermissionDeniedError(Exception exception)
+        {
+            return false; // Default is unknown
+        }
+
+        /// <summary>
         /// Builds the store type usage for the specified <paramref name="storeTypeName"/> using the facets from the specified <paramref name="propertyModel"/>.
         /// </summary>
         /// <param name="storeTypeName">Name of the store type.</param>

--- a/test/EntityFramework/FunctionalTests/FunctionalTests.csproj
+++ b/test/EntityFramework/FunctionalTests/FunctionalTests.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Migrations\AlterTableAnnotationsScenarios.cs" />
     <Compile Include="Migrations\BasicMigrationScenarios.cs" />
     <Compile Include="Migrations\CustomHistoryScenarios.cs" />
+    <Compile Include="Migrations\DbPermissionsScenarios.cs" />
     <Compile Include="Migrations\LoggingScenarios.cs" />
     <Compile Include="Migrations\CreateStoredProcedureScenarios.cs" />
     <Compile Include="Migrations\ModificationFunctionsScenarios.cs" />

--- a/test/EntityFramework/FunctionalTests/Migrations/DbPermissionsScenarios.cs
+++ b/test/EntityFramework/FunctionalTests/Migrations/DbPermissionsScenarios.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Migrations
+{
+    using System.Data.Entity.Core;
+    using System.Data.Entity.Infrastructure;
+    using System.Data.SqlClient;
+    using Xunit;
+
+    [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
+    public class DbPermissionsScenarios : DbTestCase
+    {
+        [MigrationsTheory]
+        public void GetDatabaseMigrations_when_not_permissioned()
+        {
+            ResetDatabase();
+
+            var migrator = CreateMigrator<ShopContext_v1>();
+
+            migrator.Update();
+
+            CreateNotPermissionedConfig(migrator);
+
+            migrator = new DbMigrator(migrator.Configuration);
+
+            Assert.Throws<EntityCommandExecutionException>(() => migrator.GetDatabaseMigrations());
+        }
+
+        [MigrationsTheory]
+        public void Update_when_not_permissioned()
+        {
+            ResetDatabase();
+
+            var migrator = CreateMigrator<ShopContext_v1>();
+
+            migrator.Update();
+
+            CreateNotPermissionedConfig(migrator);
+
+            migrator = new DbMigrator(migrator.Configuration);
+
+            Assert.Throws<EntityCommandExecutionException>(() => migrator.Update());
+        }
+
+        private void CreateNotPermissionedConfig(DbMigrator migrator)
+        {
+            TestDatabase.ExecuteNonQuery(
+                @"IF NOT EXISTS (SELECT * FROM sys.server_principals WHERE name = N'EFDDLAdminOnly')
+BEGIN
+    CREATE LOGIN [EFDDLAdminOnly] WITH PASSWORD=N'Password1', DEFAULT_DATABASE=[MigrationsTest]
+END
+
+USE [MigrationsTest]
+
+IF USER_ID('EFDDLAdminOnly') IS NULL
+BEGIN
+    CREATE USER [EFDDLAdminOnly] FOR LOGIN [EFDDLAdminOnly]
+    ALTER AUTHORIZATION ON SCHEMA::[db_ddladmin] TO [EFDDLAdminOnly]
+END
+");
+
+            var connectionStringBuilder
+                = new SqlConnectionStringBuilder(TestDatabase.ConnectionString)
+                {
+                    IntegratedSecurity = false,
+                    UserID = "EFDDLAdminOnly",
+                    Password = "Password1"
+                };
+
+            migrator.Configuration.TargetDatabase
+                = new DbConnectionInfo(connectionStringBuilder.ToString(), TestDatabase.ProviderName);
+        }
+    }
+}


### PR DESCRIPTION
…y applied

- Adds simple detection of permission denied DB error. Provided hook is added to MigrationSqlGenerator for simplicity instead of introducing a new seam.