### PR TITLE
Migrations configuration seeder aware of migrations applied.

### DIFF
--- a/src/EntityFramework/Migrations/DbMigrationsConfiguration.cs
+++ b/src/EntityFramework/Migrations/DbMigrationsConfiguration.cs
@@ -271,10 +271,11 @@ namespace System.Data.Entity.Migrations
                 _commandTimeout = value;
             }
         }
-
-        internal virtual void OnSeed(DbContext context)
+        
+        internal virtual void OnSeed(DbContext context, IEnumerable<string> migrationsApplied)
         {
             DebugCheck.NotNull(context);
+            DebugCheck.NotNull(migrationsApplied);
         }
 
         internal EdmModelDiffer ModelDiffer

--- a/src/EntityFramework/Migrations/DbMigrationsConfiguration`.cs
+++ b/src/EntityFramework/Migrations/DbMigrationsConfiguration`.cs
@@ -2,6 +2,7 @@
 
 namespace System.Data.Entity.Migrations
 {
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Data.Entity.Infrastructure.DependencyResolution;
     using System.Data.Entity.Utilities;
@@ -37,6 +38,8 @@ namespace System.Data.Entity.Migrations
         /// implementations of this method must check whether or not seed data is present and/or up-to-date
         /// and then only make changes if necessary and in a non-destructive way. The 
         /// <see cref="DbSetMigrationsExtensions.AddOrUpdate{TEntity}(System.Data.Entity.IDbSet{TEntity},TEntity[])"/>
+        /// and
+        /// <see cref="DbSetMigrationsExtensions.RemoveIfExist{TEntity}(System.Data.Entity.IDbSet{TEntity},TEntity[])"/>
         /// can be used to help with this, but for seeding large amounts of data it may be necessary to do less
         /// granular checks if performance is an issue.
         /// If the <see cref="MigrateDatabaseToLatestVersion{TContext,TMigrationsConfiguration}"/> database 
@@ -51,11 +54,38 @@ namespace System.Data.Entity.Migrations
             Check.NotNull(context, "context");
         }
 
-        internal override void OnSeed(DbContext context)
+        /// <summary>
+        /// Runs after upgrading to the latest migration to allow seed data to be updated.
+        /// </summary>
+        /// <remarks>
+        /// Note that the database may already contain seed data when this method runs. This means that
+        /// implementations of this method must check whether or not seed data is present and/or up-to-date
+        /// and then only make changes if necessary and in a non-destructive way. The 
+        /// <see cref="DbSetMigrationsExtensions.AddOrUpdate{TEntity}(System.Data.Entity.IDbSet{TEntity},TEntity[])"/>
+        /// and
+        /// <see cref="DbSetMigrationsExtensions.RemoveIfExist{TEntity}(System.Data.Entity.IDbSet{TEntity},TEntity[])"/>
+        /// can be used to help with this, but for seeding large amounts of data it may be necessary to do less
+        /// granular checks if performance is an issue.
+        /// If the <see cref="MigrateDatabaseToLatestVersion{TContext,TMigrationsConfiguration}"/> database 
+        /// initializer is being used, then this method will be called each time that the initializer runs.
+        /// If one of the <see cref="DropCreateDatabaseAlways{TContext}"/>, <see cref="DropCreateDatabaseIfModelChanges{TContext}"/>,
+        /// or <see cref="CreateDatabaseIfNotExists{TContext}"/> initializers is being used, then this method will not be
+        /// called and the Seed method defined in the initializer should be used instead.
+        /// </remarks>
+        /// <param name="context"> Context to be used for updating seed data. </param>
+        /// /// <param name="migrationsApplied"> List of migrations applied during migration. </param>
+        protected virtual void Seed(TContext context, IEnumerable<string> migrationsApplied)
         {
-            Seed((TContext)context);
+            Check.NotNull(context, "context");
+            Check.NotNull(migrationsApplied, "migrationsApplied");
+            Seed(context);
         }
 
+        internal override void OnSeed(DbContext context, IEnumerable<string> migrationsApplied)
+        {
+            Seed((TContext)context, migrationsApplied);
+        }
+        
         #region Hide object members
 
         /// <inheritdoc />

