### PR TITLE
HierarchyId support #339

### DIFF
--- a/src/Common/TypeExtensions.cs
+++ b/src/Common/TypeExtensions.cs
@@ -12,6 +12,7 @@ namespace System.Data.Entity.Utilities
     using System.Data.Entity.Core;
     using System.Data.Entity.Core.Metadata.Edm;
     using System.Data.Entity.Core.Objects.DataClasses;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Resources;
     using System.Data.Entity.Spatial;
     using System.Diagnostics;
@@ -181,7 +182,8 @@ namespace System.Data.Entity.Utilities
                      || type.IsArray
                      || type == typeof(string)
                      || type == typeof(DbGeography)
-                     || type == typeof(DbGeometry))
+                     || type == typeof(DbGeometry)
+                     || type == typeof(HierarchyId))
                    && type.IsValidStructuralPropertyType();
         }
 

--- a/src/EFTools/EntityDesignerVersioningFacade/LegacyProviderWrapper/LegacyDbProviderManifestWrapper.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/LegacyProviderWrapper/LegacyDbProviderManifestWrapper.cs
@@ -379,6 +379,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.LegacyProviderWrapper
                 case PrimitiveTypeKind.Guid:
                 case PrimitiveTypeKind.Double:
                 case PrimitiveTypeKind.Single:
+                case PrimitiveTypeKind.HierarchyId:
                 case PrimitiveTypeKind.Geography:
                 case PrimitiveTypeKind.GeographyPoint:
                 case PrimitiveTypeKind.GeographyLineString:

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/StoreModelBuilder.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/StoreModelBuilder.cs
@@ -932,7 +932,8 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb
                 && _nameToEdmType.TryGetValue(typeName, out storeType))
             {
                 if ((storeType.PrimitiveTypeKind == PrimitiveTypeKind.Geography ||
-                     storeType.PrimitiveTypeKind == PrimitiveTypeKind.Geometry)
+                     storeType.PrimitiveTypeKind == PrimitiveTypeKind.Geometry ||
+                     storeType.PrimitiveTypeKind == PrimitiveTypeKind.HierarchyId)
                     && _targetEntityFrameworkVersion < EntityFrameworkVersion.Version3)
                 {
                     excludedForVersion = true;

--- a/src/EFTools/setup/EFToolsMsi/XmlSchemas/System.Data.Resources.CSDLSchema_3.xsd
+++ b/src/EFTools/setup/EFToolsMsi/XmlSchemas/System.Data.Resources.CSDLSchema_3.xsd
@@ -61,6 +61,7 @@
       <xs:enumeration value="GeometricMultiPolygon" />
       <xs:enumeration value="GeometryCollection" />
       <xs:enumeration value="Guid" />
+      <xs:enumeration value="HierarchyId" />
       <xs:enumeration value="Int16" />
       <xs:enumeration value="Int32" />
       <xs:enumeration value="Int64" />

--- a/src/EFTools/setup/EFToolsMsi/XmlSchemas/System.Data.Resources.ProviderServices.ProviderManifest.xsd
+++ b/src/EFTools/setup/EFToolsMsi/XmlSchemas/System.Data.Resources.ProviderServices.ProviderManifest.xsd
@@ -118,6 +118,7 @@
       <xs:enumeration value="Time"/>
       <xs:enumeration value="DateTimeOffset"/>        
       <xs:enumeration value="Double"/>
+      <xs:enumeration value="HierarchyId"/>
       <!--- TODO: Spatial: only support the union types here for now.   Once we deeply understand the full heirarchy, we'll have to beef this up. -->
       <xs:enumeration value="Geography"/>
       <xs:enumeration value="Geometry"/>

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -126,6 +126,7 @@
     <Compile Include="SqlGen\BoolWrapper.cs" />
     <Compile Include="SqlGen\DmlFunctionSqlGenerator.cs" />
     <Compile Include="SqlGen\DmlSqlGenerator.cs" />
+    <Compile Include="SqlHierarchyIdFunctions.cs" />
     <Compile Include="SqlGen\SqlStringBuilder.cs" />
     <Compile Include="SqlGen\SkipClause.cs" />
     <Compile Include="SqlServerMigrationSqlGenerator.cs" />

--- a/src/EntityFramework.SqlServer/Resources/System/Data/SqlClient/System.Data.Resources.SqlClient.SqlProviderServices.ProviderManifest.xml
+++ b/src/EntityFramework.SqlServer/Resources/System/Data/SqlClient/System.Data.Resources.SqlClient.SqlProviderServices.ProviderManifest.xml
@@ -164,6 +164,7 @@ PROCESS
             </FacetDescriptions>
         </Type>
         <Type Name="uniqueidentifier" PrimitiveTypeKind="Guid"></Type>
+        <Type Name="hierarchyid" PrimitiveTypeKind="HierarchyId"></Type>
         <Type Name="xml" PrimitiveTypeKind="String">
             <FacetDescriptions>
                 <MaxLength DefaultValue="1073741823" Constant="true" />
@@ -1698,6 +1699,41 @@ PROCESS
         <Function Name="ISDATE" BuiltIn="true">
             <ReturnType Type="Int32" />
             <Parameter Name="arg" Type="String" Mode="In" />
+        </Function>
+
+        <!-- HierarchyId Functions -->
+        <Function Name="GetAncestor" BuiltIn="true">
+            <ReturnType Type="HierarchyId" />
+            <Parameter Name="hierarchyIdValue" Type="HierarchyId" Mode="In" />
+            <Parameter Name="n" Type="Int32" Mode="In" />
+        </Function>
+        <Function Name="GetDescendant" BuiltIn="true">
+            <ReturnType Type="HierarchyId" />
+            <Parameter Name="hierarchyIdValue" Type="HierarchyId" Mode="In" />
+            <Parameter Name="child1" Type="HierarchyId" Mode="In" />
+            <Parameter Name="child2" Type="HierarchyId" Mode="In" />
+        </Function>
+        <Function Name="GetLevel" BuiltIn="true">
+            <ReturnType Type="Int16" />
+            <Parameter Name="hierarchyIdValue" Type="HierarchyId" Mode="In" />
+        </Function>
+        <Function Name="GetRoot" BuiltIn="true">
+            <ReturnType Type="HierarchyId" />
+        </Function>
+        <Function Name="IsDescendantOf" BuiltIn="true">
+            <ReturnType Type="Boolean" />
+            <Parameter Name="hierarchyIdValue" Type="HierarchyId" Mode="In" />
+            <Parameter Name="parent" Type="HierarchyId" Mode="In" />
+        </Function>
+        <Function Name="GetReparentedValue" BuiltIn="true">
+            <ReturnType Type="HierarchyId" />
+            <Parameter Name="hierarchyIdValue" Type="HierarchyId" Mode="In" />
+            <Parameter Name="oldRoot" Type="HierarchyId" Mode="In" />
+            <Parameter Name="newRoot" Type="HierarchyId" Mode="In" />
+        </Function>
+        <Function Name="Parse" BuiltIn="true">
+            <ReturnType Type="HierarchyId" />
+            <Parameter Name="input" Type="String" Mode="In" />
         </Function>
 
         <!-- Spatial Functions -->

--- a/src/EntityFramework.SqlServer/SqlGen/SqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlGen/SqlGenerator.cs
@@ -8,6 +8,7 @@ namespace System.Data.Entity.SqlServer.SqlGen
     using System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder;
     using System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder.Spatial;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Spatial;
     using System.Data.Entity.SqlServer.Resources;
     using System.Data.Entity.SqlServer.Utilities;
@@ -963,6 +964,10 @@ namespace System.Data.Entity.SqlServer.SqlGen
                         WrapWithCastIfNeeded(true, EscapeSingleQuote(e.Value.ToString(), false /* IsUnicode */), "uniqueidentifier", result);
                         break;
 
+                    case PrimitiveTypeKind.HierarchyId:
+                        AppendHierarchyConstant(result, (HierarchyId)e.Value);
+                        break;
+
                     case PrimitiveTypeKind.Int16:
                         WrapWithCastIfNeeded(!isCastOptional, e.Value.ToString(), "smallint", result);
                         break;
@@ -1004,6 +1009,16 @@ namespace System.Data.Entity.SqlServer.SqlGen
             }
 
             return result;
+        }
+
+        private static void AppendHierarchyConstant(SqlBuilder result, HierarchyId hierarchyId)
+        {
+            DebugCheck.NotNull(result);
+            DebugCheck.NotNull(hierarchyId);
+
+            result.Append("cast(");
+            result.Append(EscapeSingleQuote(hierarchyId.ToString(), false /* IsUnicode */));
+            result.Append(" as hierarchyid)");
         }
 
         private void AppendSpatialConstant(SqlBuilder result, IDbSpatialValue spatialValue)

--- a/src/EntityFramework.SqlServer/SqlHierarchyIdFunctions.cs
+++ b/src/EntityFramework.SqlServer/SqlHierarchyIdFunctions.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.SqlServer
+{
+    using System.Data.Entity.SqlServer.Resources;
+    using System.Data.Entity.Hierarchy;
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Contains function stubs that expose SqlServer methods in Linq to Entities.
+    /// </summary>
+    public static class SqlHierarchyIdFunctions
+    {
+        /// <summary>Returns a hierarchyid representing the nth ancestor of this.</summary>
+        /// <returns>A hierarchyid representing the nth ancestor of this.</returns>
+        /// <param name="hierarchyIdValue">The hierarchyid value.</param>
+        /// <param name="n">n</param>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "hierarchyIdValue")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "n")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "n")]
+        [DbFunction("SqlServer", "GetAncestor")]
+        public static HierarchyId GetAncestor(HierarchyId hierarchyIdValue, int n)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>Returns a child node of the parent.</summary>
+        /// <param name="hierarchyIdValue">The hierarchyid value.</param>
+        /// <param name="child1"> null or the hierarchyid of a child of the current node. </param>
+        /// <param name="child2"> null or the hierarchyid of a child of the current node. </param>
+        /// <returns>
+        /// Returns one child node that is a descendant of the parent.
+        /// If parent is null, returns null.
+        /// If parent is not null, and both child1 and child2 are null, returns a child of parent.
+        /// If parent and child1 are not null, and child2 is null, returns a child of parent greater than child1.
+        /// If parent and child2 are not null and child1 is null, returns a child of parent less than child2.
+        /// If parent, child1, and child2 are not null, returns a child of parent greater than child1 and less than child2.
+        /// If child1 is not null and not a child of parent, an exception is raised.
+        /// If child2 is not null and not a child of parent, an exception is raised.
+        /// If child1 >= child2, an exception is raised.
+        /// </returns>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "hierarchyIdValue")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "child1")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "child2")]
+        [DbFunction("SqlServer", "GetDescendant")]
+        public static HierarchyId GetDescendant(HierarchyId hierarchyIdValue, HierarchyId child1, HierarchyId child2)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>Returns an integer that represents the depth of the node this in the tree.</summary>
+        /// <returns>An integer that represents the depth of the node this in the tree.</returns>
+        /// <param name="hierarchyIdValue">The hierarchyid value.</param>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "hierarchyIdValue")]
+        [DbFunction("SqlServer", "GetLevel")]
+        public static short GetLevel(HierarchyId hierarchyIdValue)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>Returns the root of the hierarchy tree.</summary>
+        /// <returns>The root of the hierarchy tree.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [DbFunction("SqlServer", "GetRoot")]
+        public static HierarchyId GetRoot()
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>Returns true if this is a descendant of parent.</summary>
+        /// <returns>True if this is a descendant of parent.</returns>
+        /// <param name="hierarchyIdValue">The hierarchyid value.</param>
+        /// <param name="parent">parent</param>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "hierarchyIdValue")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "parent")]
+        [DbFunction("SqlServer", "IsDescendantOf")]
+        public static bool IsDescendantOf(HierarchyId hierarchyIdValue, HierarchyId parent)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>Returns a node whose path from the root is the path to newRoot, followed by the path from oldRoot to this.</summary>
+        /// <returns>Hierarchyid value.</returns>
+        /// <param name="hierarchyIdValue">The hierarchyid value.</param>
+        /// <param name="oldRoot">oldRoot</param>
+        /// <param name="newRoot">newRoot</param>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "hierarchyIdValue")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "oldRoot")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "newRoot")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Reparented")]
+        [DbFunction("SqlServer", "GetReparentedValue")]
+        public static HierarchyId GetReparentedValue(HierarchyId hierarchyIdValue, HierarchyId oldRoot, HierarchyId newRoot)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+
+        /// <summary>Converts the canonical string representation of a hierarchyid to a hierarchyid value.</summary>
+        /// <returns>Hierarchyid value.</returns>
+        /// <param name="input">input</param>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "input")]
+        [DbFunction("SqlServer", "Parse")]
+        public static HierarchyId Parse(string input)
+        {
+            throw new NotSupportedException(Strings.ELinq_DbFunctionDirectCall);
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/SqlProviderManifest.cs
+++ b/src/EntityFramework.SqlServer/SqlProviderManifest.cs
@@ -84,6 +84,7 @@ namespace System.Data.Entity.SqlServer
                                          primitiveType.Name.Equals("date", StringComparison.OrdinalIgnoreCase) ||
                                          primitiveType.Name.Equals("datetime2", StringComparison.OrdinalIgnoreCase) ||
                                          primitiveType.Name.Equals("datetimeoffset", StringComparison.OrdinalIgnoreCase) ||
+                                         primitiveType.Name.Equals("hierarchyid", StringComparison.OrdinalIgnoreCase) ||
                                          primitiveType.Name.Equals("geography", StringComparison.OrdinalIgnoreCase) ||
                                          primitiveType.Name.Equals("geometry", StringComparison.OrdinalIgnoreCase)
                         );
@@ -364,6 +365,7 @@ namespace System.Data.Entity.SqlServer
                 case "bigint":
                 case "bit":
                 case "uniqueidentifier":
+                case "hierarchyid":
                 case "int":
                 case "geography":
                 case "geometry":
@@ -566,6 +568,9 @@ namespace System.Data.Entity.SqlServer
 
                 case PrimitiveTypeKind.Guid:
                     return TypeUsage.CreateDefaultTypeUsage(StoreTypeNameToStorePrimitiveType["uniqueidentifier"]);
+
+                case PrimitiveTypeKind.HierarchyId:
+                    return TypeUsage.CreateDefaultTypeUsage(StoreTypeNameToStorePrimitiveType["hierarchyid"]);
 
                 case PrimitiveTypeKind.Double:
                     return TypeUsage.CreateDefaultTypeUsage(StoreTypeNameToStorePrimitiveType["float"]);

--- a/src/EntityFramework.SqlServer/SqlProviderServices.cs
+++ b/src/EntityFramework.SqlServer/SqlProviderServices.cs
@@ -9,6 +9,7 @@ namespace System.Data.Entity.SqlServer
     using System.Data.Entity.Core.Common;
     using System.Data.Entity.Core.Common.CommandTrees;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Infrastructure;
     using System.Data.Entity.Infrastructure.DependencyResolution;
     using System.Data.Entity.Infrastructure.Interception;
@@ -677,6 +678,14 @@ namespace System.Data.Entity.SqlServer
                     {
                         value = SqlTypesAssemblyLoader.DefaultInstance.GetSqlTypesAssembly().ConvertToSqlTypesGeometry(geometryValue);
                     }
+                    else
+                    {
+                        var hierarchyIdValue = value as HierarchyId;
+                        if (hierarchyIdValue != null)
+                        {
+                            value = SqlTypesAssemblyLoader.DefaultInstance.GetSqlTypesAssembly().ConvertToSqlTypesHierarchyId(hierarchyIdValue);
+                        }
+                    }
                 }
             }
 
@@ -760,6 +769,12 @@ namespace System.Data.Entity.SqlServer
 
                 case PrimitiveTypeKind.Guid:
                     return SqlDbType.UniqueIdentifier;
+
+                case PrimitiveTypeKind.HierarchyId:
+                    {
+                        udtName = "hierarchyid";
+                        return SqlDbType.Udt;
+                    }
 
                 case PrimitiveTypeKind.Int16:
                     return SqlDbType.SmallInt;

--- a/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrationSqlGenerator.cs
@@ -7,6 +7,7 @@ namespace System.Data.Entity.SqlServer
     using System.Data.Entity.Core.Common;
     using System.Data.Entity.Core.Common.CommandTrees;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Infrastructure.DependencyResolution;
     using System.Data.Entity.Migrations.History;
     using System.Data.Entity.Migrations.Model;
@@ -1292,6 +1293,17 @@ namespace System.Data.Entity.SqlServer
         protected virtual string Generate(TimeSpan defaultValue)
         {
             return "'" + defaultValue + "'";
+        }
+
+        /// <summary>
+        /// Generates SQL to specify a constant hierarchyid default value being set on a column.
+        /// This method just generates the actual value, not the SQL to set the default value.
+        /// </summary>
+        /// <param name="defaultValue"> The value to be set. </param>
+        /// <returns> SQL representing the default value. </returns>
+        protected virtual string Generate(HierarchyId defaultValue)
+        {
+            return "cast('" + defaultValue + "' as hierarchyid)";
         }
 
         /// <summary>

