### PR TITLE
[6.2] Fix to #162 - problem with OFFSET and FETCH when the order is by a column that has one value

### DIFF
--- a/src/EntityFramework.SqlServer/SqlGen/SqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlGen/SqlGenerator.cs
@@ -2552,7 +2552,16 @@ namespace System.Data.Entity.SqlServer.SqlGen
                 input.Select.Skip = new SkipClause(HandleCountExpression(e.Count));
 
                 // Add the ORDER BY part.
-                AddSortKeys(input.OrderBy, e.SortOrder);
+                if (SqlProviderServices.UseRowNumberOrderingInOffsetQueries)
+                {
+                    input.OrderBy.Append("row_number() OVER (ORDER BY ");
+                    AddSortKeys(input.OrderBy, e.SortOrder);
+                    input.OrderBy.Append(")");
+                }
+                else
+                {
+                    AddSortKeys(input.OrderBy, e.SortOrder);
+                }
 
                 symbolTable.ExitScope();
                 selectStatementStack.Pop();

--- a/src/EntityFramework.SqlServer/SqlProviderServices.cs
+++ b/src/EntityFramework.SqlServer/SqlProviderServices.cs
@@ -100,6 +100,7 @@ namespace System.Data.Entity.SqlServer
         private static readonly SqlProviderServices _providerInstance = new SqlProviderServices();
 
         private static bool _truncateDecimalsToScale = true;
+        private static bool _useRowNumberOrderingInOffsetQueries = true;
 
         /// <summary>
         /// The Singleton instance of the SqlProviderServices type.
@@ -129,6 +130,16 @@ namespace System.Data.Entity.SqlServer
         {
             get { return _truncateDecimalsToScale; }
             set { _truncateDecimalsToScale = value; }
+        }
+
+        /// <summary>
+        /// Set this flag to false to prevent ordering using a row_number() function for queries with OFFSET operation, and order by columns directly instead.
+        /// </summary>
+        /// <remarks>Using row_number() can reduce ambiguity of the ordering result for some cases.</remarks>
+        public static bool UseRowNumberOrderingInOffsetQueries
+        {
+            get { return _useRowNumberOrderingInOffsetQueries; }
+            set { _useRowNumberOrderingInOffsetQueries = value; }
         }
 
         /// <summary>

--- a/test/EntityFramework/FunctionalTests/PlanCompiler/LimitExpressionTests.cs
+++ b/test/EntityFramework/FunctionalTests/PlanCompiler/LimitExpressionTests.cs
@@ -1592,7 +1592,7 @@ namespace PlanCompilerTests
     FROM  [dbo].[ArubaOwners] AS [Extent1]
     LEFT OUTER JOIN [dbo].[ArubaRuns] AS [Extent2] ON [Extent1].[Id] = [Extent2].[Id]
     WHERE N'Diego' = [Extent1].[FirstName]
-    ORDER BY [Extent1].[LastName] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[LastName] ASC)
     OFFSET 2 ROWS FETCH NEXT 1 ROWS ONLY ";
 
             Limit_SimpleModel_OrderBy_Skip_FirstOrDefault_expectedSql =
@@ -1608,7 +1608,7 @@ namespace PlanCompilerTests
     FROM  [dbo].[ArubaOwners] AS [Extent1]
     LEFT OUTER JOIN [dbo].[ArubaRuns] AS [Extent2] ON [Extent1].[Id] = [Extent2].[Id]
     WHERE N'Diego' = [Extent1].[FirstName]
-    ORDER BY [Extent1].[LastName] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[LastName] ASC)
     OFFSET 2 ROWS FETCH NEXT 1 ROWS ONLY ";
 
             Limit_SimpleModel_OrderBy_Skip_Single_expectedSql =
