### PR TITLE
Add or update and delete operation for data manipulation as part of the migration.

### DIFF
--- a/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
@@ -829,9 +829,9 @@ namespace System.Data.Entity.SqlServer
         {
             Check.NotNull(addOrUpdateOperation, "addOrUpdateOperation");
 
-            var columns = addOrUpdateOperation.Columns.ToList();
+            var columns = addOrUpdateOperation.Columns;
             var identifiers = columns.Intersect(addOrUpdateOperation.Identifiers).ToList();
-            var values = addOrUpdateOperation.Values.ToList();
+            var values = addOrUpdateOperation.Values;
 
             using (var writer = Writer())
             {

--- a/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
@@ -824,19 +824,23 @@ namespace System.Data.Entity.SqlServer
         /// Generates SQL for a <see cref="AddOrUpdateOperation" />.
         /// Generated SQL should be added using the Statement method.
         /// </summary>
-        /// <param name="addOrUpdateRowOperation">The operation to produce SQL for.</param>
-        protected virtual void Generate(AddOrUpdateOperation addOrUpdateRowOperation)
+        /// <param name="addOrUpdateOperation">The operation to produce SQL for.</param>
+        protected virtual void Generate(AddOrUpdateOperation addOrUpdateOperation)
         {
-            Check.NotNull(addOrUpdateRowOperation, "addOrUpdateRowOperation");
+            Check.NotNull(addOrUpdateOperation, "addOrUpdateOperation");
 
             using (var writer = Writer())
             {
-                var identifiers = addOrUpdateRowOperation.Columns.Intersect(addOrUpdateRowOperation.Identifiers).ToList();
+                writer.Write("IF object_id('");
+                writer.Write(Name(addOrUpdateOperation.Table));
+                writer.WriteLine("') IS NOT NULL");
+
+                var identifiers = addOrUpdateOperation.Columns.Intersect(addOrUpdateOperation.Identifiers).ToList();
 
                 if (identifiers.Any())
                 {
-                    writer.Write("IF EXISTS (SELECT 1 FROM ");
-                    writer.Write(Name(addOrUpdateRowOperation.Table));
+                    writer.Write(" IF EXISTS (SELECT 1 FROM ");
+                    writer.Write(Name(addOrUpdateOperation.Table));
                     writer.Write(" WHERE ");
 
                     writer.Write(
@@ -844,19 +848,19 @@ namespace System.Data.Entity.SqlServer
                             identifier =>
                                 string.Join(
                                     " = ", Quote(identifier),
-                                    Generate((dynamic)addOrUpdateRowOperation.Values[addOrUpdateRowOperation.Columns.IndexOf(identifier)])),
+                                    Generate((dynamic)addOrUpdateOperation.Values[addOrUpdateOperation.Columns.IndexOf(identifier)])),
                             " AND "));
 
                     writer.Write(") UPDATE ");
-                    writer.Write(Name(addOrUpdateRowOperation.Table));
+                    writer.Write(Name(addOrUpdateOperation.Table));
                     writer.Write(" SET ");
 
                     writer.Write(
-                        addOrUpdateRowOperation.Columns.Join(
+                        addOrUpdateOperation.Columns.Join(
                             column =>
                                 string.Join(
                                     " = ", Quote(column),
-                                    Generate((dynamic)addOrUpdateRowOperation.Values[addOrUpdateRowOperation.Columns.IndexOf(column)]))));
+                                    Generate((dynamic)addOrUpdateOperation.Values[addOrUpdateOperation.Columns.IndexOf(column)]))));
 
                     writer.Write(" WHERE ");
 
@@ -865,18 +869,18 @@ namespace System.Data.Entity.SqlServer
                             identifier =>
                                 string.Join(
                                     " = ", Quote(identifier),
-                                    Generate((dynamic)addOrUpdateRowOperation.Values[addOrUpdateRowOperation.Columns.IndexOf(identifier)])),
+                                    Generate((dynamic)addOrUpdateOperation.Values[addOrUpdateOperation.Columns.IndexOf(identifier)])),
                             " AND "));
                     
-                    writer.Write(" ELSE ");
+                    writer.WriteLine(" ELSE");
                 }
 
-                writer.Write("INSERT INTO ");
-                writer.Write(Name(addOrUpdateRowOperation.Table));
+                writer.Write(" INSERT INTO ");
+                writer.Write(Name(addOrUpdateOperation.Table));
                 writer.Write("(");
-                writer.Write(addOrUpdateRowOperation.Columns.Join(Quote));
+                writer.Write(addOrUpdateOperation.Columns.Join(Quote));
                 writer.Write(") VALUES (");
-                writer.Write(addOrUpdateRowOperation.Values.Join(value => Generate((dynamic)value)));
+                writer.Write(addOrUpdateOperation.Values.Join(value => Generate((dynamic)value)));
                 writer.Write(")");
 
                 Statement(writer);