--- a/src/EntityFramework.SqlServer/Utilities/PrimitiveTypeExtensions.cs
+++ b/src/EntityFramework.SqlServer/Utilities/PrimitiveTypeExtensions.cs
@@ -14,5 +14,14 @@ namespace System.Data.Entity.SqlServer.Utilities
 
             return kind >= PrimitiveTypeKind.Geometry && kind <= PrimitiveTypeKind.GeographyCollection;
         }
+
+        internal static bool IsHierarchyIdType(this PrimitiveType type)
+        {
+            DebugCheck.NotNull(type);
+
+            var kind = type.PrimitiveTypeKind;
+
+            return kind == PrimitiveTypeKind.HierarchyId;
+        }
     }
 }

--- a/src/EntityFramework.SqlServer/Utilities/TypeUsageExtensions.cs
+++ b/src/EntityFramework.SqlServer/Utilities/TypeUsageExtensions.cs
@@ -190,6 +190,13 @@ namespace System.Data.Entity.SqlServer.Utilities
             return ((PrimitiveType)type.EdmType).FacetDescriptions.Single(f => f.FacetName == facetName).IsConstant;
         }
 
+        internal static bool IsHierarchyIdType(this TypeUsage type)
+        {
+            DebugCheck.NotNull(type);
+
+            return (type.EdmType.BuiltInTypeKind == BuiltInTypeKind.PrimitiveType && ((PrimitiveType)type.EdmType).IsHierarchyIdType());
+        }
+
         internal static bool IsSpatialType(this TypeUsage type)
         {
             DebugCheck.NotNull(type);

--- a/src/EntityFramework/Core/Common/CommandTrees/ExpressionBuilder/Hierarchy/HierarchyIdEdmFunctions.cs
+++ b/src/EntityFramework/Core/Common/CommandTrees/ExpressionBuilder/Hierarchy/HierarchyIdEdmFunctions.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder.Hierarchy
+{
+    using System.Data.Entity.Utilities;
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    ///     Provides an API to construct <see cref="T:System.Data.Entity.Core.Common.CommandTrees.DbExpression" />s that invoke hierarchyid realted canonical EDM functions, and, where appropriate, allows that API to be accessed as extension methods on the expression type itself.
+    /// </summary>
+    public static class HierarchyIdEdmFunctions
+    {
+        // HierarchyId ‘Static’ Functions
+
+        /// <summary>
+        ///     Creates a <see cref="DbFunctionExpression" /> that invokes the canonical 'HierarchyIdParse' function with the
+        ///     specified argument, which must have a string result type.
+        ///     The result type of the expression is Edm.HierarchyId.
+        /// </summary>
+        /// <param name="input"> An expression that provides the canonical representation of the hierarchyid value. </param>
+        /// <returns> A new DbFunctionExpression that returns a new hierarchyid value based on the specified value. </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="input" />
+        ///     is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     No overload of the canonical 'HierarchyIdParse' function accept an argument with the result type of
+        ///     <paramref name="input" />
+        ///     .
+        /// </exception>
+        public static DbFunctionExpression HierarchyIdParse(DbExpression input)
+        {
+            Check.NotNull(input, "input");
+            return EdmFunctions.InvokeCanonicalFunction("HierarchyIdParse", input);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="DbFunctionExpression" /> that invokes the canonical 'HierarchyIdGetRoot' function.
+        ///     The result type of the expression is Edm.HierarchyId.
+        /// </summary>
+        /// <returns> A new DbFunctionExpression that returns a new root hierarchyid value. </returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        public static DbFunctionExpression HierarchyIdGetRoot()
+        {
+            return EdmFunctions.InvokeCanonicalFunction("HierarchyIdGetRoot");
+        }
+
+        // HierarchyId ‘Instance’ Functions
+
+        /// <summary>
+        ///     Creates a <see cref="DbFunctionExpression" /> that invokes the canonical 'GetAncestor' function with the
+        ///     specified argument, which must have an Int32 result type.
+        ///     The result type of the expression is Edm.HierarchyId.
+        /// </summary>
+        /// <param name="hierarchyIdValue"> An expression that specifies the hierarchyid value. </param>
+        /// <param name="n"> An expression that provides an integer value. </param>
+        /// <returns> A new DbFunctionExpression that returns a hierarchyid. </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="hierarchyIdValue" />
+        ///     or
+        ///     <paramref name="n" />
+        ///     is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     No overload of the canonical 'GetAncestor' function accept an argument with the result type of
+        ///     <paramref name="n" />
+        ///     .
+        /// </exception>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "n")]
+        public static DbFunctionExpression GetAncestor(this DbExpression hierarchyIdValue, DbExpression n)
+        {
+            Check.NotNull(hierarchyIdValue, "hierarchyIdValue");
+            Check.NotNull(n, "n");
+            return EdmFunctions.InvokeCanonicalFunction("GetAncestor", hierarchyIdValue, n);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="DbFunctionExpression" /> that invokes the canonical 'GetDescendant' function with the
+        ///     specified argument, which must have a HierarchyId result type.
+        ///     The result type of the expression is Edm.HierarchyId.
+        /// </summary>
+        /// <param name="hierarchyIdValue"> An expression that specifies the hierarchyid value. </param>
+        /// <param name="child1"> An expression that provides a hierarchyid value. </param>
+        /// <param name="child2"> An expression that provides a hierarchyid value. </param>
+        /// <returns> A new DbFunctionExpression that returns a hierarchyid. </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="hierarchyIdValue" />
+        ///     or
+        ///     <paramref name="child1" />
+        ///     or
+        ///     <paramref name="child2" />
+        ///     is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     No overload of the canonical 'GetDescendant' function accept an argument with the result type of
+        ///     <paramref name="child1" />
+        ///     and
+        ///     <paramref name="child2" />
+        ///     .
+        /// </exception>
+        public static DbFunctionExpression GetDescendant(this DbExpression hierarchyIdValue, DbExpression child1, DbExpression child2)
+        {
+            Check.NotNull(hierarchyIdValue, "hierarchyIdValue");
+            Check.NotNull(child1, "child1");
+            Check.NotNull(child2, "child2");
+            return EdmFunctions.InvokeCanonicalFunction("GetDescendant", hierarchyIdValue, child1, child2);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="DbFunctionExpression" /> that invokes the canonical 'GetLevel' function.
+        ///     The result type of the expression is Int32.
+        /// </summary>
+        /// <param name="hierarchyIdValue"> An expression that specifies the hierarchyid value. </param>
+        /// <returns> A new DbFunctionExpression that returns the level of the given hierarchyid. </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="hierarchyIdValue" />
+        ///     is null.
+        /// </exception>
+        public static DbFunctionExpression GetLevel(this DbExpression hierarchyIdValue)
+        {
+            Check.NotNull(hierarchyIdValue, "hierarchyIdValue");
+            return EdmFunctions.InvokeCanonicalFunction("GetLevel", hierarchyIdValue);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="DbFunctionExpression" /> that invokes the canonical 'IsDescendantOf' function with the
+        ///     specified argument, which must have a HierarchyId result type.
+        ///     The result type of the expression is Int32.
+        /// </summary>
+        /// <param name="hierarchyIdValue"> An expression that specifies the hierarchyid value. </param>
+        /// <param name="parent"> An expression that provides a hierarchyid value. </param>
+        /// <returns> A new DbFunctionExpression that returns an integer value. </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="hierarchyIdValue" />
+        ///     or
+        ///     <paramref name="parent" />
+        ///     is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     No overload of the canonical 'IsDescendantOf' function accept an argument with the result type of
+        ///     <paramref name="parent" />
+        ///     .
+        /// </exception>
+        public static DbFunctionExpression IsDescendantOf(this DbExpression hierarchyIdValue, DbExpression parent)
+        {
+            Check.NotNull(hierarchyIdValue, "hierarchyIdValue");
+            Check.NotNull(parent, "parent");
+            return EdmFunctions.InvokeCanonicalFunction("IsDescendantOf", hierarchyIdValue, parent);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="DbFunctionExpression" /> that invokes the canonical 'GetReparentedValue' function with the
+        ///     specified arguments, which must have a HierarchyId result type.
+        ///     The result type of the expression is Edm.HierarchyId.
+        /// </summary>
+        /// <param name="hierarchyIdValue"> An expression that specifies the hierarchyid value. </param>
+        /// <param name="oldRoot"> An expression that provides a hierarchyid value. </param>
+        /// <param name="newRoot"> An expression that provides a hierarchyid value. </param>
+        /// <returns> A new DbFunctionExpression that returns a hierarchyid. </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="hierarchyIdValue" />
+        ///     or
+        ///     <paramref name="oldRoot" />
+        ///     or
+        ///     <paramref name="newRoot" />
+        ///     is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     No overload of the canonical 'GetReparentedValue' function accept an argument with the result type of
+        ///     <paramref name="oldRoot" />
+        ///     and
+        ///     <paramref name="newRoot" />
+        ///     .
+        /// </exception>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Reparented")]
+        public static DbFunctionExpression GetReparentedValue(this DbExpression hierarchyIdValue, DbExpression oldRoot, DbExpression newRoot)
+        {
+            Check.NotNull(hierarchyIdValue, "hierarchyIdValue");
+            Check.NotNull(oldRoot, "oldRoot");
+            Check.NotNull(newRoot, "newRoot");
+            return EdmFunctions.InvokeCanonicalFunction("GetReparentedValue", hierarchyIdValue, oldRoot, newRoot);
+        }
+    }
+}

--- a/src/EntityFramework/Core/Common/CommandTrees/Internal/ExpressionKeyGen.cs
+++ b/src/EntityFramework/Core/Common/CommandTrees/Internal/ExpressionKeyGen.cs
@@ -5,6 +5,7 @@ namespace System.Data.Entity.Core.Common.CommandTrees.Internal
     using System.Collections.Generic;
     using System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Resources;
     using System.Data.Entity.Spatial;
     using System.Data.Entity.Utilities;
@@ -244,6 +245,18 @@ namespace System.Data.Entity.Core.Common.CommandTrees.Internal
                 case PrimitiveTypeKind.Int64:
                 case PrimitiveTypeKind.Time:
                     _key.AppendFormat(CultureInfo.InvariantCulture, "{0}", e.Value);
+                    break;
+
+                case PrimitiveTypeKind.HierarchyId:
+                    var hierarchyId = e.Value as HierarchyId;
+                    if (hierarchyId != null)
+                    {
+                        _key.Append(hierarchyId);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException();
+                    }
                     break;
 
                 case PrimitiveTypeKind.DateTime:

--- a/src/EntityFramework/Core/Common/internal/materialization/CodeGenEmitter.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/CodeGenEmitter.cs
@@ -84,6 +84,8 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
         internal static readonly MethodInfo Shaper_GetColumnValueWithErrorHandling =
             typeof(Shaper).GetOnlyDeclaredMethod("GetColumnValueWithErrorHandling");
 
+        internal static readonly MethodInfo Shaper_GetHierarchyIdColumnValue = typeof(Shaper).GetOnlyDeclaredMethod("GetHierarchyIdColumnValue");
+        
         internal static readonly MethodInfo Shaper_GetGeographyColumnValue = typeof(Shaper).GetOnlyDeclaredMethod("GetGeographyColumnValue");
         internal static readonly MethodInfo Shaper_GetGeometryColumnValue = typeof(Shaper).GetOnlyDeclaredMethod("GetGeometryColumnValue");
 
@@ -620,6 +622,16 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                 result = Expression.Call(
                     Shaper_Parameter, Shaper_GetColumnValueWithErrorHandling.MakeGenericMethod(resultType), Expression.Constant(ordinal));
             }
+            return result;
+        }
+
+        // <summary>
+        // Create expression to read a column value of type System.Data.Entity.Hierarchy.HierarchyId by delegating to the DbSpatialServices implementation of the underlying provider
+        // </summary>
+        internal static Expression Emit_Shaper_GetHierarchyIdColumnValue(int ordinal)
+        {
+            // shaper.GetHierarchyIdColumnValue(ordinal)   
+            Expression result = Expression.Call(Shaper_Parameter, Shaper_GetHierarchyIdColumnValue, Expression.Constant(ordinal));
             return result;
         }
 

--- a/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
@@ -9,6 +9,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
     using System.Data.Entity.Core.Objects;
     using System.Data.Entity.Core.Objects.DataClasses;
     using System.Data.Entity.Core.Objects.Internal;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Resources;
     using System.Data.Entity.Spatial;
     using System.Data.Entity.Utilities;
@@ -576,6 +577,17 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
         {
             var result = new ColumnErrorHandlingValueReader<TColumn>().GetValue(Reader, ordinal);
             return result;
+        }
+
+        /// <summary>
+        ///     Get the hierarchyid value of a column with the given ordinal
+        /// </summary>
+        /// <param name="ordinal"> The ordinal of the column to retrieve the value </param>
+        /// <returns> The hierarchyid value </returns>
+        public HierarchyId GetHierarchyIdColumnValue(int ordinal)
+        {
+            var hierarchyId = Reader.GetValue(ordinal);
+            return new HierarchyId(hierarchyId.ToString());
         }
 
         protected virtual DbSpatialDataReader CreateSpatialDataReader()

--- a/src/EntityFramework/Core/Common/internal/materialization/translator.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/translator.cs
@@ -1223,6 +1223,13 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                         NullableColumns.Add(ordinal);
                     }
                 }
+                else if (Helper.IsHierarchyIdType(columnType))
+                {
+                    result =
+                        CodeGenEmitter.Emit_Conditional_NotDBNull(
+                            CodeGenEmitter.Emit_EnsureType(CodeGenEmitter.Emit_Shaper_GetHierarchyIdColumnValue(ordinal), type), ordinal,
+                            type);
+                }
                 else
                 {
                     bool needsNullableCheck;

--- a/src/EntityFramework/Core/EntityClient/EntityParameter.cs
+++ b/src/EntityFramework/Core/EntityClient/EntityParameter.cs
@@ -612,12 +612,12 @@ namespace System.Data.Entity.Core.EntityClient
             }
             else if (!DbTypeMap.TryGetModelTypeUsage(DbType, out typeUsage))
             {
-                // Spatial types have only DbType 'Object', and cannot be represented in the static type map.
+                // Spatial and HierarchyId types have only DbType 'Object', and cannot be represented in the static type map. 
                 PrimitiveType primitiveParameterType;
                 if (DbType == DbType.Object
                     && Value != null
                     && ClrProviderManifest.Instance.TryGetPrimitiveType(Value.GetType(), out primitiveParameterType)
-                    && Helper.IsSpatialType(primitiveParameterType))
+                    && (Helper.IsSpatialType(primitiveParameterType) || Helper.IsHierarchyIdType(primitiveParameterType))) 
                 {
                     typeUsage = EdmProviderManifest.Instance.GetCanonicalModelTypeUsage(primitiveParameterType.PrimitiveTypeKind);
                 }

--- a/src/EntityFramework/Core/Mapping/Update/Internal/Propagator.ExtentPlaceholderCreator.cs
+++ b/src/EntityFramework/Core/Mapping/Update/Internal/Propagator.ExtentPlaceholderCreator.cs
@@ -6,6 +6,7 @@ namespace System.Data.Entity.Core.Mapping.Update.Internal
     using System.Data.Entity.Core.Common;
     using System.Data.Entity.Core.Common.CommandTrees;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Resources;
     using System.Data.Entity.Spatial;
     using System.Data.Entity.Utilities;
@@ -50,6 +51,7 @@ namespace System.Data.Entity.Core.Mapping.Update.Internal
                 typeDefaultMap[PrimitiveTypeKind.Single] = default(Single);
                 typeDefaultMap[PrimitiveTypeKind.SByte] = default(SByte);
                 typeDefaultMap[PrimitiveTypeKind.String] = String.Empty;
+                typeDefaultMap[PrimitiveTypeKind.HierarchyId] = HierarchyId.GetRoot();
 
 #if DEBUG
                 foreach (var o in typeDefaultMap.Values)

--- a/src/EntityFramework/Core/Metadata/Edm/EdmConstants.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EdmConstants.cs
@@ -11,7 +11,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
         internal const string TransientNamespace = "Transient";
 
         // max number of primitive types
-        internal const int NumPrimitiveTypes = (int)Edm.PrimitiveTypeKind.GeographyCollection + 1;
+        internal const int NumPrimitiveTypes = (int)Edm.PrimitiveTypeKind.HierarchyId + 1;
 
         // max number of primitive types
         internal const int NumBuiltInTypes = (int)BuiltInTypeKind.TypeUsage + 1;
@@ -146,6 +146,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
         internal const string GeographyMultiPolygon = "GeographyMultiPolygon";
         internal const string GeographyCollection = "GeographyCollection";
         internal const string Guid = "Guid";
+        internal const string HierarchyId = "HierarchyId";
         internal const string Single = "Single";
         internal const string SByte = "SByte";
         internal const string Int16 = "Int16";

--- a/src/EntityFramework/Core/Metadata/Edm/EdmItemCollection.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/EdmItemCollection.cs
@@ -382,7 +382,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
                 || edmVersion == XmlConstants.EdmVersionForV1_1
                 || edmVersion == XmlConstants.EdmVersionForV2)
             {
-                return new ReadOnlyCollection<PrimitiveType>(_primitiveTypeMaps.GetTypes().Where(type => !Helper.IsSpatialType(type)).ToList());
+                return new ReadOnlyCollection<PrimitiveType>(_primitiveTypeMaps.GetTypes().Where(type => !Helper.IsSpatialType(type) && !Helper.IsHierarchyIdType(type)).ToList());
             }
 
             if (edmVersion == XmlConstants.EdmVersionForV3)

--- a/src/EntityFramework/Core/Metadata/Edm/Helper.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/Helper.cs
@@ -358,6 +358,11 @@ namespace System.Data.Entity.Core.Metadata.Edm
             return IsEnumType(edmType) || IsPrimitiveType(edmType);
         }
 