--- a/src/EntityFramework/Migrations/DbMigrator.cs
+++ b/src/EntityFramework/Migrations/DbMigrator.cs
@@ -558,6 +558,8 @@ namespace System.Data.Entity.Migrations
         {
             DbMigration lastMigration = null;
 
+            var migrationsApplied = new List<string>();
+
             if (lastMigrationId != null)
             {
                 lastMigration = _migrationAssembly.GetMigration(lastMigrationId);
@@ -572,6 +574,8 @@ namespace System.Data.Entity.Migrations
                 lastMigration = migration;
 
                 _emptyMigrationNeeded = false;
+
+                migrationsApplied.Add(pendingMigration);
 
                 if (pendingMigration.EqualsIgnoreCase(targetMigrationId))
                 {
@@ -605,11 +609,11 @@ namespace System.Data.Entity.Migrations
             if (!_calledByCreateDatabase
                 && !IsModelOutOfDate(_currentModel, lastMigration))
             {
-                base.SeedDatabase();
+                base.SeedDatabase(migrationsApplied);
             }
         }
 
-        internal override void SeedDatabase()
+        internal override void SeedDatabase(IEnumerable<string> migrationsApplied)
         {
             Debug.Assert(!_calledByCreateDatabase);
 
@@ -622,7 +626,7 @@ namespace System.Data.Entity.Migrations
 
             try
             {
-                _configuration.OnSeed(context);
+                _configuration.OnSeed(context, migrationsApplied);
 
                 context.SaveChanges();
             }

--- a/src/EntityFramework/Migrations/DbSetMigrationsExtensions.cs
+++ b/src/EntityFramework/Migrations/DbSetMigrationsExtensions.cs
@@ -267,7 +267,6 @@ namespace System.Data.Entity.Migrations
             DebugCheck.NotNull(identifyingProperties);
             DebugCheck.NotNull(entities);
 
-            var keyProperties = GetKeyProperties(typeof(TEntity), internalSet);
             var parameter = Expression.Parameter(typeof(TEntity));
 
             foreach (var entity in entities)
@@ -289,12 +288,7 @@ namespace System.Data.Entity.Migrations
 
                 if (existing != null)
                 {
-                    foreach (var keyProperty in keyProperties)
-                    {
-                        keyProperty.Single().GetPropertyInfoForSet().SetValue(entity, keyProperty.Single().GetValue(existing, null), null);
-                    }
-
-                    internalSet.Remove(entity);
+                    internalSet.Remove(internalSet.InternalContext.Owner.Entry(existing).Entity);
                 }
             }
         }

--- a/src/EntityFramework/Migrations/DbSetMigrationsExtensions.cs
+++ b/src/EntityFramework/Migrations/DbSetMigrationsExtensions.cs
@@ -115,6 +115,103 @@ namespace System.Data.Entity.Migrations
             method.Invoke(set, new object[] { identifierExpression, entities });
         }
 
+        /// <summary>
+        /// Remove entities, if they exist, by key when SaveChanges is called. 
+        /// This method can useful when seeding data using Migrations.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of entities to remove if exist.</typeparam>
+        /// <param name="set">The set to which the entities belong.</param>
+        /// <param name="entities"> The entities to remove if exist. </param>
+        /// <remarks>
+        /// When the <paramref name="set" /> parameter is a custom or fake IDbSet implementation, this method will
+        /// attempt to locate and invoke a public, instance method with the same signature as this extension method.
+        /// </remarks>
+        public static void RemoveIfExist<TEntity>(
+            this IDbSet<TEntity> set, params TEntity[] entities)
+            where TEntity : class
+        {
+            Check.NotNull(set, "set");
+            Check.NotNull(entities, "entities");
+
+            var dbSet = set as DbSet<TEntity>;
+
+            if (dbSet != null)
+            {
+                var internalSet = (InternalSet<TEntity>)((IInternalSetAdapter)dbSet).InternalSet;
+
+                if (internalSet != null)
+                {
+                    dbSet.RemoveIfExist(GetKeyProperties(typeof(TEntity), internalSet), internalSet, entities);
+
+                    return;
+                }
+            }
+
+            var targetType = set.GetType();
+
+            var method = targetType.GetDeclaredMethod("RemoveIfExist", typeof(TEntity[]));
+
+            if (method == null)
+            {
+                throw Error.UnableToDispatchRemoveIfExist(targetType);
+            }
+
+            method.Invoke(set, new[] { entities });
+        }
+
+        /// <summary>
+        /// Remove entities, if they exist, by a custom identification expression when SaveChanges is called.
+        /// This method can useful when seeding data using Migrations.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of entities to remove if exist.</typeparam>
+        /// <param name="set">The set to which the entities belong.</param>
+        /// <param name="identifierExpression"> An expression specifying the properties that should be used when determining if a remove operation should be performed. </param>
+        /// <param name="entities"> The entities to remove if exist. </param>
+        /// <remarks>
+        /// When the <paramref name="set" /> parameter is a custom or fake IDbSet implementation, this method will
+        /// attempt to locate and invoke a public, instance method with the same signature as this extension method.
+        /// </remarks>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
+        public static void RemoveIfExist<TEntity>(
+            this IDbSet<TEntity> set, Expression<Func<TEntity, object>> identifierExpression, params TEntity[] entities)
+            where TEntity : class
+        {
+            Check.NotNull(set, "set");
+            Check.NotNull(identifierExpression, "identifierExpression");
+            Check.NotNull(entities, "entities");
+
+            var dbSet = set as DbSet<TEntity>;
+
+            if (dbSet != null)
+            {
+                var internalSet = (InternalSet<TEntity>)((IInternalSetAdapter)dbSet).InternalSet;
+
+                if (internalSet != null)
+                {
+                    var identifyingProperties
+                        = identifierExpression.GetSimplePropertyAccessList();
+
+                    dbSet.RemoveIfExist(identifyingProperties, internalSet, entities);
+
+                    return;
+                }
+            }
+
+            var targetType = set.GetType();
+
+            var method
+                = targetType.GetDeclaredMethod(
+                    "RemoveIfExist",
+                    typeof(Expression<Func<TEntity, object>>), typeof(TEntity[]));
+
+            if (method == null)
+            {
+                throw Error.UnableToDispatchRemoveIfExist(targetType);
+            }
+
+            method.Invoke(set, new object[] { identifierExpression, entities });
+        }
+
         private static void AddOrUpdate<TEntity>(
             this DbSet<TEntity> set, IEnumerable<PropertyPath> identifyingProperties,
             InternalSet<TEntity> internalSet, params TEntity[] entities)
