### PR TITLE
Fixes #185 by moving the optimization for update model from database into tools code

### DIFF
--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGenerator.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGenerator.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             Debug.Assert(parameters != null, "parameters != null");
 
             var whereClause = new StringBuilder();
+            var parameterMap = new Dictionary<string, string>(StringComparer.Ordinal);
             foreach (var alias in _filterAliases)
             {
                 var allows = new StringBuilder();
@@ -73,12 +74,12 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                 {
                     if (entry.Effect == EntityStoreSchemaFilterEffect.Allow)
                     {
-                        AppendFilterEntry(allows, alias, entry, parameters);
+                        AppendFilterEntry(allows, alias, entry, parameterMap);
                     }
                     else
                     {
                         Debug.Assert(entry.Effect == EntityStoreSchemaFilterEffect.Exclude, "did you add new value?");
-                        AppendFilterEntry(excludes, alias, entry, parameters);
+                        AppendFilterEntry(excludes, alias, entry, parameterMap);
                     }
                 }
 
@@ -110,25 +111,31 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                         .Append(")");
                 }
             }
+
+            foreach(var entry in parameterMap)
+            {
+                parameters.AddWithValue(entry.Value, entry.Key);
+            }
+
             return whereClause;
         }
 
         // internal to allow unit testing
         internal static StringBuilder AppendFilterEntry(
-            StringBuilder segment, string alias, EntityStoreSchemaFilterEntry entry, EntityParameterCollection parameters)
+            StringBuilder segment, string alias, EntityStoreSchemaFilterEntry entry, Dictionary<string, string> parameterMap)
         {
             Debug.Assert(segment != null, "segment != null");
             Debug.Assert(alias != null, "alias != null");
             Debug.Assert(entry != null, "entry != null");
-            Debug.Assert(parameters != null, "parameters != null");
+            Debug.Assert(parameterMap != null, "parameters != null");
 
             var filterText = new StringBuilder();
-            AppendComparison(filterText, alias, "CatalogName", entry.Catalog, parameters);
-            AppendComparison(filterText, alias, "SchemaName", entry.Schema, parameters);
+            AppendComparison(filterText, alias, "CatalogName", entry.Catalog, parameterMap);
+            AppendComparison(filterText, alias, "SchemaName", entry.Schema, parameterMap);
             AppendComparison(
                 filterText, alias, "Name",
                 entry.Catalog == null && entry.Schema == null && entry.Name == null ? "%" : entry.Name,
-                parameters);
+                parameterMap);
             segment
                 .AppendIfNotEmpty(" OR ")
                 .Append("(")