+        internal static bool IsHierarchyIdType(PrimitiveType type)
+        {
+            return type.PrimitiveTypeKind == PrimitiveTypeKind.HierarchyId;
+        }
+
         internal static bool IsSpatialType(PrimitiveType type)
         {
             return IsGeographicType(type) || IsGeometricType(type);
@@ -430,6 +435,12 @@ namespace System.Data.Entity.Core.Metadata.Edm
         private static bool IsStrongGeographicTypeKind(PrimitiveTypeKind kind)
         {
             return kind >= PrimitiveTypeKind.GeographyPoint && kind <= PrimitiveTypeKind.GeographyCollection;
+        }
+
+        internal static bool IsHierarchyIdType(TypeUsage type)
+        {
+            return (type.EdmType.BuiltInTypeKind == BuiltInTypeKind.PrimitiveType
+                    && ((PrimitiveType)type.EdmType).PrimitiveTypeKind == PrimitiveTypeKind.HierarchyId);
         }
 
         internal static bool IsSpatialType(TypeUsage type)

--- a/src/EntityFramework/Core/Metadata/Edm/PrimitiveType.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/PrimitiveType.cs
@@ -5,6 +5,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Data.Entity.Core.Common;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Spatial;
     using System.Data.Entity.Utilities;
     using System.Diagnostics;
@@ -199,6 +200,8 @@ namespace System.Data.Entity.Core.Metadata.Edm
                         return typeof(DbGeometry);
                     case PrimitiveTypeKind.Guid:
                         return typeof(Guid);
+                    case PrimitiveTypeKind.HierarchyId:
+                        return typeof(HierarchyId);
                     case PrimitiveTypeKind.Single:
                         return typeof(Single);
                     case PrimitiveTypeKind.SByte:

--- a/src/EntityFramework/Core/Metadata/Edm/PrimitiveTypeKind.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/PrimitiveTypeKind.cs
@@ -174,6 +174,11 @@ namespace System.Data.Entity.Core.Metadata.Edm
         /// </summary>
         GeographyCollection = 30,
 
+        /// <summary>
+        /// HierarchyId type kind
+        /// </summary>
+        HierarchyId = 31,
+
         //
         //If you add anything below this, make sure you update the variable NumPrimitiveTypes in EdmConstants
         //

--- a/src/EntityFramework/Core/Metadata/Edm/Provider/EdmProviderManifest.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/Provider/EdmProviderManifest.cs
@@ -5,6 +5,7 @@ namespace System.Data.Entity.Core.Metadata.Edm.Provider
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Data.Entity.Core.Common;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Spatial;
     using System.Data.Entity.Utilities;
     using System.Diagnostics;
@@ -126,6 +127,7 @@ namespace System.Data.Entity.Core.Metadata.Edm.Provider
             primitiveTypes[(int)PrimitiveTypeKind.Double] = new PrimitiveType();
             primitiveTypes[(int)PrimitiveTypeKind.Single] = new PrimitiveType();
             primitiveTypes[(int)PrimitiveTypeKind.Guid] = new PrimitiveType();
+            primitiveTypes[(int)PrimitiveTypeKind.HierarchyId] = new PrimitiveType();
             primitiveTypes[(int)PrimitiveTypeKind.Int16] = new PrimitiveType();
             primitiveTypes[(int)PrimitiveTypeKind.Int32] = new PrimitiveType();
             primitiveTypes[(int)PrimitiveTypeKind.Int64] = new PrimitiveType();
@@ -164,6 +166,9 @@ namespace System.Data.Entity.Core.Metadata.Edm.Provider
             InitializePrimitiveType(
                 primitiveTypes[(int)PrimitiveTypeKind.Single], PrimitiveTypeKind.Single, EdmConstants.Single, typeof(Single));
             InitializePrimitiveType(primitiveTypes[(int)PrimitiveTypeKind.Guid], PrimitiveTypeKind.Guid, EdmConstants.Guid, typeof(Guid));
+            InitializePrimitiveType(
+                primitiveTypes[(int)PrimitiveTypeKind.HierarchyId], PrimitiveTypeKind.HierarchyId, EdmConstants.HierarchyId,
+                typeof(HierarchyId));
             InitializePrimitiveType(
                 primitiveTypes[(int)PrimitiveTypeKind.Int16], PrimitiveTypeKind.Int16, EdmConstants.Int16, typeof(Int16));
             InitializePrimitiveType(
@@ -888,6 +893,12 @@ namespace System.Data.Entity.Core.Metadata.Edm.Provider
             #region Spatial Functions
 
             EdmProviderManifestSpatialFunctions.AddFunctions(functions);
+
+            #endregion
+
+            #region HierarchyId Functions
+
+            EdmProviderManifestHierarchyIdFunctions.AddFunctions(functions);
 
             #endregion
 

--- a/src/EntityFramework/Core/Metadata/Edm/Provider/EdmProviderManifestHierarchyIdFunctions.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/Provider/EdmProviderManifestHierarchyIdFunctions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Core.Metadata.Edm.Provider
+{
+    internal static class EdmProviderManifestHierarchyIdFunctions
+    {
+        internal static void AddFunctions(EdmProviderManifestFunctionBuilder functions)
+        {
+            // HierarchyId Functions
+            functions.AddFunction(PrimitiveTypeKind.HierarchyId, "HierarchyIdGetRoot");
+            functions.AddFunction(PrimitiveTypeKind.HierarchyId, "HierarchyIdParse", PrimitiveTypeKind.String, "input");
+            functions.AddFunction(
+                PrimitiveTypeKind.HierarchyId, "GetAncestor", PrimitiveTypeKind.HierarchyId, "hierarchyIdValue",
+                PrimitiveTypeKind.Int32, "n");
+            functions.AddFunction(
+                PrimitiveTypeKind.HierarchyId, "GetDescendant", PrimitiveTypeKind.HierarchyId, "hierarchyIdValue",
+                PrimitiveTypeKind.HierarchyId, "child1", PrimitiveTypeKind.HierarchyId, "child2");
+            functions.AddFunction(
+                PrimitiveTypeKind.Int16, "GetLevel", PrimitiveTypeKind.HierarchyId, "hierarchyIdValue");
+            functions.AddFunction(
+                PrimitiveTypeKind.Boolean, "IsDescendantOf", PrimitiveTypeKind.HierarchyId, "hierarchyIdValue",
+                PrimitiveTypeKind.HierarchyId, "parent");
+            functions.AddFunction(
+                PrimitiveTypeKind.HierarchyId, "GetReparentedValue", PrimitiveTypeKind.HierarchyId, "hierarchyIdValue",
+                PrimitiveTypeKind.HierarchyId, "oldRoot", PrimitiveTypeKind.HierarchyId, "newRoot");
+        }
+    }
+}

--- a/src/EntityFramework/Core/Objects/ELinq/HierarchyIdMethodCallTranslator.cs
+++ b/src/EntityFramework/Core/Objects/ELinq/HierarchyIdMethodCallTranslator.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Core.Objects.ELinq
+{
+    using System.Collections.Generic;
+    using System.Data.Entity.Core.Common.CommandTrees;
+    using System.Data.Entity.Hierarchy;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    internal sealed partial class ExpressionConverter
+    {
+        internal sealed partial class MethodCallTranslator
+            : TypedTranslator<MethodCallExpression>
+        {
+            internal sealed class HierarchyIdMethodCallTranslator : CallTranslator
+            {
+                private static readonly Dictionary<MethodInfo, string> _methodFunctionRenames = GetRenamedMethodFunctions();
+
+                internal HierarchyIdMethodCallTranslator()
+                    : base(GetSupportedMethods())
+                {
+                }
+
+                private static MethodInfo GetStaticMethod<TResult>(Expression<Func<TResult>> lambda)
+                {
+                    var method = ((MethodCallExpression)lambda.Body).Method;
+                    Debug.Assert(
+                        method.IsStatic && method.IsPublic &&
+                        method.DeclaringType == typeof(HierarchyId),
+                        "Supported static hierarchyid methods should be public static methods declared by a hierarchyid type");
+                    return method;
+                }
+
+                private static MethodInfo GetInstanceMethod<T, TResult>(Expression<Func<T, TResult>> lambda)
+                {
+                    var method = ((MethodCallExpression)lambda.Body).Method;
+                    Debug.Assert(
+                        !method.IsStatic && method.IsPublic &&
+                        method.DeclaringType == typeof(HierarchyId),
+                        "Supported instance hierarchyid methods should be public instance methods declared by a hierarchyid type");
+                    return method;
+                }
+
+                private static IEnumerable<MethodInfo> GetSupportedMethods()
+                {
+                    yield return GetStaticMethod(() => HierarchyId.GetRoot());
+                    yield return GetStaticMethod(() => HierarchyId.Parse(default(string)));
+                    yield return GetInstanceMethod((HierarchyId h) => h.GetAncestor(default(int)));
+                    yield return GetInstanceMethod((HierarchyId h) => h.GetDescendant(default(HierarchyId), default(HierarchyId)));
+                    yield return GetInstanceMethod((HierarchyId h) => h.GetLevel());
+                    yield return GetInstanceMethod((HierarchyId h) => h.IsDescendantOf(default(HierarchyId)));
+                    yield return GetInstanceMethod((HierarchyId h) => h.GetReparentedValue(default(HierarchyId), default(HierarchyId)));
+                }
+
+                private static Dictionary<MethodInfo, string> GetRenamedMethodFunctions()
+                {
+                    var result = new Dictionary<MethodInfo, string>();
+                    result.Add(GetStaticMethod(() => HierarchyId.GetRoot()), "HierarchyIdGetRoot");
+                    result.Add(GetStaticMethod(() => HierarchyId.Parse(default(string))), "HierarchyIdParse");
+                    result.Add(GetInstanceMethod((HierarchyId h) => h.GetAncestor(default(int))), "GetAncestor");
+                    result.Add(
+                        GetInstanceMethod((HierarchyId h) => h.GetDescendant(default(HierarchyId), default(HierarchyId))), "GetDescendant");
+                    result.Add(GetInstanceMethod((HierarchyId h) => h.GetLevel()), "GetLevel");
+                    result.Add(GetInstanceMethod((HierarchyId h) => h.IsDescendantOf(default(HierarchyId))), "IsDescendantOf");
+                    result.Add(
+                        GetInstanceMethod((HierarchyId h) => h.GetReparentedValue(default(HierarchyId), default(HierarchyId))),
+                        "GetReparentedValue");
+                    return result;
+                }
+
+                // Translator for hierarchyid methods into canonical functions. Both static and instance methods are handled.
+                // Translation proceeds as follows:
+                //      object.MethodName(args...)  -> CanonicalFunctionName(object, args...)
+                //      Type.MethodName(args...)  -> CanonicalFunctionName(args...)
+                internal override DbExpression Translate(ExpressionConverter parent, MethodCallExpression call)
+                {
+                    var method = call.Method;
+                    string canonicalFunctionName;
+                    if (!_methodFunctionRenames.TryGetValue(method, out canonicalFunctionName))
+                    {
+                        canonicalFunctionName = method.Name;
+                    }
+
+                    Expression[] arguments;
+                    if (method.IsStatic)
+                    {
+                        Debug.Assert(call.Object == null, "Static method call with instance argument?");
+                        arguments = call.Arguments.ToArray();
+                    }
+                    else
+                    {
+                        Debug.Assert(call.Object != null, "Instance method call with no instance argument?");
+                        arguments = new[] { call.Object }.Concat(call.Arguments).ToArray();
+                    }
+
+                    DbExpression result = parent.TranslateIntoCanonicalFunction(canonicalFunctionName, call, arguments);
+                    return result;
+                }
+            }
+        }
+    }
+}

--- a/src/EntityFramework/Core/Objects/ELinq/MethodCallTranslator.cs
+++ b/src/EntityFramework/Core/Objects/ELinq/MethodCallTranslator.cs
@@ -221,6 +221,7 @@ namespace System.Data.Entity.Core.Objects.ELinq
                         new TrimStartTranslator(),
                         new TrimEndTranslator(),
                         new SpatialMethodCallTranslator(),
+                        new HierarchyIdMethodCallTranslator(),
                         new HasFlagTranslator(),
                         new ToStringTranslator(),
                     };

--- a/src/EntityFramework/Core/SchemaObjectModel/TypeUsageBuilder.cs
+++ b/src/EntityFramework/Core/SchemaObjectModel/TypeUsageBuilder.cs
@@ -240,6 +240,7 @@ namespace System.Data.Entity.Core.SchemaObjectModel
                     case PrimitiveTypeKind.SByte:
                     case PrimitiveTypeKind.Double:
                     case PrimitiveTypeKind.Guid:
+                    case PrimitiveTypeKind.HierarchyId:
                     case PrimitiveTypeKind.Single:
                         break;
                     case PrimitiveTypeKind.Geography:

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Core\Common\CommandTrees\DbGroupExpressionBinding.cs" />
     <Compile Include="Core\Common\CommandTrees\ExpressionBuilder\DbExpressionBuilder.cs" />
     <Compile Include="Core\Common\CommandTrees\ExpressionBuilder\EdmFunctions.cs" />
+    <Compile Include="Core\Common\CommandTrees\ExpressionBuilder\Hierarchy\HierarchyIdEdmFunctions.cs" />
     <Compile Include="Core\Common\CommandTrees\ExpressionBuilder\Internal\ArgumentValidation.cs" />
     <Compile Include="Core\Common\CommandTrees\ExpressionBuilder\Internal\EnumerableValidator.cs" />
     <Compile Include="Core\Common\CommandTrees\ExpressionBuilder\Row.cs" />
@@ -407,10 +408,12 @@
     <Compile Include="Core\Metadata\Edm\DbDatabaseMapping.cs" />
     <Compile Include="Core\Metadata\Edm\ForeignKeyBuilder.cs" />
     <Compile Include="Core\Metadata\Edm\INamedDataModelItem.cs" />
+    <Compile Include="Core\Metadata\Edm\Provider\EdmProviderManifestHierarchyIdFunctions.cs" />
     <Compile Include="Core\Metadata\Edm\ExpensiveOSpaceLoader.cs" />
     <Compile Include="Core\Metadata\ObjectLayer\CodeFirstOSpaceLoader.cs" />
     <Compile Include="Core\Metadata\ObjectLayer\CodeFirstOSpaceTypeFactory.cs" />
     <Compile Include="Core\Metadata\ObjectLayer\OSpaceTypeFactory.cs" />
+    <Compile Include="Core\Objects\ELinq\HierarchyIdMethodCallTranslator.cs" />
     <Compile Include="Core\Objects\DataClasses\EdmFunctionAttribute.cs" />
     <Compile Include="Core\Objects\EntityFunctions.cs" />
     <Compile Include="Core\Objects\ExecutionOptions.cs" />
@@ -529,6 +532,8 @@
     <Compile Include="DataAnnotations\Schema\NotMappedAttribute.cs" />
     <Compile Include="DataAnnotations\Schema\TableAttribute.cs" />
     <Compile Include="DbContextTransaction.cs" />
+    <Compile Include="Hierarchy\DbHierarchyServices.cs" />
+    <Compile Include="Hierarchy\HierarchyId.cs" />
     <Compile Include="Infrastructure\Net40DefaultDbProviderFactoryResolver.cs" />
     <Compile Include="Migrations\Infrastructure\DynamicToFunctionModificationCommandConverter.cs" />
     <Compile Include="Migrations\Infrastructure\ModificationCommandTreeGenerator.cs" />

--- a/src/EntityFramework/GlobalSuppressions.cs
+++ b/src/EntityFramework/GlobalSuppressions.cs
@@ -27,6 +27,9 @@ using System.Diagnostics.CodeAnalysis;
 [assembly:
     SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Scope = "namespace",
         Target = "System.Data.Entity.ModelConfiguration.Edm")]
+[assembly:
+    SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Scope = "namespace",
+        Target = "System.Data.Entity.Hierarchy")]
 
 [assembly: SuppressMessage("Microsoft.Usage", "CA2243:AttributeStringLiteralsShouldParseCorrectly")]
 [assembly:
@@ -177,6 +180,9 @@ using System.Diagnostics.CodeAnalysis;
 [assembly:
     SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Scope = "namespace",
         Target = "System.Data.Entity.Core.Common.EntitySql")]
+[assembly:
+    SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Scope = "namespace",
+        Target = "System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder.Hierarchy")]
 [assembly:
     SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Scope = "namespace",
         Target = "System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder.Spatial")]