@@ -157,6 +254,47 @@ namespace System.Data.Entity.Migrations
                 else
                 {
                     internalSet.Add(entity);
+                }
+            }
+        }
+
+        private static void RemoveIfExist<TEntity>(
+            this DbSet<TEntity> set, IEnumerable<PropertyPath> identifyingProperties,
+            InternalSet<TEntity> internalSet, params TEntity[] entities)
+            where TEntity : class
+        {
+            DebugCheck.NotNull(set);
+            DebugCheck.NotNull(identifyingProperties);
+            DebugCheck.NotNull(entities);
+
+            var keyProperties = GetKeyProperties(typeof(TEntity), internalSet);
+            var parameter = Expression.Parameter(typeof(TEntity));
+
+            foreach (var entity in entities)
+            {
+                var matchExpression
+                    = identifyingProperties.Select(
+                        pi => Expression.Equal(
+                            Expression.Property(parameter, pi.Single()),
+                            Expression.Constant(pi.Last().GetValue(entity, null), pi.Last().PropertyType)))
+                                           .Aggregate<BinaryExpression, Expression>(
+                                               null,
+                                               (current, predicate)
+                                               => (current == null)
+                                                      ? predicate
+                                                      : Expression.AndAlso(current, predicate));
+
+                var existing
+                    = set.SingleOrDefault(Expression.Lambda<Func<TEntity, bool>>(matchExpression, new[] { parameter }));
+
+                if (existing != null)
+                {
+                    foreach (var keyProperty in keyProperties)
+                    {
+                        keyProperty.Single().GetPropertyInfoForSet().SetValue(entity, keyProperty.Single().GetValue(existing, null), null);
+                    }
+
+                    internalSet.Remove(entity);
                 }
             }
         }

--- a/src/EntityFramework/Migrations/Infrastructure/MigratorBase.cs
+++ b/src/EntityFramework/Migrations/Infrastructure/MigratorBase.cs
@@ -146,6 +146,11 @@ namespace System.Data.Entity.Migrations.Infrastructure
             _this.SeedDatabase();
         }
 
+        internal virtual void SeedDatabase(IEnumerable<string> migrationsApplied)
+        {
+            _this.SeedDatabase(migrationsApplied);
+        }
+
         internal virtual void ExecuteStatements(IEnumerable<MigrationStatement> migrationStatements)
         {
             DebugCheck.NotNull(migrationStatements);

--- a/src/EntityFramework/Migrations/Infrastructure/MigratorLoggingDecorator.cs
+++ b/src/EntityFramework/Migrations/Infrastructure/MigratorLoggingDecorator.cs
@@ -136,6 +136,13 @@ namespace System.Data.Entity.Migrations.Infrastructure
             base.SeedDatabase();
         }
 