--- a/src/EntityFramework.SqlServerCompact/SqlCeMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServerCompact/SqlCeMigrationSqlGenerator.cs
@@ -430,9 +430,9 @@ namespace System.Data.Entity.SqlServerCompact
         {
             Check.NotNull(addOrUpdateOperation, "addOrUpdateOperation");
 
-            var columns = addOrUpdateOperation.Columns.ToList();
+            var columns = addOrUpdateOperation.Columns;
             var identifiers = columns.Intersect(addOrUpdateOperation.Identifiers).ToList();
-            var values = addOrUpdateOperation.Values.ToList();
+            var values = addOrUpdateOperation.Values;
 
             using (var writer = Writer())
             {

--- a/src/EntityFramework.SqlServerCompact/SqlCeMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServerCompact/SqlCeMigrationSqlGenerator.cs
@@ -489,6 +489,49 @@ namespace System.Data.Entity.SqlServerCompact
         }
 
         /// <summary>
+        /// Generates SQL for a <see cref="DeleteOperation" />.
+        /// Generated SQL should be added using the Statement method.
+        /// </summary>
+        /// <param name="deleteOperation">The operation to produce SQL for.</param>
+        protected virtual void Generate(DeleteOperation deleteOperation)
+        {
+            Check.NotNull(deleteOperation, "deleteOperation");
+
+            using (var writer = Writer())
+            {
+                writer.Write("IF object_id('");
+                writer.Write(Name(deleteOperation.Table));
+                writer.WriteLine("') IS NOT NULL");
+
+                writer.Write(" DELETE FROM ");
+                writer.Write(Name(deleteOperation.Table));
+                writer.Write(" WHERE ");
+
+                for (var i = 0; i < deleteOperation.Columns.Count; i++)
+                {
+                    var column = deleteOperation.Columns[i];
+                    var values = deleteOperation.Values[i];
+
+
+                    var joinedValues = values.Any() ?
+                        string.Join(" OR ", values.Select(value => string.Concat(Quote(column), value != null ? string.Concat(" = ", Generate((dynamic)value)) : " IS NULL")))
+                        : string.Empty;
+
+                    if (!string.IsNullOrEmpty(joinedValues))
+                    {
+                        if (i > 0) writer.Write(" AND ");
+
+                        writer.Write("(");
+                        writer.Write(joinedValues);
+                        writer.Write(")");
+                    }
+                }
+
+                Statement(writer);
+            }
+        }
+
+        /// <summary>
         /// Generates SQL for a <see cref="DropColumnOperation" />.
         /// Generated SQL should be added using the Statement method.
         /// </summary>

--- a/src/EntityFramework.SqlServerCompact/SqlCeMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServerCompact/SqlCeMigrationSqlGenerator.cs
@@ -422,6 +422,69 @@ namespace System.Data.Entity.SqlServerCompact
         }
 
         /// <summary>
+        /// Generates SQL for a <see cref="AddOrUpdateOperation" />.
+        /// Generated SQL should be added using the Statement method.
+        /// </summary>
+        /// <param name="addOrUpdateRowOperation">The operation to produce SQL for.</param>
+        protected virtual void Generate(AddOrUpdateOperation addOrUpdateRowOperation)
+        {
+            Check.NotNull(addOrUpdateRowOperation, "addOrUpdateRowOperation");
+
+            using (var writer = Writer())
+            {
+                var identifiers = addOrUpdateRowOperation.Columns.Intersect(addOrUpdateRowOperation.Identifiers).ToList();
+
+                if (identifiers.Any())
+                {
+                    writer.Write("IF EXISTS (SELECT 1 FROM ");
+                    writer.Write(Name(addOrUpdateRowOperation.Table));
+                    writer.Write(" WHERE ");
+
+                    writer.Write(
+                        identifiers.Join(
+                            identifier =>
+                                string.Join(
+                                    " = ", Quote(identifier),
+                                    Generate((dynamic)addOrUpdateRowOperation.Values[addOrUpdateRowOperation.Columns.IndexOf(identifier)])),
+                            " AND "));
+
+                    writer.Write(") UPDATE ");
+                    writer.Write(Name(addOrUpdateRowOperation.Table));
+                    writer.Write(" SET ");
+
+                    writer.Write(
+                        addOrUpdateRowOperation.Columns.Join(
+                            column =>
+                                string.Join(
+                                    " = ", Quote(column),
+                                    Generate((dynamic)addOrUpdateRowOperation.Values[addOrUpdateRowOperation.Columns.IndexOf(column)]))));
+
+                    writer.Write(" WHERE ");
+
+                    writer.Write(
+                        identifiers.Join(
+                            identifier =>
+                                string.Join(
+                                    " = ", Quote(identifier),
+                                    Generate((dynamic)addOrUpdateRowOperation.Values[addOrUpdateRowOperation.Columns.IndexOf(identifier)])),
+                            " AND "));
+
+                    writer.Write(" ELSE ");
+                }
+
+                writer.Write("INSERT INTO ");
+                writer.Write(Name(addOrUpdateRowOperation.Table));
+                writer.Write("(");
+                writer.Write(addOrUpdateRowOperation.Columns.Join(Quote));
+                writer.Write(") VALUES (");
+                writer.Write(addOrUpdateRowOperation.Values.Join(value => Generate((dynamic)value)));
+                writer.Write(")");
+
+                Statement(writer);
+            }
+        }
+
+        /// <summary>
         /// Generates SQL for a <see cref="DropColumnOperation" />.
         /// Generated SQL should be added using the Statement method.
         /// </summary>

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -351,6 +351,7 @@
     <Compile Include="Migrations\Model\AddOrUpdateOperation.cs" />
     <Compile Include="Migrations\Model\AlterProcedureOperation.cs" />
     <Compile Include="Migrations\Model\AlterTableOperation.cs" />
+    <Compile Include="Migrations\Model\DeleteOperation.cs" />
     <Compile Include="Migrations\Model\IAnnotationTarget.cs" />
     <Compile Include="Migrations\Model\RenameIndexOperation.cs" />
     <Compile Include="Migrations\Model\UpdateDatabaseOperation.cs" />

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -348,6 +348,7 @@
     <Compile Include="Internal\QueryCacheConfig.cs" />
     <Compile Include="Migrations\Builders\ParameterBuilder.cs" />
     <Compile Include="Migrations\Infrastructure\VersionedModel.cs" />
+    <Compile Include="Migrations\Model\AddOrUpdateOperation.cs" />
     <Compile Include="Migrations\Model\AlterProcedureOperation.cs" />
     <Compile Include="Migrations\Model\AlterTableOperation.cs" />
     <Compile Include="Migrations\Model\IAnnotationTarget.cs" />