--- a/src/EntityFramework/Hierarchy/DbHierarchyServices.cs
+++ b/src/EntityFramework/Hierarchy/DbHierarchyServices.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Hierarchy
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    ///     A provider-independent service API for HierarchyId type support.
+    /// </summary>
+    [Serializable]
+    public abstract class DbHierarchyServices
+    {
+        /// <summary>
+        ///     Returns a hierarchyid representing the nth ancestor of this.
+        /// </summary>
+        /// <returns>A hierarchyid representing the nth ancestor of this.</returns>
+        /// <param name="n">n</param>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "n")]
+        public abstract HierarchyId GetAncestor(int n);
+
+        /// <summary>
+        ///     Returns a child node of the parent.
+        /// </summary>
+        /// <param name="child1"> null or the hierarchyid of a child of the current node. </param>
+        /// <param name="child2"> null or the hierarchyid of a child of the current node. </param>
+        /// <returns>
+        /// Returns one child node that is a descendant of the parent.
+        /// If parent is null, returns null.
+        /// If parent is not null, and both child1 and child2 are null, returns a child of parent.
+        /// If parent and child1 are not null, and child2 is null, returns a child of parent greater than child1.
+        /// If parent and child2 are not null and child1 is null, returns a child of parent less than child2.
+        /// If parent, child1, and child2 are not null, returns a child of parent greater than child1 and less than child2.
+        /// If child1 is not null and not a child of parent, an exception is raised.
+        /// If child2 is not null and not a child of parent, an exception is raised.
+        /// If child1 >= child2, an exception is raised.
+        /// </returns>
+        public abstract HierarchyId GetDescendant(HierarchyId child1, HierarchyId child2);
+
+        /// <summary>
+        ///     Returns an integer that represents the depth of the node this in the tree.
+        /// </summary>
+        /// <returns>An integer that represents the depth of the node this in the tree.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        public abstract short GetLevel();
+
+        /// <summary>
+        ///     Returns the root of the hierarchy tree.
+        /// </summary>
+        /// <returns>The root of the hierarchy tree.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        public static HierarchyId GetRoot()
+        {
+            return new HierarchyId(HierarchyId.PathSeparator);
+        }
+
+        /// <summary>
+        ///     Returns true if this is a descendant of parent.
+        /// </summary>
+        /// <returns>True if this is a descendant of parent.</returns>
+        /// <param name="parent">parent</param>
+        public abstract bool IsDescendantOf(HierarchyId parent);
+
+        /// <summary>
+        ///     Returns a node whose path from the root is the path to newRoot, followed by the path from oldRoot to this.
+        /// </summary>
+        /// <returns>Hierarchyid value.</returns>
+        /// <param name="oldRoot">oldRoot</param>
+        /// <param name="newRoot">newRoot</param>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Reparented")]
+        public abstract HierarchyId GetReparentedValue(HierarchyId oldRoot, HierarchyId newRoot);
+
+        /// <summary>
+        ///     Converts the canonical string representation of a hierarchyid to a hierarchyid value.
+        /// </summary>
+        /// <returns>Hierarchyid value.</returns>
+        /// <param name="input">input</param>
+        public static HierarchyId Parse(string input)
+        {
+            return new HierarchyId(input);
+        }
+    }
+}

