### PR TITLE
Fixed a small typo in resources

### DIFF
--- a/src/EntityFramework/Properties/Resources.cs
+++ b/src/EntityFramework/Properties/Resources.cs
@@ -223,7 +223,7 @@ namespace System.Data.Entity.Resources
         }
 
         // <summary>
-        // A string like "The migrations configuration type '{0}' was not be found in the assembly '{1}'."
+        // A string like "The migrations configuration type '{0}' was not found in the assembly '{1}'."
         // </summary>
         internal static string AssemblyMigrator_NoConfigurationWithName(object p0, object p1)
         {
@@ -14141,7 +14141,7 @@ namespace System.Data.Entity.Resources
         }
 
         // <summary>
-        // Migrations.Infrastructure.MigrationsException with message like "The migrations configuration type '{0}' was not be found in the assembly '{1}'."
+        // Migrations.Infrastructure.MigrationsException with message like "The migrations configuration type '{0}' was not found in the assembly '{1}'."
         // </summary>
         internal static Exception AssemblyMigrator_NoConfigurationWithName(object p0, object p1)
         {

--- a/src/EntityFramework/Properties/Resources.resx
+++ b/src/EntityFramework/Properties/Resources.resx
@@ -206,7 +206,7 @@
     <comment>## ExceptionType=Migrations.Infrastructure.MigrationsException</comment>
   </data>
   <data name="AssemblyMigrator_NoConfigurationWithName" xml:space="preserve">
-    <value>The migrations configuration type '{0}' was not be found in the assembly '{1}'.</value>
+    <value>The migrations configuration type '{0}' was not found in the assembly '{1}'.</value>
     <comment>## ExceptionType=Migrations.Infrastructure.MigrationsException</comment>
   </data>
   <data name="AssemblyMigrator_MultipleConfigurationsWithName" xml:space="preserve">


### PR DESCRIPTION
When **migrate.exe** tool is executed with a configuration type argument specified, but this type cannot be found in the migrations assembly, the error message is shown which contains a small typo:
*ERROR: The migrations configuration type 'foo' **was not be found** in the assembly 'MigrationsAssemblyName'*

This change fixes the error text to match similar messages.