--- a/src/EntityFramework/Migrations/DbMigration.cs
+++ b/src/EntityFramework/Migrations/DbMigration.cs
@@ -917,12 +917,39 @@ namespace System.Data.Entity.Migrations
         }
 
         /// <summary>
+        /// Adds an operation to upsert an row in an existing table
         /// 
+        /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+        /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+        /// before being passed to these APIs to protect against SQL injection attacks etc.
         /// </summary>
         /// <param name="table"></param>
-        /// <param name="identifier"></param>
-        /// <param name="columns"></param>
-        /// <param name="values"></param>
+        ///  The name of the table the row should be added or updated to. Schema name is optional, if no schema is specified
+        /// then dbo is assumed.
+        /// <param name="columns"> The name/s of the column/s that going to have data added or updated. </param>
+        /// <param name="values"> The value/s that going to be or updated. </param>
+        protected internal void AddOrUpdate(string table, string[] columns, object[] values)
+        {
+            Check.NotEmpty(table, "table");
+            Check.NotNull(columns, "columns");
+            Check.NotNull(values, "values");
+
+            AddOperation(new AddOrUpdateOperation(table, columns, values));
+        }
+
+        /// <summary>
+        /// Adds an operation to upsert an row in an existing table
+        /// 
+        /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+        /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+        /// before being passed to these APIs to protect against SQL injection attacks etc.
+        /// </summary>
+        /// <param name="table"></param>
+        ///  The name of the table the row should be added or updated to. Schema name is optional, if no schema is specified
+        /// then dbo is assumed.
+        /// <param name="identifier"> The name/s of the column/s that going to identiy if the column/s with the respective value exists. </param>
+        /// <param name="columns"> The name/s of the column/s that going to have data added or updated. </param>
+        /// <param name="values"> The value/s that going to be or updated. </param>
         protected internal void AddOrUpdate(string table, string[] identifier, string[] columns, object[] values)
         {
             Check.NotEmpty(table, "table");

--- a/src/EntityFramework/Migrations/DbMigration.cs
+++ b/src/EntityFramework/Migrations/DbMigration.cs
@@ -917,6 +917,23 @@ namespace System.Data.Entity.Migrations
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="table"></param>
+        /// <param name="identifier"></param>
+        /// <param name="columns"></param>
+        /// <param name="values"></param>
+        protected internal void AddOrUpdate(string table, string[] identifier, string[] columns, object[] values)
+        {
+            Check.NotEmpty(table, "table");
+            Check.NotNull(columns, "columns");
+            Check.NotNull(values, "values");
+            Check.NotNull(identifier, "identifier");
+
+            AddOperation(new AddOrUpdateOperation(table, identifier, columns, values));
+        }
+
+        /// <summary>
         /// Adds an operation to drop an existing column.
         ///
         /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 

--- a/src/EntityFramework/Migrations/DbMigration.cs
+++ b/src/EntityFramework/Migrations/DbMigration.cs
@@ -923,7 +923,7 @@ namespace System.Data.Entity.Migrations
         /// (such as the end user of an application). If input is accepted from such sources it should be validated 
         /// before being passed to these APIs to protect against SQL injection attacks etc.
         /// </summary>
-        /// <param name="table"></param>
+        /// <param name="table"> The name of the table the row should be added or updated to. </param>
         ///  The name of the table the row should be added or updated to. Schema name is optional, if no schema is specified
         /// then dbo is assumed.
         /// <param name="columns"> The name/s of the column/s that going to have data added or updated. </param>
@@ -944,7 +944,7 @@ namespace System.Data.Entity.Migrations
         /// (such as the end user of an application). If input is accepted from such sources it should be validated 
         /// before being passed to these APIs to protect against SQL injection attacks etc.
         /// </summary>
-        /// <param name="table"></param>
+        /// <param name="table"> The name of the table the row should be added or updated to. </param>
         ///  The name of the table the row should be added or updated to. Schema name is optional, if no schema is specified
         /// then dbo is assumed.
         /// <param name="identifier"> The name/s of the column/s that going to identiy if the column/s with the respective value exists. </param>
@@ -967,7 +967,7 @@ namespace System.Data.Entity.Migrations
         /// (such as the end user of an application). If input is accepted from such sources it should be validated 
         /// before being passed to these APIs to protect against SQL injection attacks etc.
         /// </summary>
-        /// <param name="table"></param>
+        /// <param name="table"> The name of the table the row should be deleteded from. </param>
         ///  The name of the table the row should be deleteded from. Schema name is optional, if no schema is specified
         /// then dbo is assumed.
         /// <param name="columns"> The name/s of the column/s that are going to identify the row be deleted. </param>

--- a/src/EntityFramework/Migrations/DbMigration.cs
+++ b/src/EntityFramework/Migrations/DbMigration.cs
@@ -961,6 +961,27 @@ namespace System.Data.Entity.Migrations
         }
 
         /// <summary>
+        /// Adds an operation to delete an row in an existing table
+        /// 
+        /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+        /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+        /// before being passed to these APIs to protect against SQL injection attacks etc.
+        /// </summary>
+        /// <param name="table"></param>
+        ///  The name of the table the row should be deleteded from. Schema name is optional, if no schema is specified
+        /// then dbo is assumed.
+        /// <param name="columns"> The name/s of the column/s that are going to identify the row be deleted. </param>
+        /// <param name="values"> The value/s that going to identify the row be deleted. </param>
+        protected internal void Delete(string table, string[] columns, object[][] values)
+        {
+            Check.NotEmpty(table, "table");
+            Check.NotNull(columns, "columns");
+            Check.NotNull(values, "values");
+
+            AddOperation(new DeleteOperation(table, columns, values));
+        }
+
+        /// <summary>
         /// Adds an operation to drop an existing column.
         ///
         /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 