--- a/src/EntityFramework/Hierarchy/HierarchyId.cs
+++ b/src/EntityFramework/Hierarchy/HierarchyId.cs
@@ -1,0 +1,513 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Hierarchy
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using System.Text;
+
+    /// <summary>
+    /// Represents hierarchical data.
+    /// </summary>
+    [DataContract]
+    [Serializable]
+    public class HierarchyId : IComparable
+    {
+        private readonly string _hierarchyId;
+        private readonly int[][] _nodes;
+
+        /// <summary>
+        /// The Path separator character
+        /// </summary>
+        public const string PathSeparator = "/";
+
+        private const string InvalidHierarchyIdExceptionMessage =
+            "The input string '{0}' is not a valid string representation of a HierarchyId node.";
+
+        private const string GetReparentedValueOldRootExceptionMessage =
+            "HierarchyId.GetReparentedValue failed because 'oldRoot' was not an ancestor node of 'this'.  'oldRoot' was '{0}', and 'this' was '{1}'.";
+
+        private const string GetDescendantMostBeChildExceptionMessage =
+            "HierarchyId.GetDescendant failed because '{0}' must be a child of 'this'.  '{0}' was '{1}' and 'this' was '{2}'.";
+
+        private const string GetDescendantChild1MustLessThanChild2ExceptionMessage =
+            "HierarchyId.GetDescendant failed because 'child1' must be less than 'child2'.  'child1' was '{0}' and 'child2' was '{1}'.";
+
+        /// <summary>
+        ///     Constructs an HierarchyId.
+        /// </summary>
+        public HierarchyId()
+        {
+        }
+
+        /// <summary>
+        ///     Constructs an HierarchyId with the given canonical string representation value.
+        /// </summary>
+        /// <returns>Hierarchyid value.</returns>
+        /// <param name="hierarchyId">Canonical string representation</param>
+        public HierarchyId(string hierarchyId)
+        {
+            _hierarchyId = hierarchyId;
+            if (hierarchyId != null)
+            {
+                var nodesStr = hierarchyId.Split('/');
+                if (!string.IsNullOrEmpty(nodesStr[0])
+                    || !string.IsNullOrEmpty(nodesStr[nodesStr.Length - 1]))
+                {
+                    throw new ArgumentException(
+                        string.Format(CultureInfo.InvariantCulture, InvalidHierarchyIdExceptionMessage, hierarchyId), "hierarchyId");
+                }
+                int nodesCount = nodesStr.Length - 2;
+                var nodes = new int[nodesCount][];
+                for (int i = 0; i < nodesCount; i++)
+                {
+                    string node = nodesStr[i + 1];
+                    var intsStr = node.Split('.');
+                    var ints = new int[intsStr.Length];
+                    for (int j = 0; j < intsStr.Length; j++)
+                    {
+                        int num;
+                        if (!int.TryParse(intsStr[j], out num))
+                        {
+                            throw new ArgumentException(
+                                string.Format(CultureInfo.InvariantCulture, InvalidHierarchyIdExceptionMessage, hierarchyId), "hierarchyId");
+                        }
+                        ints[j] = num;
+                    }
+                    nodes[i] = ints;
+                }
+                _nodes = nodes;
+            }
+        }
+
+        /// <summary>
+        ///     Returns a hierarchyid representing the nth ancestor of this.
+        /// </summary>
+        /// <returns>A hierarchyid representing the nth ancestor of this.</returns>
+        /// <param name="n">n</param>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "n")]
+        public HierarchyId GetAncestor(int n)
+        {
+            if (_nodes == null
+                || GetLevel() < n)
+            {
+                return new HierarchyId(null);
+            }
+            string hierarchyStr = PathSeparator +
+                                  string.Join(PathSeparator, _nodes.Take(GetLevel() - n).Select(IntArrayToStirng))
+                                  + PathSeparator;
+            return new HierarchyId(hierarchyStr);
+        }
+
+        /// <summary>
+        ///     Returns a child node of the parent.
+        /// </summary>
+        /// <param name="child1"> null or the hierarchyid of a child of the current node. </param>
+        /// <param name="child2"> null or the hierarchyid of a child of the current node. </param>
+        /// <returns>
+        /// Returns one child node that is a descendant of the parent.
+        /// If parent is null, returns null.
+        /// If parent is not null, and both child1 and child2 are null, returns a child of parent.
+        /// If parent and child1 are not null, and child2 is null, returns a child of parent greater than child1.
+        /// If parent and child2 are not null and child1 is null, returns a child of parent less than child2.
+        /// If parent, child1, and child2 are not null, returns a child of parent greater than child1 and less than child2.
+        /// If child1 is not null and not a child of parent, an exception is raised.
+        /// If child2 is not null and not a child of parent, an exception is raised.
+        /// If child1 >= child2, an exception is raised.
+        /// </returns>
+        public HierarchyId GetDescendant(HierarchyId child1, HierarchyId child2)
+        {
+            if (_nodes == null)
+            {
+                return new HierarchyId(null);
+            }
+            if (child1 != null
+                && (child1.GetLevel() != GetLevel() + 1 || !child1.IsDescendantOf(this)))
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, GetDescendantMostBeChildExceptionMessage, "child1", child1, ToString()),
+                    "child1");
+            }
+            if (child2 != null
+                && (child2.GetLevel() != GetLevel() + 1 || !child2.IsDescendantOf(this)))
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, GetDescendantMostBeChildExceptionMessage, "child2", child1, ToString()),
+                    "child2");
+            }
+            if (child1 == null
+                && child2 == null)
+            {
+                return new HierarchyId(ToString() + 1 + PathSeparator);
+            }
+            string hierarchyStr;
+            if (child1 == null)
+            {
+                var result = new HierarchyId(child2.ToString());
+                var lastNode = result._nodes.Last();
+                //decrease the last part of the last node of the 1nd child
+                lastNode[lastNode.Length - 1]--;
+                hierarchyStr = PathSeparator +
+                               string.Join(PathSeparator, result._nodes.Select(IntArrayToStirng))
+                               + PathSeparator;
+                return new HierarchyId(hierarchyStr);
+            }
+            if (child2 == null)
+            {
+                var result = new HierarchyId(child1.ToString());
+                var lastNode = result._nodes.Last();
+                //increase the last part of the last node of the 2nd child
+                lastNode[lastNode.Length - 1]++;
+                hierarchyStr = PathSeparator +
+                               string.Join(PathSeparator, result._nodes.Select(IntArrayToStirng))
+                               + PathSeparator;
+                return new HierarchyId(hierarchyStr);
+            }
+            var child1LastNode = child1._nodes.Last();
+            var child2LastNode = child2._nodes.Last();
+            var cmp = CompareIntArrays(child1LastNode, child2LastNode);
+            if (cmp >= 0)
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, GetDescendantChild1MustLessThanChild2ExceptionMessage, child1, child2),
+                    "child1");
+            }
+            int firstDiffrenceIdx = 0;
+            for (; firstDiffrenceIdx < child1LastNode.Length; firstDiffrenceIdx++)
+            {
+                if (child1LastNode[firstDiffrenceIdx] < child2LastNode[firstDiffrenceIdx])
+                {
+                    break;
+                }
+            }
+            child1LastNode = child1LastNode.Take(firstDiffrenceIdx + 1).ToArray();
+            if (child1LastNode[firstDiffrenceIdx] + 1 < child2LastNode[firstDiffrenceIdx])
+            {
+                child1LastNode[firstDiffrenceIdx]++;
+            }
+            else
+            {
+                child1LastNode = child1LastNode.Concat(new[] { 1 }).ToArray();
+            }
+            hierarchyStr = PathSeparator +
+                           string.Join(PathSeparator, _nodes.Select(IntArrayToStirng))
+                           + PathSeparator
+                           + IntArrayToStirng(child1LastNode)
+                           + PathSeparator;
+            return new HierarchyId(hierarchyStr);
+        }
+
+        /// <summary>
+        ///     Returns an integer that represents the depth of the node this in the tree.
+        /// </summary>
+        /// <returns>An integer that represents the depth of the node this in the tree.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        public short GetLevel()
+        {
+            if (_nodes == null)
+            {
+                return 0;
+            }
+            return (short)_nodes.Length;
+        }
+
+        /// <summary>
+        ///     Returns the root of the hierarchy tree.
+        /// </summary>
+        /// <returns>The root of the hierarchy tree.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        public static HierarchyId GetRoot()
+        {
+            return DbHierarchyServices.GetRoot();
+        }
+
+        /// <summary>
+        ///     Returns true if this is a descendant of parent.
+        /// </summary>
+        /// <returns>True if this is a descendant of parent.</returns>
+        /// <param name="parent">parent</param>
+        public bool IsDescendantOf(HierarchyId parent)
+        {
+            if (parent == null)
+            {
+                return true;
+            }
+            if (_nodes == null
+                || parent.GetLevel() > GetLevel())
+            {
+                return false;
+            }
+            for (int i = 0; i < parent.GetLevel(); i++)
+            {
+                int cmp = CompareIntArrays(_nodes[i], parent._nodes[i]);
+                if (cmp != 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///     Returns a node whose path from the root is the path to newRoot, followed by the path from oldRoot to this.
+        /// </summary>
+        /// <returns>Hierarchyid value.</returns>
+        /// <param name="oldRoot">oldRoot</param>
+        /// <param name="newRoot">newRoot</param>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Reparented")]
+        public HierarchyId GetReparentedValue(HierarchyId oldRoot, HierarchyId newRoot)
+        {
+            if (oldRoot == null
+                || newRoot == null)
+            {
+                return new HierarchyId(null);
+            }
+            if (!IsDescendantOf(oldRoot))
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, GetReparentedValueOldRootExceptionMessage, oldRoot, ToString()), "oldRoot");
+            }
+            StringBuilder sb = new StringBuilder();
+            sb.Append(PathSeparator);
+            foreach (var node in newRoot._nodes)
+            {
+                sb.Append(IntArrayToStirng(node));
+                sb.Append(PathSeparator);
+            }
+            foreach (var node in _nodes.Skip(oldRoot.GetLevel()))
+            {
+                sb.Append(IntArrayToStirng(node));
+                sb.Append(PathSeparator);
+            }
+            return new HierarchyId(sb.ToString());
+        }
+
+        /// <summary>
+        ///     Converts the canonical string representation of a hierarchyid to a hierarchyid value.
+        /// </summary>
+        /// <returns>Hierarchyid value.</returns>
+        /// <param name="input">input</param>
+        public static HierarchyId Parse(string input)
+        {
+            return new HierarchyId(input);
+        }
+
+        private static string IntArrayToStirng(IEnumerable<int> array)
+        {
+            return string.Join(".", array);
+        }
+
+        private static int CompareIntArrays(int[] array1, int[] array2)
+        {
+            int count = Math.Min(array1.Length, array2.Length);
+            for (int i = 0; i < count; i++)
+            {
+                int item1 = array1[i];
+                int item2 = array2[i];
+                if (item1 < item2)
+                {
+                    return -1;
+                }
+                if (item1 > item2)
+                {
+                    return 1;
+                }
+            }
+            if (array1.Length > count)
+            {
+                return 1;
+            }
+            if (array2.Length > count)
+            {
+                return -1;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        ///     Compares two HierarchyIds by their values.
+        /// </summary>
+        /// <param name="hid1"> a HierarchyId to compare </param>
+        /// <param name="hid2"> a HierarchyId to compare </param>
+        /// <returns> 
+        ///     A 32-bit signed integer that indicates the lexical relationship between the two comparands.
+        ///     Value Condition Less than zero: hid1 is less than hid2. 
+        ///     Zero: hid1 equals hid2. 
+        ///     Greater than zero: hid1 is greater than hid2. 
+        /// </returns>
+        public static int Compare(HierarchyId hid1, HierarchyId hid2)
+        {
+            var nodes1 = (object)hid1 == null ? null : hid1._nodes;
+            var nodes2 = (object)hid2 == null ? null : hid2._nodes;
+            if (nodes1 == null
+                && nodes2 == null)
+            {
+                return 0;
+            }
+            if (nodes1 == null)
+            {
+                return -1;
+            }
+            if (nodes2 == null)
+            {
+                return 1;
+            }
+            int count = Math.Min(nodes1.Length, nodes2.Length);
+            for (int i = 0; i < count; i++)
+            {
+                var node1 = nodes1[i];
+                var node2 = nodes2[i];
+                int cmp = CompareIntArrays(node1, node2);
+                if (cmp != 0)
+                {
+                    return cmp;
+                }
+            }
+            if (hid1._nodes.Length > count)
+            {
+                return 1;
+            }
+            if (hid2._nodes.Length > count)
+            {
+                return -1;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        ///     Compares two HierarchyIds by their values.
+        /// </summary>
+        /// <param name="hid1"> a HierarchyId to compare </param>
+        /// <param name="hid2"> a HierarchyId to compare </param>
+        /// <returns> 
+        ///     true if the the first parameter is less than the second parameter, false otherwise 
+        /// </returns>
+        public static bool operator <(HierarchyId hid1, HierarchyId hid2)
+        {
+            int cmp = Compare(hid1, hid2);
+            return cmp < 0;
+        }
+
+        /// <summary>
+        ///     Compares two HierarchyIds by their values.
+        /// </summary>
+        /// <param name="hid1"> a HierarchyId to compare </param>
+        /// <param name="hid2"> a HierarchyId to compare </param>
+        /// <returns> 
+        ///     true if the the first parameter is greater than the second parameter, false otherwise 
+        /// </returns>
+        public static bool operator >(HierarchyId hid1, HierarchyId hid2)
+        {
+            return hid2 < hid1;
+        }
+
+        /// <summary>
+        ///     Compares two HierarchyIds by their values.
+        /// </summary>
+        /// <param name="hid1"> a HierarchyId to compare </param>
+        /// <param name="hid2"> a HierarchyId to compare </param>
+        /// <returns> 
+        ///     true if the the first parameter is less or equal than the second parameter, false otherwise 
+        /// </returns>
+        public static bool operator <=(HierarchyId hid1, HierarchyId hid2)
+        {
+            int cmp = Compare(hid1, hid2);
+            return cmp <= 0;
+        }
+
+        /// <summary>
+        ///     Compares two HierarchyIds by their values.
+        /// </summary>
+        /// <param name="hid1"> a HierarchyId to compare </param>
+        /// <param name="hid2"> a HierarchyId to compare </param>
+        /// <returns> 
+        ///     true if the the first parameter is greater or equal than the second parameter, false otherwise 
+        /// </returns>
+        public static bool operator >=(HierarchyId hid1, HierarchyId hid2)
+        {
+            return hid2 <= hid1;
+        }
+
+        /// <summary>
+        ///     Compares two HierarchyIds by their values.
+        /// </summary>
+        /// <param name="hid1"> a HierarchyId to compare </param>
+        /// <param name="hid2"> a HierarchyId to compare </param>
+        /// <returns> true if the two HierarchyIds are equal, false otherwise </returns>
+        public static bool operator ==(HierarchyId hid1, HierarchyId hid2)
+        {
+            int cmp = Compare(hid1, hid2);
+            return cmp == 0;
+        }
+
+        /// <summary>
+        ///     Compares two HierarchyIds by their values.
+        /// </summary>
+        /// <param name="hid1"> a HierarchyId to compare </param>
+        /// <param name="hid2"> a HierarchyId to compare </param>
+        /// <returns> true if the two HierarchyIds are not equal, false otherwise </returns>
+        public static bool operator !=(HierarchyId hid1, HierarchyId hid2)
+        {
+            return !(hid1 == hid2);
+        }
+
+        /// <summary>
+        ///     Compares this instance to a given HierarchyId by their values.
+        /// </summary>
+        /// <param name="other"> the HierarchyId to compare against this instance </param>
+        /// <returns> true if this instance is equal to the given HierarchyId, and false otherwise </returns>
+        protected bool Equals(HierarchyId other)
+        {
+            return this == other;
+        }
+
+        /// <summary>
+        ///     Returns a value-based hash code, to allow HierarchyId to be used in hash tables.
+        /// </summary>
+        /// <returns> the hash value of this HierarchyId </returns>
+        public override int GetHashCode()
+        {
+            return (_hierarchyId != null ? _hierarchyId.GetHashCode() : 0);
+        }
+
+        /// <summary>
+        ///     Compares this instance to a given HierarchyId by their values.
+        /// </summary>
+        /// <param name="obj"> the HierarchyId to compare against this instance </param>
+        /// <returns> true if this instance is equal to the given HierarchyId, and false otherwise </returns>
+        public override bool Equals(object obj)
+        {
+            return Equals((HierarchyId)obj);
+        }
+
+        /// <summary>
+        ///     Returns a string representation of the hierarchyid value.
+        /// </summary>
+        /// <returns>A string representation of the hierarchyid value.</returns>
+        public override string ToString()
+        {
+            return _hierarchyId;
+        }
+
+        /// <summary>
+        /// Implementation of IComparable.CompareTo()
+        /// </summary>
+        /// <param name="obj"> The object to compare to </param>
+        /// <returns> 0 if the HierarchyIds are "equal" (i.e., have the same _hierarchyId value) </returns>
+        public int CompareTo(object obj)
+        {
+            var loader = obj as HierarchyId;
+            if (loader != null)
+            {
+                return Compare(this, loader);
+            }
+
+            Debug.Assert(false, "object is not a HierarchyId");
+            return -1;
+        }
+    }
+}

--- a/src/EntityFramework/Migrations/Builders/ColumnBuilder.cs
+++ b/src/EntityFramework/Migrations/Builders/ColumnBuilder.cs
@@ -5,6 +5,7 @@ namespace System.Data.Entity.Migrations.Builders
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Infrastructure.Annotations;
     using System.Data.Entity.Migrations.Model;
     using System.Data.Entity.Spatial;
@@ -541,6 +542,40 @@ namespace System.Data.Entity.Migrations.Builders
                 defaultValue,
                 defaultValueSql,
                 precision: precision,
+                name: name,
+                storeType: storeType,
+                annotations: annotations);
+        }
+
+        /// <summary>
+        /// Creates a new column definition to store hierarchyid data.
+        ///
+        /// Entity Framework Migrations APIs are not designed to accept input provided by untrusted sources 
+        /// (such as the end user of an application). If input is accepted from such sources it should be validated 
+        /// before being passed to these APIs to protect against SQL injection attacks etc.
+        /// </summary>
+        /// <param name="nullable"> Value indicating whether or not the column allows null values. </param>
+        /// <param name="defaultValue"> Constant value to use as the default value for this column. </param>
+        /// <param name="defaultValueSql"> SQL expression used as the default value for this column. </param>
+        /// <param name="name"> The name of the column. </param>
+        /// <param name="storeType"> Provider specific data type to use for this column. </param>
+        /// <param name="annotations"> Custom annotations usually from the Code First model. </param>
+        /// <returns> The newly constructed column definition. </returns>
+        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
+        public ColumnModel HierarchyId(
+            bool? nullable = null,
+            HierarchyId defaultValue = null,
+            string defaultValueSql = null,
+            string name = null,
+            string storeType = null,
+            IDictionary<string, AnnotationValues> annotations = null)
+        {
+            return BuildColumn(
+                PrimitiveTypeKind.HierarchyId,
+                nullable,
+                defaultValue,
+                defaultValueSql,
                 name: name,
                 storeType: storeType,
                 annotations: annotations);

--- a/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
@@ -4,6 +4,7 @@ namespace System.Data.Entity.Migrations.Design
 {
     using System.Collections.Generic;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Infrastructure.Annotations;
     using System.Data.Entity.Migrations.Model;
     using System.Data.Entity.Migrations.Utilities;
@@ -1266,6 +1267,16 @@ namespace System.Data.Entity.Migrations.Design
         protected virtual string Generate(TimeSpan defaultValue)
         {
             return "new TimeSpan(" + defaultValue.Ticks + ")";
+        }
+
+        /// <summary>
+        /// Generates code to specify the default value for a <see cref="HierarchyId" /> column.
+        /// </summary>
+        /// <param name="defaultValue"> The value to be used as the default. </param>
+        /// <returns> Code representing the default value. </returns>
+        protected virtual string Generate(HierarchyId defaultValue)
+        {
+            return "new HierarchyId(\"" + defaultValue + "\")";
         }
 
         /// <summary>

--- a/src/EntityFramework/Migrations/Design/MigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/MigrationCodeGenerator.cs
@@ -65,6 +65,11 @@ namespace System.Data.Entity.Migrations.Design
                 namespaces = namespaces.Concat(new[] { "System.Data.Entity.Spatial" });
             }
 
+            if (operationsArray.OfType<AddColumnOperation>().Any(o => o.Column.Type == PrimitiveTypeKind.HierarchyId))
+            {
+                namespaces = namespaces.Concat(new[] { "System.Data.Entity.Hierarchy" });
+            }
+
             if (AnnotationsExist(operationsArray))
             {
                 namespaces = namespaces.Concat(new[] { "System.Collections.Generic", "System.Data.Entity.Infrastructure.Annotations" });

--- a/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
@@ -4,6 +4,7 @@ namespace System.Data.Entity.Migrations.Design
 {
     using System.Collections.Generic;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Infrastructure.Annotations;
     using System.Data.Entity.Migrations.Model;
     using System.Data.Entity.Migrations.Utilities;
@@ -1302,6 +1303,16 @@ namespace System.Data.Entity.Migrations.Design
         protected virtual string Generate(TimeSpan defaultValue)
         {
             return "New TimeSpan(" + defaultValue.Ticks + ")";
+        }
+
+        /// <summary>
+        /// Generates code to specify the default value for a <see cref="HierarchyId" /> column.
+        /// </summary>
+        /// <param name="defaultValue"> The value to be used as the default. </param>
+        /// <returns> Code representing the default value. </returns>
+        protected virtual string Generate(HierarchyId defaultValue)
+        {
+            return "New HierarchyId(\"" + defaultValue + "\")";
         }
 
         /// <summary>

--- a/src/EntityFramework/Migrations/Model/ColumnModel.cs
+++ b/src/EntityFramework/Migrations/Model/ColumnModel.cs
@@ -149,6 +149,7 @@ namespace System.Data.Entity.Migrations.Model
                       { PrimitiveTypeKind.Single, 4 },
                       { PrimitiveTypeKind.String, int.MaxValue },
                       { PrimitiveTypeKind.Time, 5 },
+                      { PrimitiveTypeKind.HierarchyId, int.MaxValue },
                       { PrimitiveTypeKind.Geometry, int.MaxValue },
                       { PrimitiveTypeKind.Geography, int.MaxValue },
                       { PrimitiveTypeKind.GeometryPoint, int.MaxValue },

--- a/src/EntityFramework/ModelConfiguration/Configuration/Types/StructuralTypeConfiguration.cs
+++ b/src/EntityFramework/ModelConfiguration/Configuration/Types/StructuralTypeConfiguration.cs
@@ -6,6 +6,7 @@ namespace System.Data.Entity.ModelConfiguration.Configuration.Types
     using System.Data.Entity.Core.Common;
     using System.Data.Entity.Core.Mapping;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.ModelConfiguration.Configuration.Properties.Navigation;
     using System.Data.Entity.ModelConfiguration.Configuration.Properties.Primitive;
     using System.Data.Entity.ModelConfiguration.Edm;
@@ -50,6 +51,7 @@ namespace System.Data.Entity.ModelConfiguration.Configuration.Types
             }
 
             return (propertyType.IsValueType()
+                    || propertyType == typeof(HierarchyId) 
                     || propertyType == typeof(DbGeography)
                     || propertyType == typeof(DbGeometry)
                    )

--- a/src/EntityFramework/ModelConfiguration/Configuration/Types/StructuralTypeConfiguration`.cs
+++ b/src/EntityFramework/ModelConfiguration/Configuration/Types/StructuralTypeConfiguration`.cs
@@ -3,6 +3,7 @@
 namespace System.Data.Entity.ModelConfiguration.Configuration
 {
     using System.ComponentModel;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.ModelConfiguration.Configuration.Types;
     using System.Data.Entity.Spatial;
     using System.Diagnostics.CodeAnalysis;
@@ -41,6 +42,20 @@ namespace System.Data.Entity.ModelConfiguration.Configuration
         public PrimitivePropertyConfiguration Property<T>(
             Expression<Func<TStructuralType, T?>> propertyExpression)
             where T : struct
+        {
+            return new PrimitivePropertyConfiguration(
+                Property<Properties.Primitive.PrimitivePropertyConfiguration>(propertyExpression));
+        }
+
+        /// <summary>
+        /// Configures a <see cref="T:HierarchyId" /> property that is defined on this type.
+        /// </summary>
+        /// <param name="propertyExpression"> A lambda expression representing the property to be configured. C#: t => t.MyProperty VB.Net: Function(t) t.MyProperty </param>
+        /// <returns> A configuration object that can be used to configure the property. </returns>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
+        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
+        public PrimitivePropertyConfiguration Property(
+            Expression<Func<TStructuralType, HierarchyId>> propertyExpression)
         {
             return new PrimitivePropertyConfiguration(
                 Property<Properties.Primitive.PrimitivePropertyConfiguration>(propertyExpression));

--- a/src/EntityFramework/ModelConfiguration/Mappers/PropertyFilter.cs
+++ b/src/EntityFramework/ModelConfiguration/Mappers/PropertyFilter.cs
@@ -4,6 +4,7 @@ namespace System.Data.Entity.ModelConfiguration.Mappers
 {
     using System.Collections.Generic;
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Resources;
     using System.Data.Entity.Spatial;
     using System.Data.Entity.Utilities;
@@ -39,7 +40,7 @@ namespace System.Data.Entity.ModelConfiguration.Mappers
                   let m = p.Getter()
                   where (includePrivate || (m.IsPublic || explicitlyMappedProperties.Contains(p) || knownTypes.Contains(p.PropertyType)))
                         && (!declaredOnly || type.BaseType().GetInstanceProperties().All(bp => bp.Name != p.Name))
-                        && (EdmV3FeaturesSupported || (!IsEnumType(p.PropertyType) && !IsSpatialType(p.PropertyType)))
+                        && (EdmV3FeaturesSupported || (!IsEnumType(p.PropertyType) && !IsSpatialType(p.PropertyType) && !IsHierarchyIdType(p.PropertyType)))
                         && (Ef6FeaturesSupported || !p.PropertyType.IsNested)
                   select p;
 
@@ -57,7 +58,7 @@ namespace System.Data.Entity.ModelConfiguration.Mappers
             {
                 var firstBadProperty =
                     explicitlyMappedProperties.FirstOrDefault(
-                        p => IsEnumType(p.PropertyType) || IsSpatialType(p.PropertyType));
+                        p => IsEnumType(p.PropertyType) || IsSpatialType(p.PropertyType) || IsHierarchyIdType(p.PropertyType)); 
                 if (firstBadProperty != null)
                 {
                     throw Error.UnsupportedUseOfV3Type(type.Name, firstBadProperty.Name);
@@ -84,6 +85,13 @@ namespace System.Data.Entity.ModelConfiguration.Mappers
             type.TryUnwrapNullableType(out type);
 
             return type.IsEnum();
+        }
+
+        private static bool IsHierarchyIdType(Type type)
+        {
+            type.TryUnwrapNullableType(out type);
+
+            return type == typeof(HierarchyId);
         }
 
         private static bool IsSpatialType(Type type)

--- a/src/EntityFramework/Resources/System/Data/EntityModel/System.Data.Resources.CSDLSchema_3.xsd
+++ b/src/EntityFramework/Resources/System/Data/EntityModel/System.Data.Resources.CSDLSchema_3.xsd
@@ -60,6 +60,7 @@
             <xs:enumeration value="GeometryMultiPolygon" />
             <xs:enumeration value="GeometryCollection" />
             <xs:enumeration value="Guid" />
+            <xs:enumeration value="HierarchyId" />
             <xs:enumeration value="Int16" />
             <xs:enumeration value="Int32" />
             <xs:enumeration value="Int64" />

--- a/src/EntityFramework/Resources/System/Data/System.Data.Resources.ProviderServices.ProviderManifest.xsd
+++ b/src/EntityFramework/Resources/System/Data/System.Data.Resources.ProviderServices.ProviderManifest.xsd
@@ -119,6 +119,7 @@
             <xs:enumeration value="Geography" />
             <xs:enumeration value="Geometry" />
             <xs:enumeration value="Guid" />
+            <xs:enumeration value="HierarchyId" />
             <xs:enumeration value="Single" />
             <xs:enumeration value="SByte" />
             <xs:enumeration value="Int16" />

--- a/test/EFTools/UnitTests/EntityDesignModel/Entity/StorageEntityModelTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignModel/Entity/StorageEntityModelTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Design.Model.Entity
                 var typeMap = storageModel.StoreTypeNameToStoreTypeMap;
 
                 Assert.Equal(
-                    SqlProviderServices.Instance.GetProviderManifest("2008").GetStoreTypes().Select(t => t.Name),
+                    SqlProviderServices.Instance.GetProviderManifest("2008").GetStoreTypes().Where(t => t.Name != "hierarchyid").Select(t => t.Name),
                     typeMap.Keys);
 
                 Assert.False(typeMap.Any(t => t.Key != t.Value.Name));

--- a/test/EFTools/UnitTests/EntityDesignModel/ModelHelperTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignModel/ModelHelperTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Data.Entity.Design.Model
                 var expectedTypes =
                     PrimitiveType
                         .GetEdmPrimitiveTypes()
-                        .Where(t => schemaVersion == EntityFrameworkVersion.Version3 || !IsGeoSpatialType(t))
+                        .Where(t => schemaVersion == EntityFrameworkVersion.Version3 || (!IsGeoSpatialType(t) && !IsHierardchyIdType(t)))
                         .Select(t => t.Name);
 
                 Assert.Equal(expectedTypes, ModelHelper.AllPrimitiveTypes(schemaVersion));
@@ -207,6 +207,11 @@ namespace Microsoft.Data.Entity.Design.Model
         {
             return type.PrimitiveTypeKind >= PrimitiveTypeKind.Geometry &&
                    type.PrimitiveTypeKind <= PrimitiveTypeKind.GeographyCollection;
+        }
+
+        private static bool IsHierardchyIdType(PrimitiveType type)
+        {
+            return type.PrimitiveTypeKind == PrimitiveTypeKind.HierarchyId;
         }
     }
 }

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/LegacyProviderWrapper/LegacyMetadataExtensions/MetadataWorkspaceExtensionsTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/LegacyProviderWrapper/LegacyMetadataExtensions/MetadataWorkspaceExtensionsTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.LegacyProviderWrapper.Le
                 var legacyStoreItemCollection = legacyWorkspace.GetItemCollection(LegacyMetadata.DataSpace.SSpace);
 
                 Assert.Equal(
-                    storeItemCollection.GetItems<GlobalItem>().Count,
+                    storeItemCollection.GetItems<GlobalItem>().Count - 8, // 8 hierarchyid releated items
                     legacyStoreItemCollection.GetItems<LegacyMetadata.GlobalItem>().Count);
 
                 Assert.NotNull(

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/LegacyProviderWrapper/LegacyMetadataExtensions/StoreItemCollectionExtensionsTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/LegacyProviderWrapper/LegacyMetadataExtensions/StoreItemCollectionExtensionsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.LegacyProviderWrapper.Le
                 Assert.Equal(storeItemCollection.StoreSchemaVersion, legacyStoreItemCollection.StoreSchemaVersion);
 
                 Assert.Equal(
-                    storeItemCollection.GetItems<GlobalItem>().Count,
+                    storeItemCollection.GetItems<GlobalItem>().Count - 8, // 8 hierarchyid releated items
                     legacyStoreItemCollection.GetItems<LegacyMetadata.GlobalItem>().Count);
             }
         }
@@ -87,8 +87,8 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.LegacyProviderWrapper.Le
             var sourceGlobalItems = storeItemCollection.GetItems<EdmType>();
             var legacyGlobalItems = legacyStoreItemCollection.GetItems<LegacyMetadata.EdmType>();
 
-            Assert.Equal(sourceGlobalItems.Count, legacyGlobalItems.Count);
-            Assert.True(sourceGlobalItems.All(i => legacyGlobalItems.Any(j => j.FullName == i.FullName)));
+            Assert.Equal(sourceGlobalItems.Count - 8, legacyGlobalItems.Count); // 8 hierarchyid releated items
+            Assert.True(legacyGlobalItems.All(i => sourceGlobalItems.Any(j => j.FullName == i.FullName)));
         }
     }
 }

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/StoreModelBuilderTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/StoreModelBuilderTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb
             {
                 var schemaGenerator = CreateStoreModelBuilder(targetEntityFrameworkVersion: EntityFrameworkVersion.Version2);
 
-                foreach (var unsupportedTypeName in new[] { "geography", "geometry" })
+                foreach (var unsupportedTypeName in new[] { "geography", "geometry", "hierarchyid" })
                 {
                     var errors = new List<EdmSchemaError>();
                     var property =

--- a/test/EntityFramework/FunctionalTests.Transitional/CodeFirst/HierarchyIdScenarioTests.cs
+++ b/test/EntityFramework/FunctionalTests.Transitional/CodeFirst/HierarchyIdScenarioTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace FunctionalTests
+{
+    using System;
+    using System.Data.Entity;
+    using FunctionalTests.Fixtures;
+    using Xunit;
+
+    public sealed class HierarchyIdScenarioTests : TestBase
+    {
+        [Fact]
+        public void Simple_hierarchyid_mapping_scenario()
+        {
+            var modelBuilder = new DbModelBuilder();
+
+            modelBuilder.Entity<HierarchyId_Customer>();
+
+            var databaseMapping = BuildMapping(modelBuilder);
+
+            databaseMapping.AssertValid();
+            databaseMapping.Assert<HierarchyId_Customer>(c => c.Path).DbEqual("hierarchyid", c => c.TypeName);
+        }
+
+        [Fact]
+        public void Complex_type_hierarchyid_mapping_scenario()
+        {
+            var modelBuilder = new DbModelBuilder();
+
+            modelBuilder.Entity<HierarchyId_ComplexClass>();
+
+            var databaseMapping = BuildMapping(modelBuilder);
+
+            databaseMapping.AssertValid();
+            databaseMapping.Assert<HierarchyId_ComplexType>(c => c.Path).DbEqual("hierarchyid", c => c.TypeName);
+        }
+
+        [Fact]
+        public void Configure_hierarchyid_members_on_type()
+        {
+            var modelBuilder = new DbModelBuilder();
+
+            modelBuilder.Entity<HierarchyId_Customer>().Property(c => c.Path).HasColumnName("the_column");
+
+            var databaseMapping = BuildMapping(modelBuilder);
+
+            databaseMapping.AssertValid();
+            databaseMapping.Assert<HierarchyId_Customer>(c => c.Path).DbEqual("the_column", c => c.Name);
+        }
+
+        [Fact]
+        public void Should_be_able_to_use_v4_1_model_builder_without_hierarchyids()
+        {
+            var modelBuilder = new DbModelBuilder(DbModelBuilderVersion.V4_1);
+
+            modelBuilder.Entity<HierarchyId_Customer>();
+
+            var databaseMapping = BuildMapping(modelBuilder);
+
+            databaseMapping.AssertValid();
+            Assert.Equal(2.0, databaseMapping.Model.SchemaVersion);
+            Assert.Equal(2.0, databaseMapping.Database.SchemaVersion);
+        }
+
+        [Fact]
+        public void Explicitly_using_a_HierarchyId_property_as_a_key_with_4_1_throws()
+        {
+            var modelBuilder = new DbModelBuilder(DbModelBuilderVersion.V4_1);
+
+            modelBuilder.Entity<HierarchyId_Customer>().HasKey(e => e.Path);
+
+            Assert.Throws<NotSupportedException>(
+                () =>
+                modelBuilder.Build(ProviderRegistry.Sql2008_ProviderInfo))
+                .ValidateMessage("UnsupportedUseOfV3Type", "HierarchyId_Customer", "Path");
+        }
+
+        [Fact]
+        public void Explicitly_using_a_HierarchyId_property_as_part_of_a_composite_key_with_4_1_throws()
+        {
+            var modelBuilder = new DbModelBuilder(DbModelBuilderVersion.V4_1);
+
+            modelBuilder.Entity<HierarchyId_Customer>().HasKey(
+                e => new
+                {
+                    e.Id,
+                    e.Path
+                });
+
+            Assert.Throws<NotSupportedException>(
+                () =>
+                modelBuilder.Build(ProviderRegistry.Sql2008_ProviderInfo))
+                .ValidateMessage("UnsupportedUseOfV3Type", "HierarchyId_Customer", "Path");
+        }
+
+        [Fact]
+        public void Explicitly_mapping_a_HierarchyId_property_with_Map_using_4_1_throws()
+        {
+            var modelBuilder = new DbModelBuilder(DbModelBuilderVersion.V4_1);
+
+            modelBuilder.Entity<HierarchyId_Customer>().Map(
+                mapping =>
+                {
+                    mapping.ToTable("Table1");
+                    mapping.Properties(e => e.Path);
+                });
+
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                modelBuilder.Build(
+                    ProviderRegistry.Sql2008_ProviderInfo))
+                .ValidateMessage("EntityMappingConfiguration_CannotMapIgnoredProperty", "HierarchyId_Customer", "Path");
+        }
+
+        [Fact]
+        public void Explicitly_mapping_a_HierarchyId_property_using_4_1_throws()
+        {
+            var modelBuilder = new DbModelBuilder(DbModelBuilderVersion.V4_1);
+
+            modelBuilder.Entity<HierarchyId_Customer>().Property(e => e.Path);
+
+            Assert.Throws<NotSupportedException>(
+                () =>
+                modelBuilder.Build(ProviderRegistry.Sql2008_ProviderInfo))
+                .ValidateMessage("UnsupportedUseOfV3Type", "HierarchyId_Customer", "Path");
+        }
+
+        [Fact]
+        public void Explicitly_mapping_a_HierarchyId_property_on_a_complex_type_using_4_1_throws()
+        {
+            var modelBuilder = new DbModelBuilder(DbModelBuilderVersion.V4_1);
+
+            modelBuilder.ComplexType<HierarchyId_ComplexType>().Property(c => c.Path);
+
+            Assert.Throws<NotSupportedException>(
+                () =>
+                modelBuilder.Build(ProviderRegistry.Sql2008_ProviderInfo))
+                .ValidateMessage("UnsupportedUseOfV3Type", "HierarchyId_ComplexType", "Path");
+        }
+    }
+
+    namespace Fixtures
+    {
+        using System.ComponentModel.DataAnnotations;
+        using System.ComponentModel.DataAnnotations.Schema;
+        using System.Data.Entity.Hierarchy;
+
+        public class HierarchyId_Customer
+        {
+            public int Id { get; set; }
+
+            [Required]
+            public HierarchyId Path { get; set; }
+        }
+
+        public class HierarchyId_ComplexClass
+        {
+            public int Id { get; set; }
+            public HierarchyId_ComplexType Complex { get; set; }
+        }
+
+        [ComplexType]
+        public class HierarchyId_ComplexType
+        {
+            [Column("c")]
+            public HierarchyId Path { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework/FunctionalTests.Transitional/FunctionalTests.Transitional.csproj
+++ b/test/EntityFramework/FunctionalTests.Transitional/FunctionalTests.Transitional.csproj
@@ -147,6 +147,7 @@
     <Compile Include="CodeFirst\DataAnnotationScenarioTests.cs" />
     <Compile Include="CodeFirst\DataServicesTests.cs" />
     <Compile Include="CodeFirst\FunctionsScenarioTests.cs" />
+    <Compile Include="CodeFirst\HierarchyIdScenarioTests.cs" />
     <Compile Include="CodeFirst\IndexScenarios.cs" />
     <Compile Include="CodeFirst\TableSplittingTests.cs" />
     <Compile Include="CodeFirst\TestHelpers\EndToEndFunctionsTest.cs" />

--- a/test/EntityFramework/FunctionalTests/FunctionalTests.csproj
+++ b/test/EntityFramework/FunctionalTests/FunctionalTests.csproj
@@ -129,6 +129,15 @@
     <EmbeddedResource Include="TestModels\SpatialTvfsModel\226644SpatialModel.ssdl">
       <LogicalName>FunctionalTests.ProductivityApi.SpatialTvfsModel.226644SpatialModel.ssdl</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="TestModels\HierarchyIdTvfsModel\226644HierarchyIdModel.csdl">
+      <LogicalName>FunctionalTests.ProductivityApi.HierarchyIdTvfsModel.226644HierarchyIdModel.csdl</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TestModels\HierarchyIdTvfsModel\226644HierarchyIdModel.msl">
+      <LogicalName>FunctionalTests.ProductivityApi.HierarchyIdTvfsModel.226644HierarchyIdModel.msl</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TestModels\HierarchyIdTvfsModel\226644HierarchyIdModel.ssdl">
+      <LogicalName>FunctionalTests.ProductivityApi.HierarchyIdTvfsModel.226644HierarchyIdModel.ssdl</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Query\StoredProcedures\IceAndFireModel.csdl" />
     <EmbeddedResource Include="Query\StoredProcedures\IceAndFireModel.msl" />
     <EmbeddedResource Include="Query\StoredProcedures\IceAndFireModel.ssdl" />
@@ -634,6 +643,7 @@
     <Compile Include="Migrations\TestModel\TestMigration.cs" />
     <Compile Include="Objects\LazyLoadingTests.cs" />
     <Compile Include="Objects\SerializationScenarios.cs" />
+    <Compile Include="ProductivityApi\HierarchyIdTests.cs" />
     <Compile Include="ProductivityApi\DbConfigurationTests.cs" />
     <Compile Include="ProductivityApi\ScaffoldingScenarioTests.cs" />
     <Compile Include="ProductivityApi\SimpleScenariosForLocalDb.cs" />
@@ -659,6 +669,8 @@
     <Compile Include="TestHelpers\PartialTrustClassCommand.cs" />
     <Compile Include="TestHelpers\PartialTrustCommand.cs" />
     <Compile Include="TestHelpers\PartialTrustFixtureAttribute.cs" />
+    <Compile Include="TestModels\HierarchyIdTvfsModel\HierarchyIdNorthwindContext.cs" />
+    <Compile Include="TestModels\HierarchyIdTvfsModel\HierarchyIdNorthwindInitializer.cs" />
     <Compile Include="TestModels\SimpleModel\LocalDbLoginsContext.cs" />
     <Compile Include="TestModels\SimpleModel\SimpleLocalDbModelContext.cs" />
     <Compile Include="TestModels\SimpleModel\SimpleLocalDbModelContextWithNoData.cs" />

--- a/test/EntityFramework/FunctionalTests/Migrations/AddColumnScenarios.cs
+++ b/test/EntityFramework/FunctionalTests/Migrations/AddColumnScenarios.cs
@@ -3,6 +3,7 @@
 namespace System.Data.Entity.Migrations
 {
     using System.Collections.Generic;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Infrastructure.Annotations;
     using System.Data.Entity.Migrations.Sql;
     using System.Data.Entity.Spatial;
@@ -115,6 +116,34 @@ namespace System.Data.Entity.Migrations
             migrator = CreateMigrator<ShopContext_v1>(new AddColumnWithDateTimeDefault());
 
             migrator.Update();
+        }
+
+        private class AddColumnWithHierarchyIdDefault : DbMigration
+        {
+            public override void Up()
+            {
+                AddColumn(
+                    "MigrationsCustomers", "hierarchyid_col",
+                    c => c.HierarchyId(nullable: false, defaultValue: HierarchyId.GetRoot()));
+            }
+        }
+
+        [MigrationsTheory]
+        public void Can_add_column_with_hierarchyid_default()
+        {
+            WhenNotSqlCe(
+                () =>
+                    {
+                        ResetDatabase();
+
+                        var migrator = CreateMigrator<ShopContext_v1>();
+
+                        migrator.Update();
+
+                        migrator = CreateMigrator<ShopContext_v1>(new AddColumnWithHierarchyIdDefault());
+
+                        migrator.Update();
+                    });
         }
 
         private class AddColumnWithGeographyDefault : DbMigration

--- a/test/EntityFramework/FunctionalTests/ProductivityApi/HierarchyIdTests.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/HierarchyIdTests.cs
@@ -1,0 +1,353 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace ProductivityApiTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.Common;
+    using System.Data.Entity;
+    using System.Data.Entity.Core.EntityClient;
+    using System.Data.Entity.Hierarchy;
+    using System.Data.Entity.Infrastructure;
+    using System.Globalization;
+    using System.Linq;
+    using Xunit;
+
+    /// <summary>
+    ///     Tests for hierarchyid and DbContext.
+    /// </summary>
+    public class HierarchyIdTests : FunctionalTestBase
+    {
+        #region Infrastructure/setup
+
+        private static readonly string _connectionString;
+
+        static HierarchyIdTests()
+        {
+            const string prefix = "FunctionalTests.ProductivityApi.HierarchyIdTvfsModel.";
+            ResourceUtilities.CopyEmbeddedResourcesToCurrentDir(
+                typeof(HierarchyIdTests).Assembly, prefix, /*overwrite*/ true,
+                "226644HierarchyIdModel.csdl", "226644HierarchyIdModel.msl",
+                "226644HierarchyIdModel.ssdl");
+
+            const string baseConnectionString =
+                @"metadata=.\226644HierarchyIdModel.csdl|.\226644HierarchyIdModel.ssdl|.\226644HierarchyIdModel.msl;
+                                                  provider=System.Data.SqlClient;provider connection string='{0}'";
+            _connectionString = String.Format(
+                CultureInfo.InvariantCulture, baseConnectionString,
+                SimpleConnectionString<HierarchyIdNorthwindContext>());
+        }
+
+        #endregion
+
+        #region Tests for TVFs with hierarchyid types
+
+        // Dev11 226644
+        [Fact]
+        public void DbQuery_with_TVFs_mapped_to_context_instance_methods_involving_hierarchyid_types_works_sync()
+        {
+            DbQuery_with_TVFs_mapped_to_context_instance_methods_involving_hierarchyid_types_works(ToList);
+        }
+
+#if !NET40
+
+        [Fact]
+        public void DbQuery_with_TVFs_mapped_to_context_instance_methods_involving_hierarchyid_types_works_async()
+        {
+            DbQuery_with_TVFs_mapped_to_context_instance_methods_involving_hierarchyid_types_works(ToListAsync);
+        }
+
+#endif
+
+        private void DbQuery_with_TVFs_mapped_to_context_instance_methods_involving_hierarchyid_types_works(
+            Func<IQueryable<IQueryable<SupplierWithHierarchyId>>, List<IQueryable<SupplierWithHierarchyId>>> toList)
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                var suppliers = toList(
+                    from x in context.Suppliers
+                    select
+                        context.SuppliersWithinRange(
+                            HierarchyId.Parse("/1/"),
+                            HierarchyId.Parse("/10/")));
+
+                Assert.Equal(16, suppliers.Count);
+            }
+        }
+
+        [Fact]
+        public void DbQuery_with_TVFs_mapped_to_static_methods_involving_hierarchyid_types_works_sync()
+        {
+            DbQuery_with_TVFs_mapped_to_static_methods_involving_hierarchyid_types_works(ToList);
+        }
+
+#if !NET40
+
+        [Fact]
+        public void DbQuery_with_TVFs_mapped_to_static_methods_involving_hierarchyid_types_works_async()
+        {
+            DbQuery_with_TVFs_mapped_to_static_methods_involving_hierarchyid_types_works(ToListAsync);
+        }
+
+#endif
+
+        private void DbQuery_with_TVFs_mapped_to_static_methods_involving_hierarchyid_types_works(
+            Func<IQueryable<IQueryable<SupplierWithHierarchyId>>, List<IQueryable<SupplierWithHierarchyId>>> toList)
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                var suppliers = toList(
+                    from x in context.Suppliers
+                    select
+                        HierarchyIdNorthwindContext.StaticSuppliersWithinRange(
+                            HierarchyId.Parse("/1/"),
+                            HierarchyId.Parse("/10/")));
+
+                Assert.Equal(16, suppliers.Count);
+            }
+        }
+
+        [DbFunction("HierarchyIdNorthwindContext", "SuppliersWithinRange")]
+        public static IQueryable<SupplierWithHierarchyId> ArbitrarySuppliersWithinRange(HierarchyId path1, HierarchyId path2)
+        {
+            throw new NotImplementedException("Should not be called by client code.");
+        }
+
+        [Fact]
+        public void DbQuery_with_TVFs_mapped_to_arbitrary_instance_methods_involving_hierarchyid_types_works_sync()
+        {
+            DbQuery_with_TVFs_mapped_to_arbitrary_instance_methods_involving_hierarchyid_types_works(ToList);
+        }
+
+#if !NET40
+
+        [Fact]
+        public void DbQuery_with_TVFs_mapped_to_arbitrary_instance_methods_involving_hierarchyid_types_works_async()
+        {
+            DbQuery_with_TVFs_mapped_to_arbitrary_instance_methods_involving_hierarchyid_types_works(ToListAsync);
+        }
+
+#endif
+
+        private void DbQuery_with_TVFs_mapped_to_arbitrary_instance_methods_involving_hierarchyid_types_works(
+            Func<IQueryable<IQueryable<SupplierWithHierarchyId>>, List<IQueryable<SupplierWithHierarchyId>>> toList)
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                var suppliers = (from x in context.Suppliers
+                                 select
+                                     ArbitrarySuppliersWithinRange(
+                                         HierarchyId.Parse("/1/"),
+                                         HierarchyId.Parse("/10/"))).ToList();
+
+                Assert.Equal(16, suppliers.Count);
+            }
+        }
+
+        [Fact]
+        public void DbQuery_SelectMany_with_TVFs_and_hierarchyid_types_works()
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                var results =
+                    (from s1 in
+                         context.SuppliersWithinRange(HierarchyId.Parse("/-100/"), HierarchyId.Parse("/100/"))
+                     from s2 in
+                         context.SuppliersWithinRange(HierarchyId.Parse("/-100/"), HierarchyId.Parse("/100/"))
+                     where s1.Name == s2.Name
+                     select new
+                                {
+                                    s1,
+                                    s2
+                                }).ToList();
+
+
+                Assert.Equal(16, results.Count);
+            }
+        }
+
+        [Fact]
+        public void DbQuery_SelectMany_with_TVFs_and_hierarchyid_types_using_Point_and_Point_return_in_function_import_works()
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                context.Database.Initialize(force: false);
+
+                var results =
+                    (from s1 in
+                         context.SupplierHierarchyIdsWithinRange(
+                             HierarchyId.Parse("/-100/"),
+                             HierarchyId.Parse("/100/"))
+                     from s2 in
+                         context.SupplierHierarchyIdsWithinRange(
+                             HierarchyId.Parse("/-100/"),
+                             HierarchyId.Parse("/100/"))
+                     select new
+                                {
+                                    s1,
+                                    s2
+                                }).ToList();
+
+                Assert.Equal(256, results.Count);
+            }
+        }
+
+        #endregion
+
+        #region Tests for strongly typed hierarchyid values for type construction (Dev11 254822)
+
+        [Fact]
+        public void Can_query_for_strongly_typed_hierarchyid_using_type_construction()
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                var query =
+                    @"select value ProductivityApiTests.SupplierWithHierarchyId(-77, N'MyName', Edm.HierarchyIdParse(""/1/"")) 
+                              from [HierarchyIdNorthwindContext].[Suppliers] as SupplierWithHierarchyId";
+                Assert.Equal(16, TestWithReader(context, query, r => Assert.IsType<HierarchyId>(r.GetValue(2))));
+            }
+        }
+
+        [Fact]
+        public void Can_query_for_strongly_typed_hierarchyid_using_type_construction2()
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                var query =
+                    @"select value ProductivityApiTests.WidgetWithHierarchyId(-77, N'MyName', Edm.HierarchyIdParse(""/1/""), ProductivityApiTests.ComplexWithHierarchyId(N'A', Edm.HierarchyIdParse(""/1/""))) 
+                              from [HierarchyIdNorthwindContext].[Widgets] as WidgetWithHierarchyId";
+                Assert.Equal(
+                    4, TestWithReader(
+                        context, query, r =>
+                                            {
+                                                Assert.Equal(-77, r.GetInt32(0));
+                                                Assert.IsType<HierarchyId>(r.GetValue(2));
+                                                var nestedRecord = r.GetDataRecord(3);
+                                                Assert.IsType<HierarchyId>(nestedRecord.GetValue(1));
+                                            }));
+            }
+        }
+
+        [Fact]
+        public void Can_query_for_strongly_typed_hierarchyid_using_complex_type_type_construction()
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                var query =
+                    @"select value ProductivityApiTests.ComplexWithHierarchyId(N'A', Edm.HierarchyIdParse(""/1/"")) 
+                              from [HierarchyIdNorthwindContext].[Widgets] as WidgetWithHierarchyId";
+                Assert.Equal(
+                    4, TestWithReader(
+                        context, query, r =>
+                                            {
+                                                Assert.Equal("A", r.GetString(0));
+                                                Assert.IsType<HierarchyId>(r.GetValue(1));
+                                            }));
+            }
+        }
+
+        private int TestWithReader(DbContext context, string query, Action<EntityDataReader> test)
+        {
+            var entityConnection = (EntityConnection)((IObjectContextAdapter)context).ObjectContext.Connection;
+            using (var command = entityConnection.CreateCommand())
+            {
+                command.CommandText = query;
+                entityConnection.Open();
+                var count = 0;
+                var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
+                while (reader.Read())
+                {
+                    count++;
+                    test(reader);
+                }
+                return count;
+            }
+        }
+
+        #endregion
+
+        #region Tests for materializing hierarchyid types using eSQL
+
+        // Dev11 260655
+
+        [Fact]
+        public void
+            Can_materialize_record_containing_hierarchyid_types_and_get_names_of_the_types_without_null_arg_exception_sync()
+        {
+            Can_materialize_record_containing_hierarchyid_types_and_get_names_of_the_types_without_null_arg_exception(ToList);
+        }
+
+#if !NET40
+
+        [Fact]
+        public void
+            Can_materialize_record_containing_hierarchyid_types_and_get_names_of_the_types_without_null_arg_exception_async()
+        {
+            Can_materialize_record_containing_hierarchyid_types_and_get_names_of_the_types_without_null_arg_exception(ToListAsync);
+        }
+
+#endif
+
+        private void
+            Can_materialize_record_containing_hierarchyid_types_and_get_names_of_the_types_without_null_arg_exception(
+            Func<IQueryable<DbDataRecord>, List<DbDataRecord>> toList)
+        {
+            using (var context = new HierarchyIdNorthwindContext(_connectionString))
+            {
+                var query =
+                    @"select o.[Path]
+                              from [HierarchyIdNorthwindContext].[Suppliers] as [o]";
+
+                var results = ExecuteESqlQuery(context, query, toList);
+
+                Assert.Equal(16, results.Count);
+                foreach (var result in results)
+                {
+                    Assert.Equal("Path", result.GetName(0)); // GetName would throw
+                    Assert.Same(typeof(HierarchyId), result.GetFieldType(0));
+                }
+            }
+        }
+
+        private List<DbDataRecord> ExecuteESqlQuery(
+            DbContext context, string query,
+            Func<IQueryable<DbDataRecord>, List<DbDataRecord>> toList)
+        {
+            var objectContext = ((IObjectContextAdapter)context).ObjectContext;
+            objectContext.MetadataWorkspace.LoadFromAssembly(typeof(ComplexWithHierarchyId).Assembly);
+
+            return toList(objectContext.CreateQuery<DbDataRecord>(query));
+        }
+
+#if !NET40
+
+        private List<DbDataRecord> ExecuteESqlQueryAsync(
+            DbContext context, string query,
+            Func<IQueryable<DbDataRecord>, List<DbDataRecord>> toList)
+        {
+            var objectContext = ((IObjectContextAdapter)context).ObjectContext;
+            objectContext.MetadataWorkspace.LoadFromAssembly(typeof(ComplexWithHierarchyId).Assembly);
+
+            return toList(objectContext.CreateQuery<DbDataRecord>(query));
+        }
+
+#endif
+
+        private List<T> ToList<T>(IQueryable<T> query)
+        {
+            return query.ToList();
+        }
+
+#if !NET40
+
+        private List<T> ToListAsync<T>(IQueryable<T> query)
+        {
+            return query.ToListAsync().Result;
+        }
+
+#endif
+
+        #endregion
+    }
+}