@@ -1624,7 +1624,7 @@ namespace PlanCompilerTests
     FROM  [dbo].[ArubaOwners] AS [Extent1]
     LEFT OUTER JOIN [dbo].[ArubaRuns] AS [Extent2] ON [Extent1].[Id] = [Extent2].[Id]
     WHERE N'Diego' = [Extent1].[FirstName]
-    ORDER BY [Extent1].[LastName] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[LastName] ASC)
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY ";
 
             Limit_SimpleModel_OrderBy_Skip_SingleOrDefault_expectedSql =
@@ -1640,7 +1640,7 @@ namespace PlanCompilerTests
     FROM  [dbo].[ArubaOwners] AS [Extent1]
     LEFT OUTER JOIN [dbo].[ArubaRuns] AS [Extent2] ON [Extent1].[Id] = [Extent2].[Id]
     WHERE N'Diego' = [Extent1].[FirstName]
-    ORDER BY [Extent1].[LastName] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[LastName] ASC)
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY ";
 
             Limit_SimpleModel_OrderBy_Skip_Take_expectedSql =
@@ -1656,7 +1656,7 @@ namespace PlanCompilerTests
     FROM  [dbo].[ArubaOwners] AS [Extent1]
     LEFT OUTER JOIN [dbo].[ArubaRuns] AS [Extent2] ON [Extent1].[Id] = [Extent2].[Id]
     WHERE N'Diego' = [Extent1].[FirstName]
-    ORDER BY [Extent1].[LastName] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[LastName] ASC)
     OFFSET 2 ROWS FETCH NEXT 1 ROWS ONLY ";
 
             Limit_ComplexModel_OrderBy_Skip_First_expectedSql =
@@ -1692,7 +1692,7 @@ namespace PlanCompilerTests
         LEFT OUTER JOIN [dbo].[MailRooms] AS [Extent2] ON [Extent1].[PrincipalMailRoomId] = [Extent2].[id]
         WHERE N'Building One' = [Extent1].[Name]
     )  AS [Project1]
-    ORDER BY [Project1].[Address_ZipCode] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project1].[Address_ZipCode] ASC)
     OFFSET 2 ROWS FETCH NEXT 1 ROWS ONLY ";
 
             Limit_ComplexModel_OrderBy_Skip_FirstOrDefault_expectedSql =
@@ -1728,7 +1728,7 @@ namespace PlanCompilerTests
         LEFT OUTER JOIN [dbo].[MailRooms] AS [Extent2] ON [Extent1].[PrincipalMailRoomId] = [Extent2].[id]
         WHERE N'Building One' = [Extent1].[Name]
     )  AS [Project1]
-    ORDER BY [Project1].[Address_ZipCode] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project1].[Address_ZipCode] ASC)
     OFFSET 2 ROWS FETCH NEXT 1 ROWS ONLY ";
 
             Limit_ComplexModel_OrderBy_Skip_Single_expectedSql =
@@ -1764,7 +1764,7 @@ namespace PlanCompilerTests
         LEFT OUTER JOIN [dbo].[MailRooms] AS [Extent2] ON [Extent1].[PrincipalMailRoomId] = [Extent2].[id]
         WHERE N'Building One' = [Extent1].[Name]
     )  AS [Project1]
-    ORDER BY [Project1].[Address_ZipCode] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project1].[Address_ZipCode] ASC)
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY ";
 
             Limit_ComplexModel_OrderBy_Skip_SingleOrDefault_expectedSql =
@@ -1800,7 +1800,7 @@ namespace PlanCompilerTests
         LEFT OUTER JOIN [dbo].[MailRooms] AS [Extent2] ON [Extent1].[PrincipalMailRoomId] = [Extent2].[id]
         WHERE N'Building One' = [Extent1].[Name]
     )  AS [Project1]
-    ORDER BY [Project1].[Address_ZipCode] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project1].[Address_ZipCode] ASC)
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY ";
 
             Limit_ComplexModel_OrderBy_Skip_Take_expectedSql =