--- a/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
+++ b/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
@@ -1,8 +1,6 @@
 ﻿namespace System.Data.Entity.Migrations.Model
 {
-    using System.Collections.Generic;
     using System.Data.Entity.Utilities;
-    using System.Linq;
 
     /// <summary>
     /// Represents a row being added or updated to a table.
@@ -14,9 +12,9 @@
     public class AddOrUpdateOperation : MigrationOperation
     {
         private readonly string _table;
-        private readonly List<string> _identifiers;
-        private readonly List<string> _columns;
-        private readonly List<object> _values;
+        private readonly string[] _identifiers;
+        private readonly string[] _columns;
+        private readonly object[] _values;
 
         /// <summary>
         /// Initializes a new instance of the AddorUpdateOperation class.
@@ -51,9 +49,9 @@
             Check.NotNull(identifiers, "identifiers");
 
             _table = table;
-            _columns = columns.ToList();
-            _values = values.ToList();
-            _identifiers = identifiers.ToList();
+            _columns = columns;
+            _values = values;
+            _identifiers = identifiers;
         }
         /// <summary>
         /// Gets the name of the table the row should be added or updated to.
@@ -66,7 +64,7 @@
         /// <summary>
         /// Gets the name/s of the column/s that going to have data added or updated. 
         /// </summary>
-        public IList<string> Columns
+        public string[] Columns
         {
             get { return _columns; }
         }
@@ -74,7 +72,7 @@
         /// <summary>
         /// Gets the value/s that going to be or updated.
         /// </summary>
-        public IList<object> Values
+        public object[] Values
         {
             get { return _values; }
         }
@@ -82,7 +80,7 @@
         /// <summary>
         /// Gets the name/s of the column/s that going to identiy if the column/s with the respective value exists.
         /// </summary>
-        public IList<string> Identifiers
+        public string[] Identifiers
         {
             get { return _identifiers; }
         }

--- a/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
+++ b/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
@@ -1,5 +1,6 @@
 ﻿namespace System.Data.Entity.Migrations.Model
 {
+    using System.Collections.Generic;
     using System.Data.Entity.Utilities;
 
     /// <summary>
@@ -12,9 +13,9 @@
     public class AddOrUpdateOperation : MigrationOperation
     {
         private readonly string _table;
-        private readonly string[] _identifiers;
-        private readonly string[] _columns;
-        private readonly object[] _values;
+        private readonly List<string> _identifiers;
+        private readonly List<string> _columns;
+        private readonly List<object> _values;
 
         /// <summary>
         /// Initializes a new instance of the AddorUpdateOperation class.
@@ -49,9 +50,9 @@
             Check.NotNull(identifiers, "identifiers");
 
             _table = table;
-            _columns = columns;
-            _values = values;
-            _identifiers = identifiers;
+            _columns = new List<string>(columns);
+            _values = new List<object>(values);
+            _identifiers = new List<string>(identifiers);
         }
         /// <summary>
         /// Gets the name of the table the row should be added or updated to.
@@ -64,7 +65,7 @@
         /// <summary>
         /// Gets the name/s of the column/s that going to have data added or updated. 
         /// </summary>
-        public string[] Columns
+        public IList<string> Columns
         {
             get { return _columns; }
         }
@@ -72,7 +73,7 @@
         /// <summary>
         /// Gets the value/s that going to be or updated.
         /// </summary>
-        public object[] Values
+        public IList<object> Values
         {
             get { return _values; }
         }
@@ -80,7 +81,7 @@
         /// <summary>
         /// Gets the name/s of the column/s that going to identiy if the column/s with the respective value exists.
         /// </summary>
-        public string[] Identifiers
+        public IList<string> Identifiers
         {
             get { return _identifiers; }
         }

--- a/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
+++ b/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
@@ -1,12 +1,15 @@
-﻿using System.Data.Entity.Utilities;
-
-namespace System.Data.Entity.Migrations.Model
+﻿namespace System.Data.Entity.Migrations.Model
 {
     using System.Collections.Generic;
+    using System.Data.Entity.Utilities;
     using System.Linq;
 
     /// <summary>
-    /// AddOrUpdateRowOperation
+    /// Represents a row being added or updated to a table.
+    ///
+    /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+    /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+    /// before being passed to these APIs to protect against SQL injection attacks etc.
     /// </summary>
     public class AddOrUpdateOperation : MigrationOperation
     {
@@ -16,12 +19,30 @@ namespace System.Data.Entity.Migrations.Model
         private readonly List<object> _values;
 
         /// <summary>
-        /// 
+        /// Initializes a new instance of the AddorUpdateOperation class.
+        ///
+        /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+        /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+        /// before being passed to these APIs to protect against SQL injection attacks etc.
         /// </summary>
-        /// <param name="table"></param>
-        /// <param name="identifiers"></param>
-        /// <param name="columns"></param>
-        /// <param name="values"></param>
+        /// <param name="table"> The name of the table the row should be added or updated to. </param>
+        /// <param name="columns"> The name/s of the column/s that going to have data added or updated. </param>
+        /// <param name="values"> The value/s that going to be or updated. </param>
+        public AddOrUpdateOperation(string table, string[] columns, object[] values) : this(table,new []{string.Empty}, columns, values)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AddorUpdateOperation class.
+        ///
+        /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+        /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+        /// before being passed to these APIs to protect against SQL injection attacks etc. 
+        /// </summary>
+        /// <param name="table"> The name of the table the row should be added or updated to. </param>
+        /// <param name="identifiers"> The name/s of the column/s that going to identiy if the column/s with the respective value exists. </param>
+        /// <param name="columns"> The name/s of the column/s that going to have data added or updated. </param>
+        /// <param name="values"> The value/s that going to be or updated. </param>
         public AddOrUpdateOperation(string table, string[] identifiers, string[] columns, object[] values) : base(null)
         {
             Check.NotEmpty(table, "table");
@@ -35,7 +56,7 @@ namespace System.Data.Entity.Migrations.Model
             _identifiers = identifiers.ToList();
         }
         /// <summary>
-        /// 
+        /// Gets the name of the table the row should be added or updated to.
         /// </summary>
         public string Table
         {
@@ -43,7 +64,7 @@ namespace System.Data.Entity.Migrations.Model
         }
 
         /// <summary>
-        /// 
+        /// Gets the name/s of the column/s that going to have data added or updated. 
         /// </summary>
         public IList<string> Columns
         {
@@ -51,7 +72,7 @@ namespace System.Data.Entity.Migrations.Model
         }
 
         /// <summary>
-        /// 
+        /// Gets the value/s that going to be or updated.
         /// </summary>
         public IList<object> Values
         {
@@ -59,11 +80,10 @@ namespace System.Data.Entity.Migrations.Model
         }
 
         /// <summary>
-        /// 
+        /// Gets the name/s of the column/s that going to identiy if the column/s with the respective value exists.
         /// </summary>
         public IList<string> Identifiers
         {
-
             get { return _identifiers; }
         }
         /// <summary>

--- a/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
+++ b/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
@@ -86,9 +86,8 @@
         {
             get { return _identifiers; }
         }
-        /// <summary>
-        /// 
-        /// </summary>
+
+        /// <inheritdoc />
         public override bool IsDestructiveChange
         {
             get { return false; }

--- a/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
+++ b/src/EntityFramework/Migrations/Model/AddOrUpdateOperation.cs
@@ -1,0 +1,77 @@
+﻿using System.Data.Entity.Utilities;
+
+namespace System.Data.Entity.Migrations.Model
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// AddOrUpdateRowOperation
+    /// </summary>
+    public class AddOrUpdateOperation : MigrationOperation
+    {
+        private readonly string _table;
+        private readonly List<string> _identifiers;
+        private readonly List<string> _columns;
+        private readonly List<object> _values;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="table"></param>
+        /// <param name="identifiers"></param>
+        /// <param name="columns"></param>
+        /// <param name="values"></param>
+        public AddOrUpdateOperation(string table, string[] identifiers, string[] columns, object[] values) : base(null)
+        {
+            Check.NotEmpty(table, "table");
+            Check.NotNull(columns, "columns");
+            Check.NotNull(values, "values");
+            Check.NotNull(identifiers, "identifiers");
+
+            _table = table;
+            _columns = columns.ToList();
+            _values = values.ToList();
+            _identifiers = identifiers.ToList();
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Table
+        {
+            get { return _table; }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IList<string> Columns
+        {
+            get { return _columns; }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IList<object> Values
+        {
+            get { return _values; }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IList<string> Identifiers
+        {
+
+            get { return _identifiers; }
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        public override bool IsDestructiveChange
+        {
+            get { return false; }
+        }
+    }
+}

--- a/src/EntityFramework/Migrations/Model/DeleteOperation.cs
+++ b/src/EntityFramework/Migrations/Model/DeleteOperation.cs
@@ -1,8 +1,6 @@
 ﻿namespace System.Data.Entity.Migrations.Model
 {
-    using System.Collections.Generic;
     using System.Data.Entity.Utilities;
-    using System.Linq;
 
     /// <summary>
     /// Represents a row being deleted from a table.
@@ -14,8 +12,8 @@
     public class DeleteOperation : MigrationOperation
     {
         private readonly string _table;
-        private readonly List<string> _columns;
-        private readonly List<IList<object>> _values;
+        private readonly string[] _columns;
+        private readonly object[][] _values;
 
         /// <summary>
         /// Initializes a new instance of the DeleteOperation class.
@@ -35,8 +33,8 @@
             Check.NotNull(values, "values");
 
             _table = table;
-            _columns = columns.ToList();
-            _values = values.Cast<IList<object>>().ToList();
+            _columns = columns;
+            _values = values;
         }
 
         /// <summary>
@@ -50,7 +48,7 @@
         /// <summary>
         /// Gets the name/s of the column/s that are going to identify the row be deleted. 
         /// </summary>
-        public IList<string> Columns
+        public string[] Columns
         {
             get { return _columns; }
         }
@@ -58,7 +56,7 @@
         /// <summary>
         /// Gets the value/s that going to identify the row be deleted.
         /// </summary>
-        public IList<IList<object>> Values
+        public object[][] Values
         {
             get { return _values; }
         }

--- a/src/EntityFramework/Migrations/Model/DeleteOperation.cs
+++ b/src/EntityFramework/Migrations/Model/DeleteOperation.cs
@@ -14,7 +14,7 @@
     {
         private readonly string _table;
         private readonly List<string> _columns;
-        private readonly object[][] _values;
+        private readonly List<object[]> _values;
 
         /// <summary>
         /// Initializes a new instance of the DeleteOperation class.
@@ -35,7 +35,7 @@
 
             _table = table;
             _columns = new List<string>(columns);
-            _values = values;
+            _values = new List<object[]>(values);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@
         /// <summary>
         /// Gets the value/s that going to identify the row be deleted.
         /// </summary>
-        public object[][] Values
+        public IList<object[]> Values
         {
             get { return _values; }
         }

--- a/src/EntityFramework/Migrations/Model/DeleteOperation.cs
+++ b/src/EntityFramework/Migrations/Model/DeleteOperation.cs
@@ -1,5 +1,6 @@
 ﻿namespace System.Data.Entity.Migrations.Model
 {
+    using System.Collections.Generic;
     using System.Data.Entity.Utilities;
 
     /// <summary>
@@ -12,7 +13,7 @@
     public class DeleteOperation : MigrationOperation
     {
         private readonly string _table;
-        private readonly string[] _columns;
+        private readonly List<string> _columns;
         private readonly object[][] _values;
 
         /// <summary>
@@ -33,7 +34,7 @@
             Check.NotNull(values, "values");
 
             _table = table;
-            _columns = columns;
+            _columns = new List<string>(columns);
             _values = values;
         }
 
@@ -48,7 +49,7 @@
         /// <summary>
         /// Gets the name/s of the column/s that are going to identify the row be deleted. 
         /// </summary>
-        public string[] Columns
+        public IList<string> Columns
         {
             get { return _columns; }
         }

--- a/src/EntityFramework/Migrations/Model/DeleteOperation.cs
+++ b/src/EntityFramework/Migrations/Model/DeleteOperation.cs
@@ -1,0 +1,69 @@
+﻿namespace System.Data.Entity.Migrations.Model
+{
+    using System.Collections.Generic;
+    using System.Data.Entity.Utilities;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents a row being deleted from a table.
+    ///
+    /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+    /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+    /// before being passed to these APIs to protect against SQL injection attacks etc.
+    /// </summary>
+    public class DeleteOperation : MigrationOperation
+    {
+        private readonly string _table;
+        private readonly List<string> _columns;
+        private readonly List<IList<object>> _values;
+
+        /// <summary>
+        /// Initializes a new instance of the DeleteOperation class.
+        ///
+        /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+        /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+        /// before being passed to these APIs to protect against SQL injection attacks etc. 
+        /// </summary>
+        /// <param name="table"> The name of the table the row should be deleteded from. </param>
+        /// <param name="columns"> The name/s of the column/s that are going to identify the row be deleted. </param>
+        /// <param name="values"> The value/s that going to identify the row be deleted. </param>
+        public DeleteOperation(string table, string[] columns, object[][] values)
+            : base(null)
+        {
+            Check.NotEmpty(table, "table");
+            Check.NotNull(columns, "columns");
+            Check.NotNull(values, "values");
+
+            _table = table;
+            _columns = columns.ToList();
+            _values = values.Cast<IList<object>>().ToList();
+        }
+
+        /// <summary>
+        /// Gets the name of the table the row should be deleteded from.
+        /// </summary>
+        public string Table
+        {
+            get { return _table; }
+        }
+
+        /// <summary>
+        /// Gets the name/s of the column/s that are going to identify the row be deleted. 
+        /// </summary>
+        public IList<string> Columns
+        {
+            get { return _columns; }
+        }
+
+        /// <summary>
+        /// Gets the value/s that going to identify the row be deleted.
+        /// </summary>
+        public IList<IList<object>> Values
+        {
+            get { return _values; }
+        }
+
+        /// <inheritdoc />
+        public override bool IsDestructiveChange { get { return false; } }
+    }
+}

--- a/test/EntityFramework/UnitTests/SqlServer/SqlServerMigrationSqlGeneratorTests.cs
+++ b/test/EntityFramework/UnitTests/SqlServer/SqlServerMigrationSqlGeneratorTests.cs
@@ -1675,5 +1675,49 @@ EXECUTE sp_rename @objname = N'dbo.__MigrationHistory2', @newname = N'__Migratio
             Assert.Equal(sqlExpected, sqlResult);
 
         }
+
+        [Fact]
+        public void Generate_add_or_update_with_no_identifiers_given_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo.boo";
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new object[] { "vA", "vB", 1 };
+
+            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, new []{""}, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo].[boo]') IS NOT NULL
+ INSERT INTO [foo].[boo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_add_or_update_with_no_identifiers_constructor_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo.boo";
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new object[] { "vA", "vB", 1 };
+
+            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo].[boo]') IS NOT NULL
+ INSERT INTO [foo].[boo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
     }
 }

--- a/test/EntityFramework/UnitTests/SqlServer/SqlServerMigrationSqlGeneratorTests.cs
+++ b/test/EntityFramework/UnitTests/SqlServer/SqlServerMigrationSqlGeneratorTests.cs
@@ -1719,5 +1719,109 @@ EXECUTE sp_rename @objname = N'dbo.__MigrationHistory2', @newname = N'__Migratio
             Assert.Equal(sqlExpected, sqlResult);
 
         }
+
+        [Fact]
+        public void Generate_delete_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo.boo";
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new [] {
+                    new object[] { "vA1" , "vA2"},
+                    new object[] { Guid.Parse("A093B257-2EA8-4216-B623-8A11DC199981")},
+                    new object[] { }
+                };
+
+            var addOrUpdateOperation = new DeleteOperation(tableName, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo].[boo]') IS NOT NULL
+ DELETE FROM [foo].[boo] WHERE ([cA] = 'vA1' OR [cA] = 'vA2') AND ([cB] = 'a093b257-2ea8-4216-b623-8a11dc199981')";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_delete_is_null_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo.boo";
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new[] {
+                    new object[] { "vA1" , "vA2"},
+                    new object[] { Guid.Parse("A093B257-2EA8-4216-B623-8A11DC199981")},
+                    new object[] { null }
+                };
+
+            var addOrUpdateOperation = new DeleteOperation(tableName, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo].[boo]') IS NOT NULL
+ DELETE FROM [foo].[boo] WHERE ([cA] = 'vA1' OR [cA] = 'vA2') AND ([cB] = 'a093b257-2ea8-4216-b623-8a11dc199981') AND ([cC] IS NULL)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_delete_is_null_and_with_values_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo.boo";
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new[] {
+                    new object[] { "vA1" , "vA2"},
+                    new object[] { Guid.Parse("A093B257-2EA8-4216-B623-8A11DC199981")},
+                    new object[] { null , 1}
+                };
+
+            var addOrUpdateOperation = new DeleteOperation(tableName, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo].[boo]') IS NOT NULL
+ DELETE FROM [foo].[boo] WHERE ([cA] = 'vA1' OR [cA] = 'vA2') AND ([cB] = 'a093b257-2ea8-4216-b623-8a11dc199981') AND ([cC] IS NULL OR [cC] = 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_delete_with_empty_values_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo.boo";
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new[] {
+                    new object[] { "vA1" , "vA2"},
+                    new object[] { },
+                    new object[] { null , 1}
+                };
+
+            var addOrUpdateOperation = new DeleteOperation(tableName, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo].[boo]') IS NOT NULL
+ DELETE FROM [foo].[boo] WHERE ([cA] = 'vA1' OR [cA] = 'vA2') AND ([cC] IS NULL OR [cC] = 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
     }
 }

--- a/test/EntityFramework/UnitTests/SqlServer/SqlServerMigrationSqlGeneratorTests.cs
+++ b/test/EntityFramework/UnitTests/SqlServer/SqlServerMigrationSqlGeneratorTests.cs
@@ -24,117 +24,6 @@ namespace System.Data.Entity.SqlServer
 
     public class SqlServerMigrationSqlGeneratorTests
     {
-
-        [Fact]
-        public void Generate_add_or_update_operation()
-        {
-            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
-
-            var tableName = "foo";
-            var identifiers = new [] { "cA" } ;
-            var columns = new[] { "cA", "cB", "cC" };
-            var values = new object[] { "vA", "vB", 1 };
-
-            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
-
-            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
-
-
-            var sqlExpected =
-                @"IF EXISTS (SELECT 1 FROM [foo] WHERE [cA] = 'vA') UPDATE [foo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' ELSE INSERT INTO [foo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
-
-            Assert.Equal(sqlExpected, sqlResult);
-
-        }
-
-        [Fact]
-        public void Generate_add_or_update_more_than_one_identifier_operation()
-        {
-            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
-
-            var tableName = "foo";
-            var identifiers = new[] { "cA", "cC" };
-            var columns = new[] { "cA", "cB", "cC" };
-            var values = new object[] { "vA", "vB", 1 };
-
-            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
-
-            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
-
-
-            var sqlExpected =
-                @"IF EXISTS (SELECT 1 FROM [foo] WHERE [cA] = 'vA' AND [cC] = 1) UPDATE [foo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' AND [cC] = 1 ELSE INSERT INTO [foo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
-
-            Assert.Equal(sqlExpected, sqlResult);
-
-        }
-
-        [Fact]
-        public void Generate_add_or_update_all_columns_as_identifiers_operation()
-        {
-            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
-
-            var tableName = "foo";
-            var identifiers = new[] { "cA", "cB", "cC" };
-            var columns = new[] { "cA", "cB", "cC" };
-            var values = new object[] { "vA", "vB", 1 };
-
-            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
-
-            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
-
-
-            var sqlExpected =
-                @"IF EXISTS (SELECT 1 FROM [foo] WHERE [cA] = 'vA' AND [cB] = 'vB' AND [cC] = 1) UPDATE [foo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' AND [cB] = 'vB' AND [cC] = 1 ELSE INSERT INTO [foo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
-
-            Assert.Equal(sqlExpected, sqlResult);
-
-        }
-
-        [Fact]
-        public void Generate_add_or_update_diferent_order_in_identifiers_columns_operation()
-        {
-            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
-
-            var tableName = "foo";
-            var identifiers = new[] { "cA", "cC", "cB" };
-            var columns = new[] { "cA", "cB", "cC" };
-            var values = new object[] { "vA", "vB", 1 };
-
-            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
-
-            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
-
-
-            var sqlExpected =
-                @"IF EXISTS (SELECT 1 FROM [foo] WHERE [cA] = 'vA' AND [cB] = 'vB' AND [cC] = 1) UPDATE [foo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' AND [cB] = 'vB' AND [cC] = 1 ELSE INSERT INTO [foo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
-
-            Assert.Equal(sqlExpected, sqlResult);
-
-        }
-
-        [Fact]
-        public void Generate_add_or_update_all_types_of_objects_operation()
-        {
-            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
-
-            var tableName = "foo";
-            var identifiers = new[] { "cString"};
-            var columns = new[] { "cString", "cBoolean", "cInt", "cLong", "cDate", "cGuid" };
-            var values = new object[] { "vString", true, 1, 2147483648, DateTime.Parse("2017-04-20T16:55:50.483+02:00"), Guid.Parse("17786656-5cc1-42a0-9a53-e6a8a2427d8b") };
-
-            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
-
-            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
-
-
-            var sqlExpected =
-                @"IF EXISTS (SELECT 1 FROM [foo] WHERE [cString] = 'vString') UPDATE [foo] SET [cString] = 'vString', [cBoolean] = 1, [cInt] = 1, [cLong] = 2147483648, [cDate] = '2017-04-20T16:55:50.483+02:00', [cGuid] = '17786656-5cc1-42a0-9a53-e6a8a2427d8b' WHERE [cString] = 'vString' ELSE INSERT INTO [foo]([cString], [cBoolean], [cInt], [cLong], [cDate], [cGuid]) VALUES ('vString', 1, 1, 2147483648, '2017-04-20T16:55:50.483+02:00', '17786656-5cc1-42a0-9a53-e6a8a2427d8b')";
-
-            Assert.Equal(sqlExpected, sqlResult);
-
-        }
-
         [Fact]
         public void Generate_can_handle_update_database_operations()
         {
@@ -1641,6 +1530,150 @@ EXECUTE sp_rename @objname = N'dbo.__MigrationHistory2', @newname = N'__Migratio
             Assert.Equal(
                 "writer",
                 Assert.Throws<ArgumentNullException>(() => generator.Generate(columnModel, null)).ParamName);
+        }
+
+        [Fact]
+        public void Generate_add_or_update_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo";
+            var identifiers = new[] { "cA" };
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new object[] { "vA", "vB", 1 };
+
+            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo]') IS NOT NULL
+ IF EXISTS (SELECT 1 FROM [foo] WHERE [cA] = 'vA') UPDATE [foo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' ELSE
+ INSERT INTO [foo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_add_or_update_more_than_one_identifier_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo";
+            var identifiers = new[] { "cA", "cC" };
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new object[] { "vA", "vB", 1 };
+
+            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo]') IS NOT NULL
+ IF EXISTS (SELECT 1 FROM [foo] WHERE [cA] = 'vA' AND [cC] = 1) UPDATE [foo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' AND [cC] = 1 ELSE
+ INSERT INTO [foo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_add_or_update_all_columns_as_identifiers_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo";
+            var identifiers = new[] { "cA", "cB", "cC" };
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new object[] { "vA", "vB", 1 };
+
+            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo]') IS NOT NULL
+ IF EXISTS (SELECT 1 FROM [foo] WHERE [cA] = 'vA' AND [cB] = 'vB' AND [cC] = 1) UPDATE [foo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' AND [cB] = 'vB' AND [cC] = 1 ELSE
+ INSERT INTO [foo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_add_or_update_diferent_order_in_identifiers_columns_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo";
+            var identifiers = new[] { "cA", "cC", "cB" };
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new object[] { "vA", "vB", 1 };
+
+            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo]') IS NOT NULL
+ IF EXISTS (SELECT 1 FROM [foo] WHERE [cA] = 'vA' AND [cB] = 'vB' AND [cC] = 1) UPDATE [foo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' AND [cB] = 'vB' AND [cC] = 1 ELSE
+ INSERT INTO [foo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_add_or_update_all_types_of_objects_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo";
+            var identifiers = new[] { "cString" };
+            var columns = new[] { "cString", "cBoolean", "cInt", "cLong", "cDate", "cGuid" };
+            var values = new object[] { "vString", true, 1, 2147483648, DateTime.Parse("2017-04-20T16:55:50.483+02:00"), Guid.Parse("17786656-5cc1-42a0-9a53-e6a8a2427d8b") };
+
+            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo]') IS NOT NULL
+ IF EXISTS (SELECT 1 FROM [foo] WHERE [cString] = 'vString') UPDATE [foo] SET [cString] = 'vString', [cBoolean] = 1, [cInt] = 1, [cLong] = 2147483648, [cDate] = '2017-04-20T16:55:50.483+02:00', [cGuid] = '17786656-5cc1-42a0-9a53-e6a8a2427d8b' WHERE [cString] = 'vString' ELSE
+ INSERT INTO [foo]([cString], [cBoolean], [cInt], [cLong], [cDate], [cGuid]) VALUES ('vString', 1, 1, 2147483648, '2017-04-20T16:55:50.483+02:00', '17786656-5cc1-42a0-9a53-e6a8a2427d8b')";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
+        }
+
+        [Fact]
+        public void Generate_add_or_update_all_types_of_objects_with_schema_name_operation()
+        {
+            var migrationSqlGenerator = new SqlServerMigrationSqlGenerator();
+
+            var tableName = "foo.boo";
+            var identifiers = new[] { "cA" };
+            var columns = new[] { "cA", "cB", "cC" };
+            var values = new object[] { "vA", "vB", 1 };
+
+            var addOrUpdateOperation = new AddOrUpdateOperation(tableName, identifiers, columns, values);
+
+            var sqlResult = migrationSqlGenerator.Generate(new[] { addOrUpdateOperation }, "2008").Join(s => s.Sql, Environment.NewLine);
+
+
+            var sqlExpected =
+                @"IF object_id('[foo].[boo]') IS NOT NULL
+ IF EXISTS (SELECT 1 FROM [foo].[boo] WHERE [cA] = 'vA') UPDATE [foo].[boo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' ELSE
+ INSERT INTO [foo].[boo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)";
+
+            Assert.Equal(sqlExpected, sqlResult);
+
         }
     }
 }


### PR DESCRIPTION
Implementation of operations AddOrUpdate and Delete in order to be able to upsert and delete data on tables while migrating. 
This pull request comes form a another issue [#221](https://github.com/aspnet/EntityFramework6/issues/221) where a discussion has placed and a previous implementation was discarded and resulting in this new implementation has originally suggested by @tinchou.

The work done in this pull request allows to have data manipulation as part of the migration. The operations are not bound to the model CLR types, so previous migrations will not break. 
This means that the data manipulation can be added to the migrations and implemented in SQL. 

The work done in this pull request is based in the work of @tinchou  for EF Core described in: [ aspnet/EntityFramework#629 (comment)](https://github.com/aspnet/EntityFramework/issues/629#issuecomment-282368487)

Examples of usage:

AddOrUpdate with identifier columns
```
// Migration
AddOrUpdate("foo.boo", new[] { "cA" }, new[] { "cA", "cB", "cC"}, new object[] { "vA", "vB", 1 });
// SQL generated
"IF object_id('[foo].[boo]') IS NOT NULL
 IF EXISTS (SELECT 1 FROM [foo].[boo] WHERE [cA] = 'vA') UPDATE [foo].[boo] SET [cA] = 'vA', [cB] = 'vB', [cC] = 1 WHERE [cA] = 'vA' ELSE
 INSERT INTO [foo].[boo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)"
```

AddOrUpdate with no identifier columns
```
// Migration
AddOrUpdate("foo.boo", new[] { "cA", "cB", "cC"}, new object[] { "vA", "vB", 1 });
// SQL generated
"IF object_id('[foo].[boo]') IS NOT NULL
 INSERT INTO [foo].[boo]([cA], [cB], [cC]) VALUES ('vA', 'vB', 1)"
```

Delete
```
// Migration
Delete("foo.boo",new[] { "cA", "cB", "cC" }, new [] { new object[] { "vA1" , "vA2"}, new object[] { 2 },  new object[] { } });
// SQL generated
"IF object_id('[foo].[boo]') IS NOT NULL
 DELETE FROM [foo].[boo] WHERE ([cA] = 'vA1' OR [cA] = 'vA2') AND ([cB] = 2)"
```