--- a/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/226644HierarchyIdModel.csdl
+++ b/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/226644HierarchyIdModel.csdl
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Schema Namespace="ProductivityApiTests" Alias="Self"
+     xmlns="http://schemas.microsoft.com/ado/2009/11/edm" 
+     xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation">
+  <EntityType Name="SupplierWithHierarchyId">
+    <Key>
+      <PropertyRef Name="Id" />
+    </Key>
+    <Property Name="Id" Type="Int32" Nullable="false" p6:StoreGeneratedPattern="Identity" xmlns:p6="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+    <Property Name="Name" Type="String" FixedLength="false" MaxLength="Max" Unicode="true" Nullable="true" />
+    <Property Name="Path" Type="HierarchyId" Nullable="true" />
+  </EntityType>
+  <EntityType Name="WidgetWithHierarchyId">
+    <Key>
+      <PropertyRef Name="Id" />
+    </Key>
+    <Property Name="Id" Type="Int32" Nullable="false" p6:StoreGeneratedPattern="Identity" xmlns:p6="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+    <Property Name="Name" Type="String" FixedLength="false" MaxLength="Max" Unicode="true" Nullable="true" />
+    <Property Name="SomeHierarchyId" Type="HierarchyId" Nullable="true" />
+    <Property Name="Complex" Type="ProductivityApiTests.ComplexWithHierarchyId" Nullable="false" />
+  </EntityType>
+  <ComplexType Name="ComplexWithHierarchyId">
+    <Property Name="NotHierarchyId" Type="String" Nullable="false" MaxLength="16" />
+    <Property Name="SomeMoreHierarchyId" Type="HierarchyId" Nullable="true" />
+  </ComplexType>
+  <EntityContainer Name="HierarchyIdNorthwindContext">
+    <EntitySet Name="Suppliers" EntityType="Self.SupplierWithHierarchyId" />
+    <EntitySet Name="Widgets" EntityType="Self.WidgetWithHierarchyId" />
+    <FunctionImport Name="SuppliersWithinRange" ReturnType="Collection(ProductivityApiTests.SupplierWithHierarchyId)" IsComposable="true"
+    	EntitySet="Suppliers">
+      <Parameter Name="path1" Type="HierarchyId" />
+      <Parameter Name="path2" Type="HierarchyId" />
+    </FunctionImport>
+    <FunctionImport Name="SupplierHierarchyIdsWithinRange" ReturnType="Collection(HierarchyId)" IsComposable="true">
+      <Parameter Name="path1" Type="HierarchyId" />
+      <Parameter Name="path2" Type="HierarchyId" />
+    </FunctionImport>
+  </EntityContainer>
+</Schema>

