### PR TITLE
Issue #176 Length of string parameters on where clause

### DIFF
--- a/src/EntityFramework.SqlServer/SqlGen/SqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlGen/SqlGenerator.cs
@@ -2416,7 +2416,7 @@ namespace System.Data.Entity.SqlServer.SqlGen
                 }
             }
 
-            if (_maxLength != null || _maxLength != 0)
+            if (_maxLength != null && _maxLength != 0)
             {
                 _parametersWithMaxLength[e.ParameterName] = _maxLength.Value;
             }

--- a/src/EntityFramework.SqlServer/SqlGen/SqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlGen/SqlGenerator.cs
@@ -2416,7 +2416,7 @@ namespace System.Data.Entity.SqlServer.SqlGen
                 }
             }
 
-            if (_maxLength != null)
+            if (_maxLength != null || _maxLength != 0)
             {
                 _parametersWithMaxLength[e.ParameterName] = _maxLength.Value;
             }

--- a/src/EntityFramework.SqlServer/Utilities/TypeUsageExtensions.cs
+++ b/src/EntityFramework.SqlServer/Utilities/TypeUsageExtensions.cs
@@ -227,5 +227,18 @@ namespace System.Data.Entity.SqlServer.Utilities
                          .Union(
                              nonUnicodeString.Facets.Where(f => f.Name == DbProviderManifest.UnicodeFacetName)));
         }
+        internal static TypeUsage ForceMaxLengh(this TypeUsage typeUsage, int value)
+        {
+            var maxlenght = TypeUsage.CreateStringTypeUsage(
+                (PrimitiveType)typeUsage.EdmType, isUnicode: false, isFixedLength: true, maxLength: value);
+
+            // Copy all existing facets except replace the maxleght facet
+            return TypeUsage.Create(
+                typeUsage.EdmType,
+                typeUsage.Facets
+                         .Where(f => f.Name != DbProviderManifest.MaxLengthFacetName)
+                         .Union(
+                             maxlenght.Facets.Where(f => f.Name == DbProviderManifest.MaxLengthFacetName)));
+        }
     }
 }


### PR DESCRIPTION
I have made some changes to solve the issue 176, just made the same thing that is done for non-unicode strings (varchar vs nvarchar). I get the MaxLength facet from the dbType, and create the TypeUsage with it.