@@ -140,36 +147,30 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
 
         // internal to allow unit testing
         internal static StringBuilder AppendComparison(
-            StringBuilder filterFragment, string alias, string propertyName, string value, EntityParameterCollection parameters)
+            StringBuilder filterFragment, string alias, string propertyName, string value, Dictionary<string, string> parameterMap)
         {
             Debug.Assert(filterFragment != null, "filterFragment != null");
             Debug.Assert(alias != null, "alias != null");
             Debug.Assert(propertyName != null, "propertyName != null");
-            Debug.Assert(parameters != null, "parameters != null");
+            Debug.Assert(parameterMap != null, "parameters != null");
 
             if (value != null)
             {
-                var matchingParameter = parameters.GetParameterByValue(value);
-
-                if (matchingParameter != null)
-                {
-                    AppendComparisonFragment(filterFragment, alias, propertyName, matchingParameter.ParameterName);
+                string parameterName = null;                
+                if (!parameterMap.TryGetValue(value, out parameterName))
+                { 
+                    parameterName = GetParameterName(parameterMap.Count);
+                    parameterMap.Add(value, parameterName);
                 }
-                else
-                {
-                    var parameterName = "p" + parameters.Count.ToString(CultureInfo.InvariantCulture);
-
-                    AppendComparisonFragment(filterFragment, alias, propertyName, parameterName);
-                    parameters.Add(
-                        new EntityParameter
-                        {
-                            ParameterName = parameterName,
-                            Value = value
-                        });
-                }
+                AppendComparisonFragment(filterFragment, alias, propertyName, parameterName);
             }
 
             return filterFragment;
+        }
+
+        private static string GetParameterName(int position)
+        {
+            return "p" + position.ToString(CultureInfo.InvariantCulture);
         }
 
         private static void AppendComparisonFragment(

--- a/src/EntityFramework/Core/EntityClient/DbParameterCollectionHelper.cs
+++ b/src/EntityFramework/Core/EntityClient/DbParameterCollectionHelper.cs
@@ -292,50 +292,6 @@ namespace System.Data.Entity.Core.EntityClient
             return -1;
         }
 
-        /// <inhertidoc />
-        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1604:ElementDocumentationMustHaveSummary")]
-        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1611:ElementParametersMustBeDocumented")]
-        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1615:ElementReturnValueMustBeDocumented")]
-        [SuppressMessage("Microsoft.Usage", "CA2201:DoNotRaiseReservedExceptionTypes")]
-        public DbParameter GetParameterByValue(string value)
-        {
-            var index = IndexOfParameterValue(InnerList, value);
-            if (index < 0)
-            {
-                return null;
-            }
-
-            return InnerList[index];
-        }
-
-        private static int IndexOfParameterValue(IEnumerable items, string parameterValue)
-        {
-            if (null != items)
-            {
-                var i = 0;
-
-                foreach (EntityParameter parameter in items)
-                {
-                    if (0 == EntityUtil.SrcCompare(parameterValue, parameter.ParameterStringValue))
-                    {
-                        return i;
-                    }
-                    ++i;
-                }
-                i = 0;
-
-                foreach (EntityParameter parameter in items)
-                {
-                    if (0 == EntityUtil.DstCompare(parameterValue, parameter.ParameterStringValue))
-                    {
-                        return i;
-                    }
-                    ++i;
-                }
-            }
-            return -1;
-        }
-
         /// <summary>
         /// Gets the location of the specified <see cref="T:System.Data.Entity.Core.EntityClient.EntityParameter" /> with the specified name.
         /// </summary>

--- a/src/EntityFramework/Core/EntityClient/EntityParameter.cs
+++ b/src/EntityFramework/Core/EntityClient/EntityParameter.cs
@@ -28,7 +28,6 @@ namespace System.Data.Entity.Core.EntityClient
         private bool _isDirty;
 
         private object _value;
-        private string _parameterStringValue;
         private object _parent;
         private ParameterDirection _direction;
         private int? _size;
@@ -320,17 +319,7 @@ namespace System.Data.Entity.Core.EntityClient
                 }
 
                 _value = value;
-
-                _parameterStringValue = value.ToString() ?? null;
             }
-        }
-
-        // <summary>
-        // Gets the ToString() representation of the value of this parameter.
-        // </summary>
-        internal string ParameterStringValue
-        {
-            get { return _parameterStringValue; }
         }
 
         // <summary>

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.SchemaDiscovery
 {
+    using System.Collections.Generic;
     using System.Data.Entity.Core.EntityClient;
     using System.Linq;
     using System.Text;
@@ -18,13 +19,13 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     string.Empty,
                     string.Empty,
                     /* value */ null,
-                    new EntityCommand().Parameters).ToString());
+                    new Dictionary<string,string>()).ToString());
         }
 
         [Fact]
         public void AppendComparison_creates_comparison_fragment_and_corresponding_parameter_for_non_null_value()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterMap = new Dictionary<string, string>();
 
             Assert.Equal(
                 "alias.propertyName LIKE @p0",
@@ -33,17 +34,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     "alias",
                     "propertyName",
                     "Value",
-                    parameters).ToString());
+                    parameterMap).ToString());
 