--- a/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/226644HierarchyIdModel.msl
+++ b/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/226644HierarchyIdModel.msl
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Mapping Space="C-S" xmlns="http://schemas.microsoft.com/ado/2009/11/mapping/cs">
+  <EntityContainerMapping StorageEntityContainer="CodeFirstDatabase" CdmEntityContainer="HierarchyIdNorthwindContext">
+    <EntitySetMapping Name="Suppliers">
+      <EntityTypeMapping TypeName="ProductivityApiTests.SupplierWithHierarchyId">
+        <MappingFragment StoreEntitySet="SupplierWithHierarchyId">
+          <ScalarProperty Name="Id" ColumnName="Id" />
+          <ScalarProperty Name="Name" ColumnName="Name" />
+          <ScalarProperty Name="Path" ColumnName="Path" />
+        </MappingFragment>
+      </EntityTypeMapping>
+    </EntitySetMapping>
+    <EntitySetMapping Name="Widgets">
+      <EntityTypeMapping TypeName="ProductivityApiTests.WidgetWithHierarchyId">
+        <MappingFragment StoreEntitySet="WidgetWithHierarchyId">
+          <ScalarProperty Name="Id" ColumnName="Id" />
+          <ScalarProperty Name="Name" ColumnName="Name" />
+          <ScalarProperty Name="SomeHierarchyId" ColumnName="SomeHierarchyId" />
+          <ComplexProperty Name="Complex" TypeName="ProductivityApiTests.ComplexWithHierarchyId">
+            <ScalarProperty Name="NotHierarchyId" ColumnName="NotHierarchyId" />
+            <ScalarProperty Name="SomeMoreHierarchyId" ColumnName="SomeMoreHierarchyId" />
+          </ComplexProperty>
+        </MappingFragment>
+      </EntityTypeMapping>
+    </EntitySetMapping>
+    <FunctionImportMapping FunctionName="CodeFirstDatabaseSchema.fx_SuppliersWithinRange" FunctionImportName="SuppliersWithinRange">
+      <ResultMapping>
+        <EntityTypeMapping TypeName="ProductivityApiTests.SupplierWithHierarchyId">
+          <ScalarProperty Name="Id" ColumnName="Id" />
+          <ScalarProperty Name="Name" ColumnName="Name" />
+          <ScalarProperty Name="Path" ColumnName="Path" />
+        </EntityTypeMapping>
+      </ResultMapping>
+    </FunctionImportMapping>
+    <FunctionImportMapping FunctionName="CodeFirstDatabaseSchema.fx_SupplierHierarchyIdsWithinRange" FunctionImportName="SupplierHierarchyIdsWithinRange"/>
+  </EntityContainerMapping>
+</Mapping>

--- a/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/226644HierarchyIdModel.ssdl
+++ b/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/226644HierarchyIdModel.ssdl
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Schema Namespace="CodeFirstDatabaseSchema" Provider="System.Data.SqlClient" ProviderManifestToken="2008" Alias="Self" xmlns="http://schemas.microsoft.com/ado/2009/11/edm/ssdl">
+  <EntityType Name="SupplierWithHierarchyId">
+    <Key>
+      <PropertyRef Name="Id" />
+    </Key>
+    <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
+    <Property Name="Name" Type="nvarchar(max)" Nullable="true" />
+    <Property Name="Path" Type="hierarchyid" Nullable="true" />
+  </EntityType>
+  <EntityType Name="WidgetWithHierarchyId">
+    <Key>
+      <PropertyRef Name="Id" />
+    </Key>
+    <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
+    <Property Name="Name" Type="nvarchar(max)" Nullable="true" />
+    <Property Name="SomeHierarchyId" Type="hierarchyid" Nullable="true" />
+    <Property Name="NotHierarchyId" Type="nvarchar" Nullable="false" MaxLength="16" />
+    <Property Name="SomeMoreHierarchyId" Type="hierarchyid" Nullable="true" />
+  </EntityType>
+  <EntityContainer Name="CodeFirstDatabase">
+    <EntitySet Name="SupplierWithHierarchyId" EntityType="Self.SupplierWithHierarchyId" Schema="dbo" Table="SupplierWithHierarchyIds" />
+    <EntitySet Name="WidgetWithHierarchyId" EntityType="Self.WidgetWithHierarchyId" Schema="dbo" Table="WidgetWithHierarchyIds" />
+  </EntityContainer>
+  <Function Name="fx_SuppliersWithinRange" Aggregate="false" BuiltIn="false" NiladicFunction="false" IsComposable="true" ParameterTypeSemantics="AllowImplicitConversion" Schema="dbo">
+    <Parameter Name="path1" Type="hierarchyid" Mode="In" />
+    <Parameter Name="path2" Type="hierarchyid" Mode="In" />
+    <ReturnType>
+      <CollectionType>
+        <RowType>
+          <Property Name="Id" Type="int" Nullable="false" />
+          <Property Name="Name" Type="nvarchar(max)" Nullable="true" />
+          <Property Name="Path" Type="hierarchyid" Nullable="true" />
+        </RowType>
+      </CollectionType>
+    </ReturnType>
+  </Function>
+  <Function Name="fx_SupplierHierarchyIdsWithinRange" Aggregate="false" BuiltIn="false" NiladicFunction="false" IsComposable="true" ParameterTypeSemantics="AllowImplicitConversion" Schema="dbo">
+    <Parameter Name="path1" Type="hierarchyid" Mode="In" />
+    <Parameter Name="path2" Type="hierarchyid" Mode="In" />
+    <ReturnType>
+      <CollectionType>
+        <RowType>
+          <Property Name="Path" Type="hierarchyid" Nullable="true" />
+        </RowType>
+      </CollectionType>
+    </ReturnType>
+  </Function>
+</Schema>

