### PR TITLE
#250 - modify MetadataCollection.AddRange method to accept IEnumerable

### DIFF
--- a/src/EntityFramework/Core/Metadata/Edm/AssociationEndMember.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/AssociationEndMember.cs
@@ -88,7 +88,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                instance.AddMetadataProperties(metadataProperties.ToList());
+                instance.AddMetadataProperties(metadataProperties);
             }
 
             instance.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/AssociationSet.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/AssociationSet.cs
@@ -217,7 +217,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                instance.AddMetadataProperties(metadataProperties.ToList());
+                instance.AddMetadataProperties(metadataProperties);
             }
 
             instance.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/AssociationType.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/AssociationType.cs
@@ -274,7 +274,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                instance.AddMetadataProperties(metadataProperties.ToList());
+                instance.AddMetadataProperties(metadataProperties);
             }
 
             instance.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/ComplexType.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/ComplexType.cs
@@ -123,7 +123,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                complexType.AddMetadataProperties(metadataProperties.ToList());
+                complexType.AddMetadataProperties(metadataProperties);
             }
 
             complexType.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/EdmFunction.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EdmFunction.cs
@@ -532,7 +532,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                function.AddMetadataProperties(metadataProperties.ToList());
+                function.AddMetadataProperties(metadataProperties);
             }
 
             function.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/EdmProperty.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EdmProperty.cs
@@ -658,7 +658,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
             Check.NotNull(metadataProperties, "metadataProperties");
 
             Util.ThrowIfReadOnly(this);
-            AddMetadataProperties(metadataProperties.ToList());
+            AddMetadataProperties(metadataProperties);
         }
     }
 }

--- a/src/EntityFramework/Core/Metadata/Edm/EntityContainer.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EntityContainer.cs
@@ -390,7 +390,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                entityContainer.AddMetadataProperties(metadataProperties.ToList());
+                entityContainer.AddMetadataProperties(metadataProperties);
             }
 
             entityContainer.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/EntitySet.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EntitySet.cs
@@ -217,7 +217,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                entitySet.AddMetadataProperties(metadataProperties.ToList());
+                entitySet.AddMetadataProperties(metadataProperties);
             }
 
             entitySet.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/EntityType.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EntityType.cs
@@ -313,7 +313,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                entity.AddMetadataProperties(metadataProperties.ToList());
+                entity.AddMetadataProperties(metadataProperties);
             }
 
             entity.SetReadOnly();
@@ -350,7 +350,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                entity.AddMetadataProperties(metadataProperties.ToList());
+                entity.AddMetadataProperties(metadataProperties);
             }
 
             entity.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/EnumMember.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EnumMember.cs
@@ -167,7 +167,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                instance.AddMetadataProperties(metadataProperties.ToList());
+                instance.AddMetadataProperties(metadataProperties);
             }
 
             instance.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/EnumType.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EnumType.cs
@@ -227,7 +227,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                instance.AddMetadataProperties(metadataProperties.ToList());
+                instance.AddMetadataProperties(metadataProperties);
             }
 
             instance.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/MetadataCollection.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/MetadataCollection.cs
@@ -261,7 +261,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
         // <exception cref="System.ArgumentException">An item to add is null.</exception>
         // <exception cref="System.ArgumentException">An item with the same identity already exists.</exception>
         // <returns>A boolean that indicates whether the operation was successful.</returns>
-        internal void AddRange(List<T> items)
+        internal void AddRange(IEnumerable<T> items)
         {
             Check.NotNull(items, "items");
 

--- a/src/EntityFramework/Core/Metadata/Edm/MetadataItem.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/MetadataItem.cs
@@ -215,7 +215,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
         // <summary>
         // Adds the given metadata property to the metadata property collection
         // </summary>
-        internal void AddMetadataProperties(List<MetadataProperty> metadataProperties)
+        internal void AddMetadataProperties(IEnumerable<MetadataProperty> metadataProperties)
         {
             GetMetadataProperties().AddRange(metadataProperties);
         }

--- a/src/EntityFramework/Core/Metadata/Edm/NavigationProperty.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/NavigationProperty.cs
@@ -163,7 +163,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                instance.AddMetadataProperties(metadataProperties.ToList());
+                instance.AddMetadataProperties(metadataProperties);
             }
 
             instance.SetReadOnly();

--- a/src/EntityFramework/Core/Metadata/Edm/RowType.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/RowType.cs
@@ -263,7 +263,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
             if (metadataProperties != null)
             {
-                rowType.AddMetadataProperties(metadataProperties.ToList());
+                rowType.AddMetadataProperties(metadataProperties);
             }
 
             rowType.SetReadOnly();


### PR DESCRIPTION
MetadataCollection class has method AddRange that accepts List. Due to internal implementation, this method just iterates through list and adds every item to internal collection _metadataList and _caseSensitiveDictionary.
It looks correct to change signature of the method AddRange to accept IEnumerable, like List.AddRange. Thereby we can change signature of method MetadataItem.AddMetadataProperties to accept IEnumerable too, and remove ToList when we call AddMetadataProperties.