### PR TITLE
Fix comment to prevent confusion.

### DIFF
--- a/src/EntityFramework/Migrations/Utilities/IndentedTextWriter.cs
+++ b/src/EntityFramework/Migrations/Utilities/IndentedTextWriter.cs
@@ -171,7 +171,7 @@ namespace System.Data.Entity.Migrations.Utilities
                 return _tabString;
             }
 
-            // Since _indentLevel is known > 2, we can safely subtract two to index the list
+            // Since _indentLevel is known >= 2, we can safely subtract two to index the list
             var cacheIndex = _indentLevel - 2;
             var cached = cacheIndex < _cachedIndents.Count ? _cachedIndents[cacheIndex] : null;
 


### PR DESCRIPTION
Since `_indentLevel` is checked for equivalency to 0 and 1, it is know that it is greater than or equal to 2 not just greater than 2.