@@ -1836,7 +1836,7 @@ namespace PlanCompilerTests
         LEFT OUTER JOIN [dbo].[MailRooms] AS [Extent2] ON [Extent1].[PrincipalMailRoomId] = [Extent2].[id]
         WHERE N'Building One' = [Extent1].[Name]
     )  AS [Project1]
-    ORDER BY [Project1].[Address_ZipCode] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project1].[Address_ZipCode] ASC)
     OFFSET 2 ROWS FETCH NEXT 1 ROWS ONLY ";
         }
 

--- a/test/EntityFramework/FunctionalTests/Query/LinqToEntities/OrderByLiftingTests.cs
+++ b/test/EntityFramework/FunctionalTests/Query/LinqToEntities/OrderByLiftingTests.cs
@@ -131,7 +131,7 @@ namespace System.Data.Entity.Query.LinqToEntities
     [Skip1].[Alias] AS [Alias]
     FROM ( SELECT [Extent1].[Id] AS [Id], [Extent1].[FirstName] AS [FirstName], [Extent1].[LastName] AS [LastName], [Extent1].[Alias] AS [Alias]
     FROM [dbo].[ArubaOwners] AS [Extent1]
-    ORDER BY [Extent1].[FirstName] DESC, [Extent1].[Id] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[FirstName] DESC, [Extent1].[Id] ASC)
     OFFSET 5 ROWS 
     )  AS [Skip1]
     WHERE 0 = ([Skip1].[Id] % 2)
@@ -145,7 +145,7 @@ namespace System.Data.Entity.Query.LinqToEntities
     [Skip1].[Alias] AS [Alias]
     FROM ( SELECT [Extent1].[Id] AS [Id], [Extent1].[FirstName] AS [FirstName], [Extent1].[LastName] AS [LastName], [Extent1].[Alias] AS [Alias]
     FROM [dbo].[ArubaOwners] AS [Extent1]
-    ORDER BY [Extent1].[FirstName] DESC, [Extent1].[Id] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[FirstName] DESC, [Extent1].[Id] ASC)
     OFFSET 5 ROWS 
     )  AS [Skip1]
     WHERE 0 = ([Skip1].[Id] % 2)
@@ -175,7 +175,7 @@ namespace System.Data.Entity.Query.LinqToEntities
 	    FROM ( SELECT [Extent1].[Id] AS [Id], [Extent1].[OS] AS [OS], [Extent1].[Lang] AS [Lang], [Extent1].[Arch] AS [Arch], [Extent1].[Host] AS [Host], [Extent1].[Address] AS [Address], [Extent1].[Location] AS [Location], [Extent1].[Discriminator] AS [Discriminator]
 	        FROM [dbo].[ArubaConfigs] AS [Extent1]
 	        WHERE [Extent1].[Discriminator] IN (N'ArubaMachineConfig',N'ArubaConfig')
-            ORDER BY [Extent1].[Arch] DESC, [Extent1].[Id] ASC
+            ORDER BY row_number() OVER (ORDER BY [Extent1].[Arch] DESC, [Extent1].[Id] ASC)
             OFFSET 5 ROWS 
 	    )  AS [Skip1]
 	    WHERE [Skip1].[Discriminator] = N'ArubaMachineConfig'
@@ -206,7 +206,7 @@ namespace System.Data.Entity.Query.LinqToEntities
         FROM ( SELECT [Extent1].[Id] AS [Id], [Extent1].[OS] AS [OS], [Extent1].[Lang] AS [Lang], [Extent1].[Arch] AS [Arch], [Extent1].[Host] AS [Host], [Extent1].[Address] AS [Address], [Extent1].[Location] AS [Location], [Extent1].[Discriminator] AS [Discriminator]
             FROM [dbo].[ArubaConfigs] AS [Extent1]
             WHERE [Extent1].[Discriminator] IN (N'ArubaMachineConfig',N'ArubaConfig')
-            ORDER BY [Extent1].[Arch] DESC, [Extent1].[Id] ASC
+            ORDER BY row_number() OVER (ORDER BY [Extent1].[Arch] DESC, [Extent1].[Id] ASC)
             OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY 
         )  AS [Limit1]
         WHERE [Limit1].[Discriminator] = N'ArubaMachineConfig'

