### PR TITLE
Enables building EFTools using Visual Studio 2017

### DIFF
--- a/src/Strict.ruleset
+++ b/src/Strict.ruleset
@@ -5,5 +5,9 @@
     <Rule Id="CA1062" Action="None" />
     <Rule Id="CA2243" Action="None" />
     <Rule Id="CA1809" Action="None" />
+    <Rule Id="CA1506" Action="None" />
+    <Rule Id="CA1020" Action="None" />
+    <Rule Id="CA2210" Action="None" />
+    <Rule Id="CA1305" Action="None" />
   </Rules>
 </RuleSet>

--- a/tools/EFToolsVsReferences.settings.targets
+++ b/tools/EFToolsVsReferences.settings.targets
@@ -12,4 +12,7 @@
     <Reference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.14.0" />
     <Reference Include="Microsoft.VisualStudio.TextTemplating.14.0" />
   </ItemGroup>
+  <ItemGroup Condition="$(VisualStudioVersion)=='15.0'">
+    <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
+  </ItemGroup>
 </Project>

--- a/tools/EntityFramework.settings.targets
+++ b/tools/EntityFramework.settings.targets
@@ -24,7 +24,7 @@ Project global pre-settings.
     <VersionReleasePrefix>0</VersionReleasePrefix>
     <VersionRelease>$(VersionReleasePrefix)-beta1</VersionRelease>
     <VersionReleaseName>Beta 1</VersionReleaseName>
-    <ToolingDotNetFrameworkVersion Condition="'$(VisualStudioVersion)' == '15.0'">v4.5.1</ToolingDotNetFrameworkVersion>
+    <ToolingDotNetFrameworkVersion Condition="'$(VisualStudioVersion)' == '15.0'">v4.6</ToolingDotNetFrameworkVersion>
     <ToolingDotNetFrameworkVersion Condition="'$(VisualStudioVersion)' != '15.0'">v4.5</ToolingDotNetFrameworkVersion>
   </PropertyGroup>
 

--- a/tools/VsIdeHostAdapter/TargetAddIn/VsIdeTestHostAddin.csproj
+++ b/tools/VsIdeHostAdapter/TargetAddIn/VsIdeTestHostAddin.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio.TestTools.HostAdapters.VsIde</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.QualityTools.HostAdapters.VsIdeAddIn</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>$(ToolingDotNetFrameworkVersion)</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
Fixes all the issues I have encountered so far with running `BuildEFTools.cmd /t:build` on a Developer Command Prompt for VS 2017 RC.3. After this I still get a couple of warnings when building EntityFramework.PowerShell.csproj (but this could be unrelated):

> C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\Microsoft.Common.CurrentVersion.targets(2493,5): warning MSB3283: Cannot find wrapper assembly for type library "EnvDTE
". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target pla
tform must not be 64-bit. [C:\Users\dbveg\Documents\GitHub\EntityFramework6\src\EntityFramework.PowerShell\EntityFramework.PowerShell.csproj]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\Microsoft.Common.CurrentVersion.targets(2493,5): warning MSB3283: Cannot find wrapper assembly for type library "VSLang
Proj". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target
 platform must not be 64-bit. [C:\Users\dbveg\Documents\GitHub\EntityFramework6\src\EntityFramework.PowerShell\EntityFramework.PowerShell.csproj]