### PR TITLE
Possible null dereference fix

### DIFF
--- a/src/EntityFramework/Core/Mapping/ObjectTypeMapping.cs
+++ b/src/EntityFramework/Core/Mapping/ObjectTypeMapping.cs
@@ -96,10 +96,9 @@ namespace System.Data.Entity.Core.Mapping
         {
             var memberMapping = GetMemberMap(propertyName, false /*ignoreCase*/);
 
-            if (memberMapping != null &&
-                memberMapping.MemberMappingKind == MemberMappingKind.ScalarPropertyMapping
+            if (memberMapping?.MemberMappingKind == MemberMappingKind.ScalarPropertyMapping
                 ||
-                memberMapping.MemberMappingKind == MemberMappingKind.ComplexPropertyMapping)
+                memberMapping?.MemberMappingKind == MemberMappingKind.ComplexPropertyMapping)
             {
                 return (ObjectPropertyMapping)memberMapping;
             }


### PR DESCRIPTION
If first condition is false, second one can cause NullReferenceException