--- a/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/HierarchyIdNorthwindContext.cs
+++ b/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/HierarchyIdNorthwindContext.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace ProductivityApiTests
+{
+    using System;
+    using System.Data.Entity;
+    using System.Data.Entity.Core.Objects;
+    using System.Data.Entity.Hierarchy;
+    using System.Data.Entity.Infrastructure;
+    using System.Linq;
+
+    public class SupplierWithHierarchyId
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public HierarchyId Path { get; set; } 
+    }
+
+    public class WidgetWithHierarchyId
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public HierarchyId SomeHierarchyId { get; set; }
+        public ComplexWithHierarchyId Complex { get; set; }
+    }
+
+    public class ComplexWithHierarchyId
+    {
+        public string NotHierarchyId { get; set; }
+        public HierarchyId SomeMoreHierarchyId { get; set; }
+    }
+
+    public class HierarchyIdNorthwindContext : DbContext
+    {
+        public HierarchyIdNorthwindContext(string connectionString)
+            : base(connectionString)
+        {
+            Database.SetInitializer(new HierarchyIdNorthwindInitializer());
+        }
+
+        public DbSet<SupplierWithHierarchyId> Suppliers { get; set; }
+        public DbSet<WidgetWithHierarchyId> Widgets { get; set; }
+
+        [DbFunction("HierarchyIdNorthwindContext", "SuppliersWithinRange")]
+        public virtual IQueryable<SupplierWithHierarchyId> SuppliersWithinRange(HierarchyId path1, HierarchyId path2)
+        {
+            var objectContext = ((IObjectContextAdapter)this).ObjectContext;
+            objectContext.MetadataWorkspace.LoadFromAssembly(typeof(SupplierWithHierarchyId).Assembly);
+
+            return objectContext.CreateQuery<SupplierWithHierarchyId>(
+                "[HierarchyIdNorthwindContext].[SuppliersWithinRange](@path1, @path2)",
+                new ObjectParameter("path1", path1),
+                new ObjectParameter("path2", path2));
+        }
+
+        [DbFunction("HierarchyIdNorthwindContext", "SuppliersWithinRange")]
+        public static IQueryable<SupplierWithHierarchyId> StaticSuppliersWithinRange(HierarchyId path1, HierarchyId path2)
+        {
+            throw new NotImplementedException("Should not be called by client code.");
+        }
+
+        [DbFunction("HierarchyIdNorthwindContext", "SupplierHierarchyIdsWithinRange")]
+        public virtual IQueryable<HierarchyId> SupplierHierarchyIdsWithinRange(HierarchyId path1, HierarchyId path2)
+        {
+            var objectContext = ((IObjectContextAdapter)this).ObjectContext;
+            objectContext.MetadataWorkspace.LoadFromAssembly(typeof(SupplierWithHierarchyId).Assembly);
+
+            return objectContext.CreateQuery<HierarchyId>(
+                "[HierarchyIdNorthwindContext].[SupplierHierarchyIdsWithinRange](@path1, @path2)",
+                new ObjectParameter("path1", path1),
+                new ObjectParameter("path2", path2));
+        }
+    }
+}

--- a/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/HierarchyIdNorthwindInitializer.cs
+++ b/test/EntityFramework/FunctionalTests/TestModels/HierarchyIdTvfsModel/HierarchyIdNorthwindInitializer.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace ProductivityApiTests
+{
+    using System.Collections.Generic;
+    using System.Data.Entity;
+    using System.Data.Entity.Hierarchy;
+
+    public class HierarchyIdNorthwindInitializer : DropCreateDatabaseAlways<HierarchyIdNorthwindContext>
+    {
+        protected override void Seed(HierarchyIdNorthwindContext context)
+        {
+            context.Database.ExecuteSqlCommand(
+                @"
+
+                CREATE FUNCTION [dbo].[fx_SuppliersWithinRange]
+                (	
+	                @path1 hierarchyid, 
+	                @path2 hierarchyid
+                )
+                RETURNS TABLE 
+                AS
+                RETURN 
+                (
+	                SELECT [Id],[Name],[Path]
+	                FROM [ProductivityApiTests.HierarchyIdNorthwindContext].[dbo].[SupplierWithHierarchyIds] as supplier
+	                Where supplier.Path > @path1 AND supplier.Path < @path2
+                )"
+                );
+
+            context.Database.ExecuteSqlCommand(
+                @"
+
+                CREATE FUNCTION [dbo].[fx_SupplierHierarchyIdsWithinRange]
+                (	
+	                @path1 hierarchyid, 
+	                @path2 hierarchyid
+                )
+                RETURNS TABLE 
+                AS
+                RETURN 
+                (
+	                SELECT [Path]
+	                FROM [ProductivityApiTests.HierarchyIdNorthwindContext].[dbo].[SupplierWithHierarchyIds] as supplier
+	                Where supplier.Path > @path1 AND supplier.Path < @path2
+                )"
+                );
+
+            new List<SupplierWithHierarchyId>
+                {
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier1",
+                            Path = HierarchyId.Parse("/1/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier2",
+                            Path = HierarchyId.Parse("/1/1/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier3",
+                            Path = HierarchyId.Parse("/1/1.1/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier4",
+                            Path = HierarchyId.Parse("/1/2/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier5",
+                            Path = HierarchyId.Parse("/1/1.1/2/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier6",
+                            Path = HierarchyId.Parse("/1/3/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier7",
+                            Path = HierarchyId.Parse("/1/4/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier8",
+                            Path = HierarchyId.Parse("/1/4/1/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier9",
+                            Path = HierarchyId.Parse("/2/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier10",
+                            Path = HierarchyId.Parse("/3/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier11",
+                            Path = HierarchyId.Parse("/3/1/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier12",
+                            Path = HierarchyId.Parse("/3/2/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier13",
+                            Path = HierarchyId.Parse("/3/2.1/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier14",
+                            Path = HierarchyId.Parse("/3/2.1/3/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier15",
+                            Path = HierarchyId.Parse("/4/")
+                        },
+                    new SupplierWithHierarchyId
+                        {
+                            Name = "Supplier16",
+                            Path = HierarchyId.Parse("/5/")
+                        },
+                }.ForEach(s => context.Suppliers.Add(s));
+
+            new List<WidgetWithHierarchyId>
+                {
+                    new WidgetWithHierarchyId
+                        {
+                            Name = "Widget1",
+                            SomeHierarchyId = HierarchyId.Parse("/11/"),
+                            Complex = new ComplexWithHierarchyId
+                                          {
+                                              NotHierarchyId = "1",
+                                              SomeMoreHierarchyId = HierarchyId.Parse("/11/1/")
+                                          }
+                        },
+                    new WidgetWithHierarchyId
+                        {
+                            Name = "Widget2",
+                            SomeHierarchyId = HierarchyId.Parse("/12/"),
+                            Complex = new ComplexWithHierarchyId
+                                          {
+                                              NotHierarchyId = "1",
+                                              SomeMoreHierarchyId = HierarchyId.Parse("/12/1/")
+                                          }
+                        },
+                    new WidgetWithHierarchyId
+                        {
+                            Name = "Widget3",
+                            SomeHierarchyId = HierarchyId.Parse("/13/"),
+                            Complex = new ComplexWithHierarchyId
+                                          {
+                                              NotHierarchyId = "1",
+                                              SomeMoreHierarchyId = HierarchyId.Parse("/13/1/")
+                                          }
+                        },
+                    new WidgetWithHierarchyId
+                        {
+                            Name = "Widget4",
+                            SomeHierarchyId = HierarchyId.Parse("/14/"),
+                            Complex = new ComplexWithHierarchyId
+                                          {
+                                              NotHierarchyId = "1",
+                                              SomeMoreHierarchyId = HierarchyId.Parse("/14/1/")
+                                          }
+                        },
+                }.ForEach(w => context.Widgets.Add(w));
+        }
+    }
+}

--- a/test/EntityFramework/UnitTests/Core/Mapping/Update/Internal/PropagatorTests.cs
+++ b/test/EntityFramework/UnitTests/Core/Mapping/Update/Internal/PropagatorTests.cs
@@ -3,6 +3,7 @@
 namespace System.Data.Entity.Core.Mapping.Update.Internal
 {
     using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Hierarchy;
     using System.Data.Entity.Spatial;
     using Xunit;
 
@@ -28,6 +29,7 @@ namespace System.Data.Entity.Core.Mapping.Update.Internal
                 Check_result_for_basic_type(PrimitiveTypeKind.Single, default(Single));
                 Check_result_for_basic_type(PrimitiveTypeKind.SByte, default(SByte));
                 Check_result_for_basic_type(PrimitiveTypeKind.String, string.Empty);
+                Check_result_for_basic_type(PrimitiveTypeKind.HierarchyId, HierarchyId.GetRoot());
             }
 
             private static void Check_result_for_basic_type(PrimitiveTypeKind primitiveTypeKind, object defaultValue)

--- a/test/EntityFramework/UnitTests/Hierarchy/HierarchyIdUnitTests.cs
+++ b/test/EntityFramework/UnitTests/Hierarchy/HierarchyIdUnitTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Spatial
+{
+    using System.Data.Entity.Hierarchy;
+    using Moq;
+    using Xunit;
+
+    public class HierarchyIdUnitTests
+    {
+        [Fact]
+        public void Check_hierarchyid_functions()
+        {
+// ReSharper disable ConditionIsAlwaysTrueOrFalse
+            Assert.Equal(null == new HierarchyId(null), true);
+            Assert.Equal(null != new HierarchyId(null), false);
+// ReSharper restore ConditionIsAlwaysTrueOrFalse
+            Assert.Equal(new HierarchyId("/1/2/") == new HierarchyId("/1/2" + "/"), true);
+            Assert.Equal(new HierarchyId("/-1/2.1/") != new HierarchyId("/-1/2.1" + "/"), false);
+            Assert.Equal(new HierarchyId("/1/2.1/").GetAncestor(1), new HierarchyId("/1/"));
+            Assert.Equal(new HierarchyId("/1/2.1/3/").GetAncestor(2), new HierarchyId("/1/"));
+            Assert.Equal(new HierarchyId("/1/").GetAncestor(2) == null, true);
+            Assert.Equal(new HierarchyId("/1/").GetAncestor(2) == new HierarchyId(null), true);
+            Assert.Equal(new HierarchyId("/1/").IsDescendantOf(null), true);
+            Assert.Equal(new HierarchyId("/1/").IsDescendantOf(new HierarchyId(null)), true);
+            Assert.Equal(new HierarchyId("/1/2/").IsDescendantOf(new HierarchyId("/")), true);
+            Assert.Equal(new HierarchyId("/1/2/").IsDescendantOf(new HierarchyId("/1/")), true);
+            Assert.Equal(new HierarchyId("/1/2/").IsDescendantOf(new HierarchyId("/1/2/")), true);
+            Assert.Equal(new HierarchyId("/1/2/").IsDescendantOf(new HierarchyId("/1/2/3/")), false);
+            Assert.Equal(new HierarchyId("/1/2/").IsDescendantOf(new HierarchyId("/1/3/")), false);
+            Assert.Equal(new HierarchyId("/1/2/").GetReparentedValue(null, null) == null, true);
+            Assert.Equal(new HierarchyId("/1/2/").GetReparentedValue(new HierarchyId("/1/3/"), null) == null, true);
+            Assert.Equal(new HierarchyId("/1/2/").GetReparentedValue(null, new HierarchyId("/1/3/")) == null, true);
+            Assert.Throws<ArgumentException>(
+                () => new HierarchyId("/1/2/").GetReparentedValue(new HierarchyId("/1/3/"), new HierarchyId("/1/4/")));
+            Assert.Equal(
+                new HierarchyId("/1/2/3/").GetReparentedValue(new HierarchyId("/1/2/"), new HierarchyId("/1/3/"))
+                == new HierarchyId("/1/3/3/"), true);
+            Assert.Equal(new HierarchyId(null).GetDescendant(null, null) == null, true);
+            Assert.Equal(new HierarchyId(null).GetDescendant(new HierarchyId("/1/1/"), null) == null, true);
+            Assert.Equal(new HierarchyId(null).GetDescendant(new HierarchyId("/1/2/"), new HierarchyId("/1/3/")) == null, true);
+            Assert.Throws<ArgumentException>(
+                () => new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/"), new HierarchyId("/2/")));
+            Assert.Throws<ArgumentException>(
+                () => new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/"), new HierarchyId("/2/")));
+            Assert.Throws<ArgumentException>(
+                () => new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/3/"), new HierarchyId("/2/")));
+            Assert.Throws<ArgumentException>(
+                () => new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/3/"), new HierarchyId("/1/2/4/1/")));
+            Assert.Throws<ArgumentException>(
+                () => new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/1/"), new HierarchyId("/1/2/1/")));
+            Assert.Throws<ArgumentException>(
+                () => new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/2/"), new HierarchyId("/1/2/1/")));
+            Assert.Equal(new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/1/"), null), new HierarchyId("/1/2/2/"));
+            Assert.Equal(new HierarchyId("/1/2/").GetDescendant(null, new HierarchyId("/1/2/1/")), new HierarchyId("/1/2/0/"));
+            Assert.Equal(new HierarchyId("/1/2/").GetDescendant(null, new HierarchyId("/1/2/0/")), new HierarchyId("/1/2/-1/"));
+            Assert.Equal(
+                new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/1/"), new HierarchyId("/1/2/3/")), new HierarchyId("/1/2/2/"));
+            Assert.Equal(
+                new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/1/"), new HierarchyId("/1/2/2/")), new HierarchyId("/1/2/1.1/"));
+            Assert.Equal(
+                new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/1/"), new HierarchyId("/1/2/2.1/")),
+                new HierarchyId("/1/2/1.1/"));
+            Assert.Equal(
+                new HierarchyId("/1/2/").GetDescendant(new HierarchyId("/1/2/1.1.1/"), new HierarchyId("/1/2/1.3.1/")),
+                new HierarchyId("/1/2/1.2/"));
+        }
+    }
+}

--- a/test/EntityFramework/UnitTests/Migrations/Builders/ColumnBuilderTests.cs
+++ b/test/EntityFramework/UnitTests/Migrations/Builders/ColumnBuilderTests.cs
@@ -213,6 +213,7 @@ namespace System.Data.Entity.Migrations.Builders
             VerifyAnnotations(builder.DateTimeOffset(annotations: annotations));
             VerifyAnnotations(builder.Decimal(annotations: annotations));
             VerifyAnnotations(builder.Double(annotations: annotations));
+            VerifyAnnotations(builder.HierarchyId(annotations: annotations));
             VerifyAnnotations(builder.Geography(annotations: annotations));
             VerifyAnnotations(builder.Geometry(annotations: annotations));
             VerifyAnnotations(builder.Guid(annotations: annotations));

--- a/test/EntityFramework/UnitTests/ModelConfiguration/Edm/Serialization/Xsd/System.Data.Resources.CSDLSchema_3.xsd
+++ b/test/EntityFramework/UnitTests/ModelConfiguration/Edm/Serialization/Xsd/System.Data.Resources.CSDLSchema_3.xsd
@@ -60,6 +60,7 @@
             <xs:enumeration value="GeometryMultiPolygon" />
             <xs:enumeration value="GeometryCollection" />
             <xs:enumeration value="Guid" />
+            <xs:enumeration value="HierarchyId" />
             <xs:enumeration value="Int16" />
             <xs:enumeration value="Int32" />
             <xs:enumeration value="Int64" />

--- a/test/EntityFramework/UnitTests/SqlServer/SqlProviderManifestTests.cs
+++ b/test/EntityFramework/UnitTests/SqlServer/SqlProviderManifestTests.cs
@@ -190,6 +190,7 @@ namespace System.Data.Entity.SqlServer
             Assert.Equal(expectedCount, types.Count(t => t.Name.ToLowerInvariant() == "datetimeoffset"));
             Assert.Equal(expectedCount, types.Count(t => t.Name.ToLowerInvariant() == "geography"));
             Assert.Equal(expectedCount, types.Count(t => t.Name.ToLowerInvariant() == "geometry"));
+            Assert.Equal(expectedCount, types.Count(t => t.Name.ToLowerInvariant() == "hierarchyid"));
         }
 
         [Fact]

--- a/test/EntityFramework/UnitTests/UnitTests.csproj
+++ b/test/EntityFramework/UnitTests/UnitTests.csproj
@@ -310,6 +310,7 @@
     <Compile Include="DbFunctionAttributeTests.cs" />
     <Compile Include="DbFunctionsTests.cs" />
     <Compile Include="Edm\EdmModelVisitorTests.cs" />
+    <Compile Include="Hierarchy\HierarchyIdUnitTests.cs" />
     <Compile Include="IDbAsyncEnumerableExtensionsTests.cs" />
     <Compile Include="Infrastructure\Annotations\AnnotationCodeGeneratorTests.cs" />
     <Compile Include="Infrastructure\Annotations\CompatibilityResultTests.cs" />


### PR DESCRIPTION
Migrated @zgabi 's [fork on codeplex](https://entityframework.codeplex.com/SourceControl/network/forks/zgabi/efhierarchyid) (many thanks) which (I think) is the source of the NuGet Package [EntityFrameworkWithHierarchyId](https://www.nuget.org/packages/EntityFrameworkWithHierarchyId/) to GitHub and reverted changes related to changing the public assembly key and NuGet package Id. 

As stated in feature request #339, community contributions for features that the EF team is not planning to implement themselves can still be considered as most of it would be already done.

( I am not the original author, I am only trying to add this contribution to the EF code base so it has the possibility to support the data type without any hacks/workarounds. It would be a shame if it is lost when CodePlex goes down. )