### PR TITLE
Perf optimization. Update pkgdef data to reflect UIContextRule autoload attributes

### DIFF
--- a/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
+++ b/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
@@ -95,7 +95,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <None Include="PkgDefData\Microsoft.Data.Entity.Design.BootstrapPackage.pkgdef" />
+    <None Include="PkgDefData\Microsoft.Data.Entity.Design.BootstrapPackage_preDev15.pkgdef" />
+    <None Include="PkgDefData\Microsoft.Data.Entity.Design.BootstrapPackage_Dev15.pkgdef" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx">
@@ -105,8 +106,12 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PkgDefFile Condition="'$(VisualStudioVersion)' == '11.0' OR '$(VisualStudioVersion)' == '12.0' OR '$(VisualStudioVersion)' == '14.0'">Microsoft.Data.Entity.Design.BootstrapPackage_preDev15.pkgdef</PkgDefFile>
+    <PkgDefFile Condition="'$(PkgDefFile)' == ''">Microsoft.Data.Entity.Design.BootstrapPackage_Dev15.pkgdef</PkgDefFile>
+  </PropertyGroup>
   <Target Name="AfterBuild">
     <MakeDir Directories="$(OutputPath)PkgDefData" />
-    <RegexReplaceInFile InputFileName="PkgDefData\Microsoft.Data.Entity.Design.BootstrapPackage.pkgdef" OutputFileName="$(OutputPath)PkgDefData\Microsoft.Data.Entity.Design.BootstrapPackage.pkgdef" Patterns="EFDESIGNERVERSIONTOKEN" Replacements="$(AssemblyVersion)" />
+    <RegexReplaceInFile InputFileName="PkgDefData\$(PkgDefFile)" OutputFileName="$(OutputPath)PkgDefData\Microsoft.Data.Entity.Design.BootstrapPackage.pkgdef" Patterns="EFDESIGNERVERSIONTOKEN" Replacements="$(AssemblyVersion)" />
   </Target>
 </Project>

--- a/src/EFTools/EntityDesignBootstrapPackage/MicrosoftDataEntityDesignBootstrapPackage.cs
+++ b/src/EFTools/EntityDesignBootstrapPackage/MicrosoftDataEntityDesignBootstrapPackage.cs
@@ -22,10 +22,13 @@ namespace Microsoft.Data.Entity.Design.BootstrapPackage
     }
 
     //
-    // Auto load this VS package when the solution has at least one loaded project.
-    // This package will then check the solution for any contained EDMX files and keep
+    // Prior to Dev15 we auto load this VS package when the solution has at least one loaded
+    // project. This package will then check the solution for any contained EDMX files and keep
     // monitoring projects/solutions for any EDMX files. If there is any, this package
     // will load the EDM package.
+    // From Dev15 onwards auto load when a .edmx file is selected and not at solution load.
+    // Note: the pkgdef files in PkgDefData _must_ be kept in sync with the
+    // ProvideAutoLoad and ProvideUIContextRule attributes.
     //
     [VSShell.DefaultRegistryRootAttribute("Software\\Microsoft\\VisualStudio\\11.0")]
     [VSShell.PackageRegistrationAttribute(RegisterUsing = VSShell.RegistrationMethod.Assembly, UseManagedResourcesOnly = true)]

--- a/src/EFTools/EntityDesignBootstrapPackage/PkgDefData/Microsoft.Data.Entity.Design.BootstrapPackage_Dev15.pkgdef
+++ b/src/EFTools/EntityDesignBootstrapPackage/PkgDefData/Microsoft.Data.Entity.Design.BootstrapPackage_Dev15.pkgdef
@@ -5,9 +5,11 @@
 "Class"="Microsoft.Data.Entity.Design.BootstrapPackage.BootstrapPackage"
 "InprocServer32"="%SystemRoot%\\system32\\mscoree.dll"
 
-// Auto load the bootstrap package
-[$RootKey$\AutoLoadPackages\{93694fa0-0397-11d1-9f4e-00a0c911004f}]
-"{7A4E8D96-5D5B-4415-9FAB-D6DCC56F47FB}"=dword:00000000
+// Auto load the bootstrap package dependent on the UIContextRules
+[$RootKey$\AutoLoadPackages\{e000c7e5-dba5-4682-abe0-7f6ce57b236d}]
+"{7a4e8d96-5d5b-4415-9fab-d6dcc56f47fb}"=dword:00000000
 
-[$RootKey$\AutoLoadPackages\{adfc4e66-0397-11d1-9f4e-00a0c911004f}]
-"{7A4E8D96-5D5B-4415-9FAB-D6DCC56F47FB}"=dword:00000000
+[$RootKey$\UIContextRules\{e000c7e5-dba5-4682-abe0-7f6ce57b236d}]
+@="Auto load Entity Data Model Package"
+"Expression"="DotEdmx"
+"DotEdmx"="HierSingleSelectionName:.edmx$"

--- a/src/EFTools/EntityDesignBootstrapPackage/PkgDefData/Microsoft.Data.Entity.Design.BootstrapPackage_preDev15.pkgdef
+++ b/src/EFTools/EntityDesignBootstrapPackage/PkgDefData/Microsoft.Data.Entity.Design.BootstrapPackage_preDev15.pkgdef
@@ -1,0 +1,13 @@
+// Entity Designer Bootstrap package registration
+[$RootKey$\Packages\{7A4E8D96-5D5B-4415-9FAB-D6DCC56F47FB}]
+@="Microsoft.Data.Entity.Design.BootstrapPackage.BootstrapPackage, Microsoft.Data.Entity.Design.BootstrapPackage, version=EFDESIGNERVERSIONTOKEN, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Assembly"="Microsoft.Data.Entity.Design.BootstrapPackage, version=EFDESIGNERVERSIONTOKEN, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Class"="Microsoft.Data.Entity.Design.BootstrapPackage.BootstrapPackage"
+"InprocServer32"="%SystemRoot%\\system32\\mscoree.dll"
+
+// Auto load the bootstrap package on solution load
+[$RootKey$\AutoLoadPackages\{93694fa0-0397-11d1-9f4e-00a0c911004f}]
+"{7A4E8D96-5D5B-4415-9FAB-D6DCC56F47FB}"=dword:00000000
+
+[$RootKey$\AutoLoadPackages\{adfc4e66-0397-11d1-9f4e-00a0c911004f}]
+"{7A4E8D96-5D5B-4415-9FAB-D6DCC56F47FB}"=dword:00000000


### PR DESCRIPTION
Fix for #247. AutoLoad attributes must be kept in sync with the pkgdef files.