+        internal override void SeedDatabase(IEnumerable<string> migrationsApllied)
+        {
+            _logger.Info(Strings.LoggingSeedingDatabase);
+
+            base.SeedDatabase(migrationsApllied);
+        }
+
         internal override void UpgradeHistory(IEnumerable<MigrationOperation> upgradeOperations)
         {
             _logger.Info(Strings.UpgradingHistoryTable);

--- a/src/EntityFramework/Migrations/Infrastructure/MigratorScriptingDecorator.cs
+++ b/src/EntityFramework/Migrations/Infrastructure/MigratorScriptingDecorator.cs
@@ -143,6 +143,10 @@ namespace System.Data.Entity.Migrations.Infrastructure
         {
         }
 
+        internal override void SeedDatabase(IEnumerable<string> migrationsApplied)
+        {
+        }
+
         internal override bool HistoryExists()
         {
             return false;

--- a/src/EntityFramework/Properties/Resources.cs
+++ b/src/EntityFramework/Properties/Resources.cs
@@ -263,7 +263,7 @@ namespace System.Data.Entity.Resources
         }
 
         // <summary>
-        // A string like "Unable to call public, instance method AddOrUpdate on derived IDbSet<T> type '{0}'. Method not found."
+        // A string like "Unable to call public, instance method RemoveIfExist on derived IDbSet<T> type '{0}'. Method not found."
         // </summary>
         internal static string UnableToDispatchRemoveIfExist(object p0)
         {

--- a/src/EntityFramework/Properties/Resources.cs
+++ b/src/EntityFramework/Properties/Resources.cs
@@ -4,8 +4,8 @@ namespace System.Data.Entity.Resources
 {
     using System.CodeDom.Compiler;
     using System.Globalization;
-    using System.Resources;
     using System.Reflection;
+    using System.Resources;
     using System.Threading;
 
     // <summary>
@@ -260,6 +260,14 @@ namespace System.Data.Entity.Resources
         internal static string MigrationsNamespaceNotUnderRootNamespace(object p0, object p1)
         {
             return EntityRes.GetString(EntityRes.MigrationsNamespaceNotUnderRootNamespace, p0, p1);
+        }
+
+        // <summary>
+        // A string like "Unable to call public, instance method AddOrUpdate on derived IDbSet<T> type '{0}'. Method not found."
+        // </summary>
+        internal static string UnableToDispatchRemoveIfExist(object p0)
+        {
+            return EntityRes.GetString(EntityRes.UnableToDispatchRemoveIfExist, p0);
         }
 
         // <summary>
@@ -14181,6 +14189,14 @@ namespace System.Data.Entity.Resources
         }
 
         // <summary>
+        // InvalidOperationException with message like "Unable to call public, instance method RemoveIfExist on derived IDbSet<T> type '{0}'. Method not found."
+        // </summary>
+        internal static Exception UnableToDispatchRemoveIfExist(object p0)
+        {
+            return new InvalidOperationException(Strings.UnableToDispatchRemoveIfExist(p0));
+        }
+
+        // <summary>
         // InvalidOperationException with message like "Unable to call public, instance method AddOrUpdate on derived IDbSet<T> type '{0}'. Method not found."
         // </summary>
         internal static Exception UnableToDispatchAddOrUpdate(object p0)
@@ -15747,6 +15763,7 @@ namespace System.Data.Entity.Resources
         internal const string AssemblyMigrator_NoConfiguration = "AssemblyMigrator_NoConfiguration";
         internal const string AssemblyMigrator_MultipleConfigurations = "AssemblyMigrator_MultipleConfigurations";
         internal const string MigrationsNamespaceNotUnderRootNamespace = "MigrationsNamespaceNotUnderRootNamespace";
+        internal const string UnableToDispatchRemoveIfExist = "UnableToDispatchRemoveIfExist";
         internal const string UnableToDispatchAddOrUpdate = "UnableToDispatchAddOrUpdate";
         internal const string NoSqlGeneratorForProvider = "NoSqlGeneratorForProvider";
         internal const string ToolingFacade_AssemblyNotFound = "ToolingFacade_AssemblyNotFound";

--- a/src/EntityFramework/Properties/Resources.resx
+++ b/src/EntityFramework/Properties/Resources.resx
@@ -5585,4 +5585,8 @@
     <value>IndexAttributes with identity '{0}' and name '{1}' cannot be merged because they ambiguously match multiple, conflicting IndexAttributes.</value>
     <comment>## ExceptionType=InvalidOperationException</comment>
   </data>
+  <data name="UnableToDispatchRemoveIfExist" xml:space="preserve">
+    <value>Unable to call public, instance method RemoveIfExist on derived IDbSet&lt;T&gt; type '{0}'. Method not found.</value>
+    <comment>## ExceptionType=InvalidOperationException</comment>
+  </data>
 </root>


### PR DESCRIPTION
Implementation of a signature overload in the `DbMigrationsConfiguration` so it can be called with a new parameter a list with the id's of the migrations that were applied during the migration upgrade.

The usage of this new method is done by replacing the method on the class "Configuration" generated by the migration, from `protected override void Seed(EfDbContext context)` to `protected override void Seed(EfDbContext context, IEnumerable<string> migrationsApplied)`. 

The both signatures are kept intact on the migration decorators in order to keep "backwards compatibility".

A different method was added to the `DbSetMigrationsExtensions` called RemoveIfExists that remove an entity if that entity exists following the same logic approach of the method `AddOrUpdate`.

A Discussion was previously started at [Configuration seed method aware of migrations applied. #221](https://github.com/aspnet/EntityFramework6/issues/221) .