### PR TITLE
Fix #73 - Evaluation of DbQuery<T>.ToString() frequently times out in…

### DIFF
--- a/src/EntityFramework/Infrastructure/DbQuery.cs
+++ b/src/EntityFramework/Infrastructure/DbQuery.cs
@@ -6,6 +6,7 @@ namespace System.Data.Entity.Infrastructure
     using System.ComponentModel;
     using System.Data.Entity.Internal.Linq;
     using System.Data.Entity.Resources;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Linq.Expressions;
@@ -15,6 +16,7 @@ namespace System.Data.Entity.Infrastructure
     /// </summary>
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
     [SuppressMessage("Microsoft.Design", "CA1010:CollectionsShouldImplementGenericInterface")]
+    [DebuggerDisplay(@"{DebuggerDisplay()}")]
     public abstract class DbQuery : IOrderedQueryable, IListSource, IInternalQueryAdapter
 #if !NET40
 , IDbAsyncEnumerable
@@ -217,7 +219,18 @@ namespace System.Data.Entity.Infrastructure
         /// <returns> The query string. </returns>
         public override string ToString()
         {
-            return InternalQuery == null ? base.ToString() : InternalQuery.ToString();
+            return InternalQuery == null ? base.ToString() : InternalQuery.ToTraceString();
+        }
+
+        private string DebuggerDisplay()
+        {
+            return base.ToString();
+        }
+
+        // ReSharper disable once UnusedMember.Local
+        private string Sql
+        {
+            get { return ToString(); }
         }
 
         #endregion

--- a/src/EntityFramework/Infrastructure/DbQuery`.cs
+++ b/src/EntityFramework/Infrastructure/DbQuery`.cs
@@ -8,6 +8,7 @@ namespace System.Data.Entity.Infrastructure
     using System.Data.Entity.Internal.Linq;
     using System.Data.Entity.Resources;
     using System.Data.Entity.Utilities;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Linq.Expressions;
@@ -18,6 +19,7 @@ namespace System.Data.Entity.Infrastructure
     /// <typeparam name="TResult"> The type of entity to query for. </typeparam>
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix",
         Justification = "Name is intentional")]
+    [DebuggerDisplay(@"{DebuggerDisplay()}")]
     public class DbQuery<TResult> : IOrderedQueryable<TResult>, IListSource, IInternalQueryAdapter
 #if !NET40
 , IDbAsyncEnumerable<TResult>
@@ -252,7 +254,18 @@ namespace System.Data.Entity.Infrastructure
         /// <returns> The query string. </returns>
         public override string ToString()
         {
-            return _internalQuery == null ? base.ToString() : _internalQuery.ToString();
+            return _internalQuery == null ? base.ToString() : _internalQuery.ToTraceString();
+        }
+
+        private string DebuggerDisplay()
+        {
+            return base.ToString();
+        }
+
+        // ReSharper disable once UnusedMember.Local
+        private string Sql
+        {
+            get { return ToString(); }
         }
 
         #endregion

--- a/src/EntityFramework/Internal/InternalContext.cs
+++ b/src/EntityFramework/Internal/InternalContext.cs
@@ -502,6 +502,9 @@ namespace System.Data.Entity.Internal
         // </summary>
         public void Initialize()
         {
+            // Causes the debugger to stop automatic evaluation on this expensive code path.
+            Debugger.NotifyOfCrossThreadDependency();
+
             InitializeContext();
             InitializeDatabase();
         }

--- a/src/EntityFramework/Internal/Linq/IInternalQuery.cs
+++ b/src/EntityFramework/Internal/Linq/IInternalQuery.cs
@@ -21,6 +21,8 @@ namespace System.Data.Entity.Internal.Linq
         Type ElementType { get; }
         Expression Expression { get; }
         ObjectQueryProvider ObjectQueryProvider { get; }
+
+        string ToTraceString();
  
 #if !NET40
 

--- a/src/EntityFramework/Internal/Linq/InternalQuery`.cs
+++ b/src/EntityFramework/Internal/Linq/InternalQuery`.cs
@@ -169,7 +169,7 @@ namespace System.Data.Entity.Internal.Linq
         // to ToTraceString on ObjectQuery.
         // </summary>
         // <returns> The query string. </returns>
-        public override string ToString()
+        public string ToTraceString()
         {
             Debug.Assert(_objectQuery != null, "InternalQuery should have been initialized.");
 


### PR DESCRIPTION
… the debugger

- Adds a read-only Sql property on DbQuery<T> which invokes ToString() and exposes the result
- Adds a call to Debugger.NotifyOfCrossThreadDependency() on model and database initialization
- Annotates DbQuery<T> with an attribute that restores the default behavior for the debugger, I.e. calling base.ToString()