--- a/test/EntityFramework/FunctionalTests/Query/SqlGeneratorTests.cs
+++ b/test/EntityFramework/FunctionalTests/Query/SqlGeneratorTests.cs
@@ -340,7 +340,7 @@ order by o.Id desc skip @pInt16 LIMIT 5";
 @"SELECT 
     [Extent1].[Id] AS [Id]
     FROM [dbo].[ArubaOwners] AS [Extent1]
-    ORDER BY [Extent1].[Id] DESC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] DESC)
     OFFSET @pInt16 ROWS FETCH NEXT 5 ROWS ONLY ";
                 }
                 else
@@ -913,7 +913,7 @@ ORDER BY i SKIP 2 LIMIT 4";
     [Extent1].[Address] AS [Address]
     FROM [dbo].[ArubaConfigs] AS [Extent1]
     WHERE [Extent1].[Discriminator] = N'ArubaMachineConfig'
-    ORDER BY [Extent1].[Id] DESC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] DESC)
     OFFSET 3 ROWS FETCH NEXT 2 ROWS ONLY ";
 
                 Skip_limit_group_by_expectedSql =
@@ -928,7 +928,7 @@ ORDER BY i SKIP 2 LIMIT 4";
             FROM [dbo].[ArubaOwners] AS [Extent1]
         )  AS [Distinct1]
     )  AS [Project2]
-    ORDER BY [Project2].[FirstName] DESC
+    ORDER BY row_number() OVER (ORDER BY [Project2].[FirstName] DESC)
     OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY ";
 
                 Skip_no_limit_with_inheritance_expectedSql =
@@ -937,7 +937,7 @@ ORDER BY i SKIP 2 LIMIT 4";
     [Extent1].[Address] AS [Address]
     FROM [dbo].[ArubaConfigs] AS [Extent1]
     WHERE [Extent1].[Discriminator] = N'ArubaMachineConfig'
-    ORDER BY [Extent1].[Id] DESC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] DESC)
     OFFSET 1 ROWS ";
 
                 Skip_limit_distinct_expectedSql =
@@ -949,7 +949,7 @@ ORDER BY i SKIP 2 LIMIT 4";
         1 AS [C1]
         FROM [dbo].[ArubaOwners] AS [Extent1]
     )  AS [Distinct1]
-    ORDER BY [Distinct1].[FirstName] ASC
+    ORDER BY row_number() OVER (ORDER BY [Distinct1].[FirstName] ASC)
     OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY ";
 
                 Multiple_sort_keys_expectedSql =
@@ -958,7 +958,7 @@ ORDER BY i SKIP 2 LIMIT 4";
     [Extent1].[FirstName] AS [FirstName], 
     [Extent1].[LastName] AS [LastName]
     FROM [dbo].[ArubaOwners] AS [Extent1]
-    ORDER BY [Extent1].[FirstName] ASC, [Extent1].[LastName] DESC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[FirstName] ASC, [Extent1].[LastName] DESC)
     OFFSET 3 ROWS FETCH NEXT 4 ROWS ONLY ";
 
                 Nested_skip_limits_in_select_expectedSql =
@@ -969,13 +969,13 @@ ORDER BY i SKIP 2 LIMIT 4";
     FROM   (SELECT [Extent1].[Id] AS [Id]
         FROM [dbo].[ArubaOwners] AS [Extent1]
         WHERE [Extent1].[Id] > 3
-        ORDER BY [Extent1].[Id] ASC
+        ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] ASC)
         OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY  ) AS [Limit1]
     LEFT OUTER JOIN  (SELECT 
         [Extent2].[Id] AS [Id], 
         1 AS [C1]
         FROM [dbo].[ArubaOwners] AS [Extent2]
-        ORDER BY [Extent2].[Id] ASC
+        ORDER BY row_number() OVER (ORDER BY [Extent2].[Id] ASC)
         OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY  ) AS [Project1] ON 1 = 1
     ORDER BY [Limit1].[Id] ASC, [Project1].[C1] ASC";
 
