### PR TITLE
Fixes bad escaping of String values in generated migration code

### DIFF
--- a/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
@@ -1536,7 +1536,14 @@ namespace System.Data.Entity.Migrations.Design
         /// <returns> The quoted identifier. </returns>
         protected virtual string Quote(string identifier)
         {
-            return "\"" + identifier + "\"";
+            using (var writer = new StringWriter())
+            {
+                using (var provider = CodeDom.Compiler.CodeDomProvider.CreateProvider("CSharp"))
+                {
+                    provider.GenerateCodeFromExpression(new CodeDom.CodePrimitiveExpression(identifier), writer, null);
+                    return writer.ToString();
+                }
+            }
         }
     }
 }

--- a/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
@@ -1536,14 +1536,7 @@ namespace System.Data.Entity.Migrations.Design
         /// <returns> The quoted identifier. </returns>
         protected virtual string Quote(string identifier)
         {
-            using (var writer = new StringWriter())
-            {
-                using (var provider = CodeDom.Compiler.CodeDomProvider.CreateProvider("CSharp"))
-                {
-                    provider.GenerateCodeFromExpression(new CodeDom.CodePrimitiveExpression(identifier), writer, null);
-                    return writer.ToString();
-                }
-            }
+            return "\"" + identifier.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
         }
     }
 }

--- a/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
@@ -1577,7 +1577,14 @@ namespace System.Data.Entity.Migrations.Design
         /// <returns> The quoted identifier. </returns>
         protected virtual string Quote(string identifier)
         {
-            return "\"" + identifier + "\"";
+            using (var writer = new StringWriter())
+            {
+                using (var provider = CodeDom.Compiler.CodeDomProvider.CreateProvider("VisualBasic"))
+                {
+                    provider.GenerateCodeFromExpression(new CodeDom.CodePrimitiveExpression(identifier), writer, null);
+                    return writer.ToString();
+                }
+            }
         }
     }
 }

--- a/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
@@ -1577,14 +1577,7 @@ namespace System.Data.Entity.Migrations.Design
         /// <returns> The quoted identifier. </returns>
         protected virtual string Quote(string identifier)
         {
-            using (var writer = new StringWriter())
-            {
-                using (var provider = CodeDom.Compiler.CodeDomProvider.CreateProvider("VisualBasic"))
-                {
-                    provider.GenerateCodeFromExpression(new CodeDom.CodePrimitiveExpression(identifier), writer, null);
-                    return writer.ToString();
-                }
-            }
+            return "\"" + identifier.Replace("\"", "\"\"") + "\"";
         }
     }
 }


### PR DESCRIPTION
To address issue #198
String values containing quotes or other language specific strings are not escaped properly when generating migration code.
This change replaces the escaping code with System.CodeDom.Compiler.CodeDomProvider to allow generating correctly escaped strings.