-            Assert.Equal(1, parameters.Count);
-            Assert.Equal("p0", parameters[0].ParameterName);
-            Assert.Equal("Value", parameters[0].Value);
+            Assert.Equal(1, parameterMap.Count);
+            Assert.Equal(parameterMap["Value"], "p0");
         }
 
         [Fact]
         public void AppendComparison_creates_parameters_and_adds_AND_for_multiple_comparisons()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterMap = new Dictionary<string, string>();
 
             var filterBuilder =
                 EntityStoreSchemaQueryGenerator.AppendComparison(
@@ -51,28 +51,28 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     "alias1",
                     "propertyName1",
                     "Value1",
-                    parameters);
+                    parameterMap);
 
             EntityStoreSchemaQueryGenerator.AppendComparison(
                 filterBuilder,
                 "alias2",
                 "propertyName2",
                 "Value2",
-                parameters);
+                parameterMap);
 
             Assert.Equal(
                 "alias1.propertyName1 LIKE @p0 AND alias2.propertyName2 LIKE @p1",
                 filterBuilder.ToString());
 
-            Assert.Equal(2, parameters.Count);
-            Assert.Equal("p0,p1", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.ParameterName)));
-            Assert.Equal("Value1,Value2", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.Value)));
+            Assert.Equal(2, parameterMap.Count);
+            Assert.Equal(parameterMap["Value1"], "p0");
+            Assert.Equal(parameterMap["Value2"], "p1");
         }
 
         [Fact]
         public void AppendFilterEntry_creates_filter_for_catalog_schema_and_name_if_all_specified()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterMap = new Dictionary<string, string>();
 
             Assert.Equal(
                 "(alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1 AND alias.Name LIKE @p2)",
@@ -80,9 +80,12 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry("catalog", "schema", "name"),
-                    parameters).ToString());
+                    parameterMap).ToString());
 
-            Assert.Equal(3, parameters.Count);
+            Assert.Equal(3, parameterMap.Count);
+            Assert.Equal(parameterMap["catalog"], "p0");
+            Assert.Equal(parameterMap["schema"], "p1");
+            Assert.Equal(parameterMap["name"], "p2");
         }
 
         [Fact]
@@ -94,7 +97,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry(null, "schema", "name"),
-                    new EntityCommand().Parameters).ToString());
+                    new Dictionary<string, string>()).ToString());
 
             Assert.Equal(
                 "(alias.CatalogName LIKE @p0 AND alias.Name LIKE @p1)",
@@ -102,7 +105,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry("catalog", null, "name"),
-                    new EntityCommand().Parameters).ToString());
+                    new Dictionary<string, string>()).ToString());
 
             Assert.Equal(
                 "(alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1)",
@@ -110,13 +113,13 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry("catalog", "schema", null),
-                    new EntityCommand().Parameters).ToString());
+                    new Dictionary<string, string>()).ToString());
         }
 
         [Fact]
         public void AppendFilterEntry_uses_wildcard_parameter_value_if_schema_catalog_and_name_are_null()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterMap = new Dictionary<string, string>();
 
             Assert.Equal(
                 "(alias.Name LIKE @p0)",
@@ -124,38 +127,38 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry(null, null, null),
-                    parameters).ToString());
+                    parameterMap).ToString());
 
-            Assert.Equal(1, parameters.Count);
-            Assert.Equal("p0", parameters[0].ParameterName);
-            Assert.Equal("%", parameters[0].Value);
+            Assert.Equal(1, parameterMap.Count);
+            Assert.Equal(parameterMap["%"], "p0");
         }
 
         [Fact]
         public void AppendFilterEntry_uses_OR_to_connect_multiple_filters()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterMap = new Dictionary<string, string>();
             var filterBuilder = new StringBuilder();
 
             EntityStoreSchemaQueryGenerator.AppendFilterEntry(
                 filterBuilder,
                 "alias",
                 new EntityStoreSchemaFilterEntry(null, null, null),
-                parameters);
+                parameterMap);
 
             EntityStoreSchemaQueryGenerator.AppendFilterEntry(
                 filterBuilder,
                 "alias",
                 new EntityStoreSchemaFilterEntry("catalog", "schema", null),
-                parameters);
+                parameterMap);
 
             Assert.Equal(
                 "(alias.Name LIKE @p0) OR (alias.CatalogName LIKE @p1 AND alias.SchemaName LIKE @p2)",
                 filterBuilder.ToString());
 