@@ -984,10 +984,10 @@ ORDER BY i SKIP 2 LIMIT 4";
     [Limit1].[Id] AS [Id]
     FROM ( SELECT [Extent1].[Id] AS [Id]
         FROM [dbo].[ArubaOwners] AS [Extent1]
-        ORDER BY [Extent1].[Id] DESC
+        ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] DESC)
         OFFSET 2 ROWS FETCH NEXT 5 ROWS ONLY 
     )  AS [Limit1]
-    ORDER BY [Limit1].[Id] ASC
+    ORDER BY row_number() OVER (ORDER BY [Limit1].[Id] ASC)
     OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY ";
 
                 Intersect_with_split_limit_expectedSql =
@@ -1003,7 +1003,7 @@ ORDER BY i SKIP 2 LIMIT 4";
             1 AS [C1]
             FROM [dbo].[ArubaOwners] AS [Extent1]
         )  AS [Project1]
-        ORDER BY [Project1].[Id] DESC, [Project1].[Alias] DESC
+        ORDER BY row_number() OVER (ORDER BY [Project1].[Id] DESC, [Project1].[Alias] DESC)
         OFFSET 3 ROWS FETCH NEXT 7 ROWS ONLY 
     INTERSECT
         SELECT 
@@ -1015,7 +1015,7 @@ ORDER BY i SKIP 2 LIMIT 4";
             1 AS [C1]
             FROM [dbo].[ArubaOwners] AS [Extent2]
         )  AS [Project3]
-        ORDER BY [Project3].[Id] ASC, [Project3].[Alias] ASC
+        ORDER BY row_number() OVER (ORDER BY [Project3].[Id] ASC, [Project3].[Alias] ASC)
         OFFSET 4 ROWS FETCH NEXT 6 ROWS ONLY ) AS [Intersect1]";
 
                 Nested_projections_list_expectedSql =
@@ -1029,7 +1029,7 @@ ORDER BY i SKIP 2 LIMIT 4";
         CASE WHEN ([Limit2].[Id] IS NULL) THEN CAST(NULL AS int) ELSE 1 END AS [C1]
         FROM   (SELECT [Extent1].[Id] AS [Id]
             FROM [dbo].[ArubaOwners] AS [Extent1]
-            ORDER BY [Extent1].[Id] ASC
+            ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] ASC)
             OFFSET 5 ROWS FETCH NEXT 2 ROWS ONLY  ) AS [Limit1]
         OUTER APPLY  (SELECT TOP (2) [Project1].[Id] AS [Id]
             FROM ( SELECT 
@@ -1049,7 +1049,7 @@ ORDER BY i SKIP 2 LIMIT 4";
         FROM ( SELECT 
             [Extent1].[Id] AS [Id]
             FROM [dbo].[ArubaOwners] AS [Extent1]
-            ORDER BY [Extent1].[Id] ASC
+            ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] ASC)
             OFFSET 3 ROWS FETCH NEXT 2 ROWS ONLY 
         )  AS [element] ) AS [Element1] ON 1 = 1";
 
@@ -1063,21 +1063,21 @@ ORDER BY i SKIP 2 LIMIT 4";
         1 AS [C2]
         FROM [dbo].[ArubaOwners] AS [Extent1]
     )  AS [Project1]
-    ORDER BY [Project1].[C1] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project1].[C1] ASC)
     OFFSET 4 ROWS FETCH NEXT 3 ROWS ONLY ";
 
                 Skip_with_no_limit_and_multiset_expectedSql =
 @"SELECT 
     [Extent1].[Id] AS [Id]
     FROM [dbo].[ArubaOwners] AS [Extent1]
