### PR TITLE
Add support for accessing Set<T> method from derived dbcontext

### DIFF
--- a/test/EntityFramework/FunctionalTests/ProductivityApi/LinqTests.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/LinqTests.cs
@@ -12422,6 +12422,33 @@ namespace ProductivityApiTests
             }
         }
 
+        [Fact]
+        public void Context_gets_properly_retrieved_from_expression_WhenUsingDerivedDbContext()
+        {
+            using (var context = new DerivedDbContextUsage())
+            {
+                var result = context.ExecuteProductsQuery().Result;
+                Assert.Equal(16, result.Count);
+            }
+        }
+
+        private class DerivedDbContextUsage : SimpleModelContext
+        {
+            public DerivedDbContextUsage() : base("EntityConnectionForSimpleModel")
+            {}
+
+            public async Task<List<Category>> ExecuteProductsQuery()
+            {
+                var queryOption = SampleEnumGitHub20.Value1;
+                int[] ids = { 1, 2, 3, 4 };
+                return await (from product in Set<Product>()
+                              where ids.Contains(product.Id)
+                                 && queryOption == SampleEnumGitHub20.Value1
+                              from category in Set<Category>()
+                              select category).ToListAsync();
+            }
+        }
+
         public enum SampleEnumGitHub20
         {
             Value1,


### PR DESCRIPTION
Add support for accessing Set<T> methods from derived dbcontext so that all queries work properly in linqpad.
For example the usage of `Set<Category>` in the following query fails in linqpad atm:

```csharp
var queryOption = SampleEnumGitHub20.Value1;
int[] ids = { 1, 2, 3, 4 };
return await (from product in Set<Product>()
   where ids.Contains(product.Id)
       && queryOption == SampleEnumGitHub20.Value1
    from category in Set<Category>() // 
    select category).ToListAsync();
```

Current exception:

> LINQ to Entities does not recognize the method 'System.Data.Entity.DbSet`1[SimpleModel.Category] Set[Category]()' method, and this method cannot be translated into a store expression.

This PR is related to https://github.com/aspnet/EntityFramework6/issues/20 although I do not know if this worked in VS 2013.