-            Assert.Equal(3, parameters.Count);
-            Assert.Equal("p0,p1,p2", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.ParameterName)));
-            Assert.Equal("%,catalog,schema", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.Value)));
+            Assert.Equal(3, parameterMap.Count);
+            Assert.Equal(parameterMap["%"], "p0");
+            Assert.Equal(parameterMap["catalog"], "p1");
+            Assert.Equal(parameterMap["schema"], "p2");
         }
 
         [Fact]
@@ -216,8 +219,9 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     .CreateWhereClause(parameters).ToString());
 
             Assert.Equal(3, parameters.Count);
-            Assert.Equal("p0,p1,p2", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.ParameterName)));
-            Assert.Equal("catalog,schema,name", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.Value)));
+            Assert.Equal(parameters["p0"].Value, "catalog");
+            Assert.Equal(parameters["p1"].Value, "schema");
+            Assert.Equal(parameters["p2"].Value, "name");
         }
 
         [Fact]
@@ -244,8 +248,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     .CreateWhereClause(parameters).ToString());
 
             Assert.Equal(1, parameters.Count);
-            Assert.Equal("p0", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.ParameterName)));
-            Assert.Equal("name", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.Value)));
+            Assert.Equal(parameters["p0"].Value, "name");
         }
 
         [Fact]
@@ -272,8 +275,9 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     .CreateWhereClause(parameters).ToString());
 
             Assert.Equal(3, parameters.Count);
-            Assert.Equal("p0,p1,p2", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.ParameterName)));
-            Assert.Equal("catalog,schema,name", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.Value)));
+            Assert.Equal(parameters["p0"].Value, "catalog");
+            Assert.Equal(parameters["p1"].Value, "schema");
+            Assert.Equal(parameters["p2"].Value, "name");
         }
 
         [Fact]
@@ -300,8 +304,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     .CreateWhereClause(parameters).ToString());
 
             Assert.Equal(1, parameters.Count);
-            Assert.Equal("p0", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.ParameterName)));
-            Assert.Equal("name", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.Value)));
+           Assert.Equal(parameters["p0"].Value, "name");
         }
 
         [Fact]
@@ -334,8 +337,8 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     .CreateWhereClause(parameters).ToString());
 
             Assert.Equal(2, parameters.Count);
-            Assert.Equal("p0,p1", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.ParameterName)));
-            Assert.Equal("nameAllowed,nameExcluded", string.Join(",", parameters.OfType<EntityParameter>().Select(p => p.Value)));
+            Assert.Equal(parameters["p0"].Value, "nameAllowed");
+            Assert.Equal(parameters["p1"].Value, "nameExcluded");
         }
 
         [Fact]
@@ -406,8 +409,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     .GenerateQuery(parameters));
 
             Assert.Equal(1, parameters.Count);
-            Assert.Equal("p0", parameters[0].ParameterName);
-            Assert.Equal("name", parameters[0].Value);
+            Assert.Equal(parameters["p0"].Value, "name");
         }
 
         [Fact]
@@ -452,8 +454,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     .GenerateQuery(parameters));
 
             Assert.Equal(1, parameters.Count);
-            Assert.Equal("p0", parameters[0].ParameterName);
-            Assert.Equal("name", parameters[0].Value);
+            Assert.Equal(parameters["p0"].Value, "name");
         }
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/aspnet/EntityFramework6/pull/41 with a very similar approach (avoiding creating duplicate parameters with the same values) but the implementation in this case lives completely into the EF Tools code and avoids changes to the EF Runtime. 