-    ORDER BY [Extent1].[Id] DESC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] DESC)
     OFFSET 2 ROWS ";
 
                 Edge_case_column_name_expectedSql =
 @"SELECT 
     [Extent1].[Id] AS [Id]
     FROM [dbo].[ArubaOwners] AS [Extent1]
-    ORDER BY [Extent1].[Id] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[Id] ASC)
     OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY ";
 
                 Skip_limit_over_skip_limit_intersect_expectedSql =
@@ -1095,7 +1095,7 @@ ORDER BY i SKIP 2 LIMIT 4";
             1 AS [C1]
             FROM [dbo].[ArubaOwners] AS [Extent1]
         )  AS [Project1]
-        ORDER BY [Project1].[Id] DESC, [Project1].[Alias] DESC
+        ORDER BY row_number() OVER (ORDER BY [Project1].[Id] DESC, [Project1].[Alias] DESC)
         OFFSET 3 ROWS FETCH NEXT 4 ROWS ONLY 
     INTERSECT
         SELECT 
@@ -1108,9 +1108,9 @@ ORDER BY i SKIP 2 LIMIT 4";
             1 AS [C1]
             FROM [dbo].[ArubaOwners] AS [Extent2]
         )  AS [Project3]
-        ORDER BY [Project3].[Id] ASC, [Project3].[Alias] ASC
+        ORDER BY row_number() OVER (ORDER BY [Project3].[Id] ASC, [Project3].[Alias] ASC)
         OFFSET 5 ROWS FETCH NEXT 2 ROWS ONLY ) AS [Intersect1]
-    ORDER BY [Intersect1].[Id] ASC
+    ORDER BY row_number() OVER (ORDER BY [Intersect1].[Id] ASC)
     OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY ";
 
                 Skip_limit_with_duplicates_expectedSql =
@@ -1135,7 +1135,7 @@ ORDER BY i SKIP 2 LIMIT 4";
         SELECT 
         2 AS [C1]
         FROM  ( SELECT 1 AS X ) AS [SingleRowTable5]) AS [UnionAll4]
-    ORDER BY [UnionAll4].[C1] ASC
+    ORDER BY row_number() OVER (ORDER BY [UnionAll4].[C1] ASC)
     OFFSET 2 ROWS FETCH NEXT 4 ROWS ONLY ";
 
                 Skip_limit_with_nulls_expectedSql =
@@ -1157,7 +1157,7 @@ ORDER BY i SKIP 2 LIMIT 4";
             2 AS [C1]
             FROM  ( SELECT 1 AS X ) AS [SingleRowTable3]) AS [UnionAll2]
     )  AS [Project4]
-    ORDER BY [Project4].[C1] ASC
+    ORDER BY row_number() OVER (ORDER BY [Project4].[C1] ASC)
     OFFSET 2 ROWS FETCH NEXT 4 ROWS ONLY ";
             }
 

--- a/test/EntityFramework/UnitTests/QueryableExtensionsTests.cs
+++ b/test/EntityFramework/UnitTests/QueryableExtensionsTests.cs
@@ -2075,7 +2075,7 @@ namespace System.Data.Entity
     [Extent1].[Id] AS [Id], 
     [Extent1].[Name] AS [Name]
     FROM [dbo].[Entities] AS [Extent1]
-    ORDER BY [Extent1].[Name] ASC
+    ORDER BY row_number() OVER (ORDER BY [Extent1].[Name] ASC)
     OFFSET @p__linq__0 ROWS ";
                 }
                 else


### PR DESCRIPTION
Problem affects some queries using paging that use ambiguous ordering. Fix is to introduce ORDER BY row_number() to remove the ambiguity.

New method is still able to take advantage of indexes, so there shouldn't be a significant impact on performance.