### PR TITLE
Use the currently configured IDbExecutionStrategy for commit verification in CommitFailureHandler

### DIFF
--- a/src/EntityFramework/Infrastructure/DbExecutionStrategy.cs
+++ b/src/EntityFramework/Infrastructure/DbExecutionStrategy.cs
@@ -101,7 +101,7 @@ namespace System.Data.Entity.Infrastructure
         ///     Indicates whether the strategy is suspended. The strategy is typically suspending while executing to avoid
         ///     recursive execution from nested operations.
         /// </summary>
-        protected static bool Suspended
+        protected internal static bool Suspended
         {
             get { return (bool?)CallContext.LogicalGetData(ContextName) ?? false; }
             set { CallContext.LogicalSetData(ContextName, value); }


### PR DESCRIPTION
Allow to customize the used strategy by deriving from CommitFailureHandler

Fixes #218