### PR TITLE
WIP: Fix for #195: Suppress schema query parameter optimization for providers that are not compatible

### DIFF
--- a/src/EFTools/EntityDesignerVersioningFacade/EntityDesignerVersioningFacade.csproj
+++ b/src/EFTools/EntityDesignerVersioningFacade/EntityDesignerVersioningFacade.csproj
@@ -93,6 +93,7 @@
     <Compile Include="ReverseEngineerDb\EntityStoreSchemaFilterEffect.cs" />
     <Compile Include="ReverseEngineerDb\EntityStoreSchemaFilterEntry.cs" />
     <Compile Include="ReverseEngineerDb\EntityStoreSchemaFilterObjectTypes.cs" />
+    <Compile Include="ReverseEngineerDb\SchemaDiscovery\ParameterCollectionBuilder.cs" />
     <Compile Include="ReverseEngineerDb\StoreSchemaConnectionFactory.cs" />
     <Compile Include="ReverseEngineerDb\ModelBuilderErrorCode.cs" />
     <Compile Include="ReverseEngineerDb\DbDatabaseMappingBuilder.cs" />

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
 
             command.CommandText =
                 new EntityStoreSchemaQueryGenerator(sql, orderByClause, queryTypes, filters, filterAliases)
-                    .GenerateQuery(command.Parameters, optimizeParameters);
+                    .GenerateQuery(new ParameterCollectionBuilder(command.Parameters, optimizeParameters));
 
             return command;
         }

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
     using System.Data.Entity.Core.EntityClient;
     using System.Data.Entity.Infrastructure.Interception;
     using System.Data.Entity.Utilities;
+    using System.Data.Entity.Core.Metadata.Edm;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
@@ -240,9 +241,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                         CommandTimeout = 0
                     };
 
+            var optimizeParameters =
+                ((StoreItemCollection)_connection
+                    .GetMetadataWorkspace()
+                    .GetItemCollection(DataSpace.SSpace))
+                        .ProviderManifest
+                        .SupportsParameterOptimizationInSchemaQueries();
+
             command.CommandText =
                 new EntityStoreSchemaQueryGenerator(sql, orderByClause, queryTypes, filters, filterAliases)
-                    .GenerateQuery(command.Parameters);
+                    .GenerateQuery(command.Parameters, optimizeParameters);
 
             return command;
         }

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGenerator.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGenerator.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             }
 
             var sqlStatement = new StringBuilder(_baseQuery);
+
             var whereClause = CreateWhereClause(parameters);
 
             if (whereClause.Length != 0)

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/ParameterCollectionBuilder.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/ParameterCollectionBuilder.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.SchemaDiscovery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.Entity.Core.EntityClient;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    // Abstracts building collections of parameters with or without duplicate parameter value de-duplication
+    internal class ParameterCollectionBuilder
+    {
+        private EntityParameterCollection _parameterCollection;
+        private Dictionary<string, string> _parameterMap = null;
+
+        public ParameterCollectionBuilder(EntityParameterCollection parameterCollection, bool optimizeParameters)
+        {
+            _parameterCollection = parameterCollection;
+            if (optimizeParameters)
+            {
+                _parameterMap = new Dictionary<string, string>(StringComparer.Ordinal);
+            }
+        }
+
+        // used for testing
+        public ParameterCollectionBuilder() : this(new EntityCommand().Parameters, true)
+        {
+        }
+
+        private bool IsOptimized
+        {
+            get
+            {
+                return _parameterMap != null;
+            }
+        }
+
+        public EntityParameterCollection ParameterCollection
+        {
+            get
+            {
+                return _parameterCollection;
+            }
+        }
+
+        public string GetOrAdd(string parameterValue)
+        {
+            string parameterName = null;
+            if (!IsOptimized || IsOptimized && !_parameterMap.TryGetValue(parameterValue, out parameterName))
+            {
+                parameterName = GetParameterName();
+                _parameterCollection.AddWithValue(parameterName, parameterValue);
+                if (IsOptimized)
+                {
+                    _parameterMap.Add(parameterValue, parameterName);
+                }
+            }
+            return parameterName;
+        }
+
+        private string GetParameterName()
+        {
+            return "p" + _parameterCollection.Count.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/ParameterCollectionBuilder.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/ParameterCollectionBuilder.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             string parameterName = null;
             if (!IsOptimized || IsOptimized && !_parameterMap.TryGetValue(parameterValue, out parameterName))
             {
-                parameterName = GetParameterName();
+                parameterName = GetNextParameterName();
                 _parameterCollection.AddWithValue(parameterName, parameterValue);
                 if (IsOptimized)
                 {
@@ -61,7 +61,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             return parameterName;
         }
 
-        private string GetParameterName()
+        private string GetNextParameterName()
         {
             return "p" + _parameterCollection.Count.ToString(CultureInfo.InvariantCulture);
         }

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/ParameterCollectionBuilder.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/ParameterCollectionBuilder.cs
@@ -6,56 +6,57 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
     using System.Collections.Generic;
     using System.Data.Entity.Core.EntityClient;
     using System.Globalization;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
-    // Abstracts building collections of parameters with or without duplicate parameter value de-duplication
+    // Abstracts building collections of parameters for schema queries 
+    // with or without parameter value de-duplication
     internal class ParameterCollectionBuilder
     {
-        private EntityParameterCollection _parameterCollection;
-        private Dictionary<string, string> _parameterMap = null;
+        private EntityParameterCollection _collection;
+        private Dictionary<string, string> _map = null;
 
-        public ParameterCollectionBuilder(EntityParameterCollection parameterCollection, bool optimizeParameters)
+        public ParameterCollectionBuilder(EntityParameterCollection collection, bool optimized)
         {
-            _parameterCollection = parameterCollection;
-            if (optimizeParameters)
+            _collection = collection;
+            if (optimized)
             {
-                _parameterMap = new Dictionary<string, string>(StringComparer.Ordinal);
+                _map = new Dictionary<string, string>(StringComparer.Ordinal);
             }
         }
 
-        // used for testing
-        public ParameterCollectionBuilder() : this(new EntityCommand().Parameters, true)
-        {
-        }
-
-        private bool IsOptimized
+        public int Count
         {
             get
             {
-                return _parameterMap != null;
+                return _collection.Count;
             }
         }
 
-        public EntityParameterCollection ParameterCollection
+        public EntityParameter this[int index]
         {
             get
             {
-                return _parameterCollection;
+                return _collection[index];
+            }
+        }
+
+        public EntityParameter this[string parameterName]
+        {
+            get
+            {
+                return _collection[parameterName];
             }
         }
 
         public string GetOrAdd(string parameterValue)
         {
             string parameterName = null;
-            if (!IsOptimized || IsOptimized && !_parameterMap.TryGetValue(parameterValue, out parameterName))
+            if (_map == null || !_map.TryGetValue(parameterValue, out parameterName))
             {
                 parameterName = GetNextParameterName();
-                _parameterCollection.AddWithValue(parameterName, parameterValue);
-                if (IsOptimized)
+                _collection.AddWithValue(parameterName, parameterValue);
+                if (_map != null)
                 {
-                    _parameterMap.Add(parameterValue, parameterName);
+                    _map.Add(parameterValue, parameterName);
                 }
             }
             return parameterName;
@@ -63,7 +64,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
 
         private string GetNextParameterName()
         {
-            return "p" + _parameterCollection.Count.ToString(CultureInfo.InvariantCulture);
+            return "p" + _collection.Count.ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
@@ -19,13 +19,13 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     string.Empty,
                     string.Empty,
                     /* value */ null,
-                    new Dictionary<string,string>()).ToString());
+                    new ParameterCollectionBuilder()).ToString());
         }
 
         [Fact]
         public void AppendComparison_creates_comparison_fragment_and_corresponding_parameter_for_non_null_value()
         {
-            var parameterMap = new Dictionary<string, string>();
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "alias.propertyName LIKE @p0",
@@ -34,16 +34,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     "alias",
                     "propertyName",
                     "Value",
-                    parameterMap).ToString());
+                    parameterBuilder).ToString());
 
-            Assert.Equal(1, parameterMap.Count);
-            Assert.Equal(parameterMap["Value"], "p0");
+            Assert.Equal(1, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal("Value", parameterBuilder.ParameterCollection["p0"].Value);
         }
 
         [Fact]
         public void AppendComparison_creates_parameters_and_adds_AND_for_multiple_comparisons()
         {
-            var parameterMap = new Dictionary<string, string>();
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             var filterBuilder =
                 EntityStoreSchemaQueryGenerator.AppendComparison(
@@ -51,28 +51,28 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     "alias1",
                     "propertyName1",
                     "Value1",
-                    parameterMap);
+                    parameterBuilder);
 
             EntityStoreSchemaQueryGenerator.AppendComparison(
                 filterBuilder,
                 "alias2",
                 "propertyName2",
                 "Value2",
-                parameterMap);
+                parameterBuilder);
 
             Assert.Equal(
                 "alias1.propertyName1 LIKE @p0 AND alias2.propertyName2 LIKE @p1",
                 filterBuilder.ToString());
 
-            Assert.Equal(2, parameterMap.Count);
-            Assert.Equal(parameterMap["Value1"], "p0");
-            Assert.Equal(parameterMap["Value2"], "p1");
+            Assert.Equal(2, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal("Value1", parameterBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal("Value2", parameterBuilder.ParameterCollection["p1"].Value);
         }
 
         [Fact]
         public void AppendFilterEntry_creates_filter_for_catalog_schema_and_name_if_all_specified()
         {
-            var parameterMap = new Dictionary<string, string>();
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "(alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1 AND alias.Name LIKE @p2)",
@@ -80,12 +80,12 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry("catalog", "schema", "name"),
-                    parameterMap).ToString());
+                    parameterBuilder).ToString());
 
             Assert.Equal(3, parameterMap.Count);
-            Assert.Equal(parameterMap["catalog"], "p0");
-            Assert.Equal(parameterMap["schema"], "p1");
-            Assert.Equal(parameterMap["name"], "p2");
+            Assert.Equal("catalog", parameterBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal("schema", parameterBuilder.ParameterCollection["p1"].Value);
+            Assert.Equal("name", parameterBuilder.ParameterCollection["p2"].Value);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry(null, "schema", "name"),
-                    new Dictionary<string, string>()).ToString());
+                    new ParameterCollectionBuilder()).ToString());
 
             Assert.Equal(
                 "(alias.CatalogName LIKE @p0 AND alias.Name LIKE @p1)",
@@ -105,7 +105,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry("catalog", null, "name"),
-                    new Dictionary<string, string>()).ToString());
+                    new ParameterCollectionBuilder()).ToString());
 
             Assert.Equal(
                 "(alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1)",
@@ -113,13 +113,13 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry("catalog", "schema", null),
-                    new Dictionary<string, string>()).ToString());
+                    new ParameterCollectionBuilder()).ToString());
         }
 
         [Fact]
         public void AppendFilterEntry_uses_wildcard_parameter_value_if_schema_catalog_and_name_are_null()
         {
-            var parameterMap = new Dictionary<string, string>();
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "(alias.Name LIKE @p0)",
@@ -127,38 +127,38 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry(null, null, null),
-                    parameterMap).ToString());
+                    parameterBuilder).ToString());
 
-            Assert.Equal(1, parameterMap.Count);
-            Assert.Equal(parameterMap["%"], "p0");
+            Assert.Equal(1, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal("%", parameterBuilder.ParameterCollection["p0"].Value);
         }
 
         [Fact]
         public void AppendFilterEntry_uses_OR_to_connect_multiple_filters()
         {
-            var parameterMap = new Dictionary<string, string>();
+            var parameterBuilder = new ParameterCollectionBuilder();
             var filterBuilder = new StringBuilder();
 
             EntityStoreSchemaQueryGenerator.AppendFilterEntry(
                 filterBuilder,
                 "alias",
                 new EntityStoreSchemaFilterEntry(null, null, null),
-                parameterMap);
+                parameterBuilder);
 
             EntityStoreSchemaQueryGenerator.AppendFilterEntry(
                 filterBuilder,
                 "alias",
                 new EntityStoreSchemaFilterEntry("catalog", "schema", null),
-                parameterMap);
+                parameterBuilder);
 
             Assert.Equal(
                 "(alias.Name LIKE @p0) OR (alias.CatalogName LIKE @p1 AND alias.SchemaName LIKE @p2)",
                 filterBuilder.ToString());
 
-            Assert.Equal(3, parameterMap.Count);
-            Assert.Equal(parameterMap["%"], "p0");
-            Assert.Equal(parameterMap["catalog"], "p1");
-            Assert.Equal(parameterMap["schema"], "p2");
+            Assert.Equal(3, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal("%", parameterBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal("catalog", parameterBuilder.ParameterCollection["p1"].Value);
+            Assert.Equal("schema", parameterBuilder.ParameterCollection["p2"].Value);
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Allow)
                         },
                     filterAliases: new string[0])
-                    .CreateWhereClause(new EntityCommand().Parameters).ToString());
+                    .CreateWhereClause(new ParameterCollectionBuilder()).ToString());
         }
 
         [Fact]
@@ -192,13 +192,13 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     EntityStoreSchemaFilterObjectTypes.Table,
                     new EntityStoreSchemaFilterEntry[0],
                     new[] { "alias" })
-                    .CreateWhereClause(new EntityCommand().Parameters).ToString());
+                    .CreateWhereClause(new ParameterCollectionBuilder()).ToString());
         }
 
         [Fact]
         public void Where_clause_created_for_single_Allow_filter()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "((alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1 AND alias.Name LIKE @p2))",
@@ -216,18 +216,18 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Allow)
                         },
                     new[] { "alias" })
-                    .CreateWhereClause(parameters).ToString());
+                    .CreateWhereClause(parameterBuilder).ToString());
 
-            Assert.Equal(3, parameters.Count);
-            Assert.Equal(parameters["p0"].Value, "catalog");
-            Assert.Equal(parameters["p1"].Value, "schema");
-            Assert.Equal(parameters["p2"].Value, "name");
+            Assert.Equal(3, parameterBuilder.Count);
+            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "catalog");
+            Assert.Equal(parameterBuilder.ParameterCollection["p1"].Value, "schema");
+            Assert.Equal(parameterBuilder.ParameterCollection["p2"].Value, "name");
         }
 
         [Fact]
         public void Where_clause_uses_AND_to_connect_multiple_aliases_and_Allow_filter()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "((alias1.Name LIKE @p0))\r\nAND\r\n((alias2.Name LIKE @p0))",
@@ -245,16 +245,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Allow),
                         },
                     new[] { "alias1", "alias2" })
-                    .CreateWhereClause(parameters).ToString());
+                    .CreateWhereClause(parameterBuilder).ToString());
 
-            Assert.Equal(1, parameters.Count);
-            Assert.Equal(parameters["p0"].Value, "name");
+            Assert.Equal(1, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "name");
         }
 
         [Fact]
         public void Where_clause_created_for_single_Exclude_filter()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "NOT ((alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1 AND alias.Name LIKE @p2))",
@@ -272,18 +272,18 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude)
                         },
                     new[] { "alias" })
-                    .CreateWhereClause(parameters).ToString());
+                    .CreateWhereClause(parameterBuilder).ToString());
 
-            Assert.Equal(3, parameters.Count);
-            Assert.Equal(parameters["p0"].Value, "catalog");
-            Assert.Equal(parameters["p1"].Value, "schema");
-            Assert.Equal(parameters["p2"].Value, "name");
+            Assert.Equal(3, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "catalog");
+            Assert.Equal(parameterBuilder.ParameterCollection["p1"].Value, "schema");
+            Assert.Equal(parameterBuilder.ParameterCollection["p2"].Value, "name");
         }
 
         [Fact]
         public void Where_clause_uses_AND_to_connect_multiple_aliases_and_Exclude_filter()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "NOT ((alias1.Name LIKE @p0))\r\nAND\r\nNOT ((alias2.Name LIKE @p0))",
@@ -301,16 +301,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude),
                         },
                     new[] { "alias1", "alias2" })
-                    .CreateWhereClause(parameters).ToString());
+                    .CreateWhereClause(parameterBuilder).ToString());
 
-            Assert.Equal(1, parameters.Count);
-           Assert.Equal(parameters["p0"].Value, "name");
+            Assert.Equal(1, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "name");
         }
 
         [Fact]
         public void Where_clause_created_when_Allow_and_Exclude_present()
         {
-            var parameters = new EntityCommand().Parameters;
+            var parameterBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "NOT ((alias.Name LIKE @p0) OR (alias.Name LIKE @p1))",
@@ -334,11 +334,11 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude)
                         },
                     new[] { "alias" })
-                    .CreateWhereClause(parameters).ToString());
+                    .CreateWhereClause(parameterBuilder).ToString());
 
-            Assert.Equal(2, parameters.Count);
-            Assert.Equal(parameters["p0"].Value, "nameAllowed");
-            Assert.Equal(parameters["p1"].Value, "nameExcluded");
+            Assert.Equal(2, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "nameAllowed");
+            Assert.Equal(parameterBuilder.ParameterCollection["p1"].Value, "nameExcluded");
         }
 
         [Fact]
@@ -354,9 +354,9 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     EntityStoreSchemaFilterObjectTypes.Table,
                     new EntityStoreSchemaFilterEntry[0],
                     new string[0])
-                    .GenerateQuery(parameters));
+                    .GenerateQuery(parameterBuilder.ParameterCollection), false);
 
-            Assert.Equal(0, parameters.Count);
+            Assert.Equal(0, parameterBuilder.ParameterCollection.Count);
         }
 
         [Fact]
@@ -380,7 +380,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude),
                         },
                     new string[0])
-                    .GenerateQuery(parameters));
+                    .GenerateQuery(parameters, false));
 
             Assert.Equal(0, parameters.Count);
         }
@@ -406,7 +406,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude),
                         },
                     new[] { "alias" })
-                    .GenerateQuery(parameters));
+                    .GenerateQuery(parameters, false));
 
             Assert.Equal(1, parameters.Count);
             Assert.Equal(parameters["p0"].Value, "name");
@@ -425,7 +425,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     EntityStoreSchemaFilterObjectTypes.Table,
                     new EntityStoreSchemaFilterEntry[0],
                     new string[0])
-                    .GenerateQuery(parameters));
+                    .GenerateQuery(parameters, false));
 
             Assert.Equal(0, parameters.Count);
         }
@@ -451,7 +451,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude),
                         },
                     new[] { "alias" })
-                    .GenerateQuery(parameters));
+                    .GenerateQuery(parameters, false));
 
             Assert.Equal(1, parameters.Count);
             Assert.Equal(parameters["p0"].Value, "name");

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
         [Fact]
         public void AppendComparison_creates_comparison_fragment_and_corresponding_parameter_for_non_null_value()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameterCollectionBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "alias.propertyName LIKE @p0",
@@ -34,16 +34,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     "alias",
                     "propertyName",
                     "Value",
-                    parameterBuilder).ToString());
+                    parameterCollectionBuilder).ToString());
 
-            Assert.Equal(1, parameterBuilder.ParameterCollection.Count);
-            Assert.Equal("Value", parameterBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal(1, parameterCollectionBuilder.ParameterCollection.Count);
+            Assert.Equal("Value", parameterCollectionBuilder.ParameterCollection["p0"].Value);
         }
 
         [Fact]
         public void AppendComparison_creates_parameters_and_adds_AND_for_multiple_comparisons()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameterCollectionBuilder = new ParameterCollectionBuilder();
 
             var filterBuilder =
                 EntityStoreSchemaQueryGenerator.AppendComparison(
@@ -51,28 +51,28 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     "alias1",
                     "propertyName1",
                     "Value1",
-                    parameterBuilder);
+                    parameterCollectionBuilder);
 
             EntityStoreSchemaQueryGenerator.AppendComparison(
                 filterBuilder,
                 "alias2",
                 "propertyName2",
                 "Value2",
-                parameterBuilder);
+                parameterCollectionBuilder);
 
             Assert.Equal(
                 "alias1.propertyName1 LIKE @p0 AND alias2.propertyName2 LIKE @p1",
                 filterBuilder.ToString());
 
-            Assert.Equal(2, parameterBuilder.ParameterCollection.Count);
-            Assert.Equal("Value1", parameterBuilder.ParameterCollection["p0"].Value);
-            Assert.Equal("Value2", parameterBuilder.ParameterCollection["p1"].Value);
+            Assert.Equal(2, parameterCollectionBuilder.ParameterCollection.Count);
+            Assert.Equal("Value1", parameterCollectionBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal("Value2", parameterCollectionBuilder.ParameterCollection["p1"].Value);
         }
 
         [Fact]
         public void AppendFilterEntry_creates_filter_for_catalog_schema_and_name_if_all_specified()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameterCollectionBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "(alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1 AND alias.Name LIKE @p2)",
@@ -80,12 +80,12 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry("catalog", "schema", "name"),
-                    parameterBuilder).ToString());
+                    parameterCollectionBuilder).ToString());
 
             Assert.Equal(3, parameterMap.Count);
-            Assert.Equal("catalog", parameterBuilder.ParameterCollection["p0"].Value);
-            Assert.Equal("schema", parameterBuilder.ParameterCollection["p1"].Value);
-            Assert.Equal("name", parameterBuilder.ParameterCollection["p2"].Value);
+            Assert.Equal("catalog", parameterCollectionBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal("schema", parameterCollectionBuilder.ParameterCollection["p1"].Value);
+            Assert.Equal("name", parameterCollectionBuilder.ParameterCollection["p2"].Value);
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
         [Fact]
         public void AppendFilterEntry_uses_wildcard_parameter_value_if_schema_catalog_and_name_are_null()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameterCollectionBuilder = new ParameterCollectionBuilder();
 
             Assert.Equal(
                 "(alias.Name LIKE @p0)",
@@ -127,38 +127,38 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new StringBuilder(),
                     "alias",
                     new EntityStoreSchemaFilterEntry(null, null, null),
-                    parameterBuilder).ToString());
+                    parameterCollectionBuilder).ToString());
 
-            Assert.Equal(1, parameterBuilder.ParameterCollection.Count);
-            Assert.Equal("%", parameterBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal(1, parameterCollectionBuilder.ParameterCollection.Count);
+            Assert.Equal("%", parameterCollectionBuilder.ParameterCollection["p0"].Value);
         }
 
         [Fact]
         public void AppendFilterEntry_uses_OR_to_connect_multiple_filters()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameterCollectionBuilder = new ParameterCollectionBuilder();
             var filterBuilder = new StringBuilder();
 
             EntityStoreSchemaQueryGenerator.AppendFilterEntry(
                 filterBuilder,
                 "alias",
                 new EntityStoreSchemaFilterEntry(null, null, null),
-                parameterBuilder);
+                parameterCollectionBuilder);
 
             EntityStoreSchemaQueryGenerator.AppendFilterEntry(
                 filterBuilder,
                 "alias",
                 new EntityStoreSchemaFilterEntry("catalog", "schema", null),
-                parameterBuilder);
+                parameterCollectionBuilder);
 
             Assert.Equal(
                 "(alias.Name LIKE @p0) OR (alias.CatalogName LIKE @p1 AND alias.SchemaName LIKE @p2)",
                 filterBuilder.ToString());
 
-            Assert.Equal(3, parameterBuilder.ParameterCollection.Count);
-            Assert.Equal("%", parameterBuilder.ParameterCollection["p0"].Value);
-            Assert.Equal("catalog", parameterBuilder.ParameterCollection["p1"].Value);
-            Assert.Equal("schema", parameterBuilder.ParameterCollection["p2"].Value);
+            Assert.Equal(3, parameterCollectionBuilder.ParameterCollection.Count);
+            Assert.Equal("%", parameterCollectionBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal("catalog", parameterCollectionBuilder.ParameterCollection["p1"].Value);
+            Assert.Equal("schema", parameterCollectionBuilder.ParameterCollection["p2"].Value);
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Allow)
                         },
                     filterAliases: new string[0])
-                    .CreateWhereClause(new ParameterCollectionBuilder()).ToString());
+                    .CreateWhereClause(new EntityCommand().Parameters).ToString());
         }
 
         [Fact]
@@ -192,13 +192,13 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     EntityStoreSchemaFilterObjectTypes.Table,
                     new EntityStoreSchemaFilterEntry[0],
                     new[] { "alias" })
-                    .CreateWhereClause(new ParameterCollectionBuilder()).ToString());
+                    .CreateWhereClause(new EntityCommand().Parameters).ToString());
         }
 
         [Fact]
         public void Where_clause_created_for_single_Allow_filter()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameters = new EntityCommand().Parameters;
 
             Assert.Equal(
                 "((alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1 AND alias.Name LIKE @p2))",
@@ -216,18 +216,18 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Allow)
                         },
                     new[] { "alias" })
-                    .CreateWhereClause(parameterBuilder).ToString());
+                    .CreateWhereClause(parameters).ToString());
 
-            Assert.Equal(3, parameterBuilder.Count);
-            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "catalog");
-            Assert.Equal(parameterBuilder.ParameterCollection["p1"].Value, "schema");
-            Assert.Equal(parameterBuilder.ParameterCollection["p2"].Value, "name");
+            Assert.Equal(3, parameters.Count);
+            Assert.Equal(parameters["p0"].Value, "catalog");
+            Assert.Equal(parameters["p1"].Value, "schema");
+            Assert.Equal(parameters["p2"].Value, "name");
         }
 
         [Fact]
         public void Where_clause_uses_AND_to_connect_multiple_aliases_and_Allow_filter()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameters = new EntityCommand().Parameters;
 
             Assert.Equal(
                 "((alias1.Name LIKE @p0))\r\nAND\r\n((alias2.Name LIKE @p0))",
@@ -245,16 +245,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Allow),
                         },
                     new[] { "alias1", "alias2" })
-                    .CreateWhereClause(parameterBuilder).ToString());
+                    .CreateWhereClause(parameters).ToString());
 
-            Assert.Equal(1, parameterBuilder.ParameterCollection.Count);
-            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "name");
+            Assert.Equal(1, parameters.Count);
+            Assert.Equal(parameters["p0"].Value, "name");
         }
 
         [Fact]
         public void Where_clause_created_for_single_Exclude_filter()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameters = new EntityCommand().Parameters;
 
             Assert.Equal(
                 "NOT ((alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1 AND alias.Name LIKE @p2))",
@@ -272,18 +272,18 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude)
                         },
                     new[] { "alias" })
-                    .CreateWhereClause(parameterBuilder).ToString());
+                    .CreateWhereClause(parameters).ToString());
 
-            Assert.Equal(3, parameterBuilder.ParameterCollection.Count);
-            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "catalog");
-            Assert.Equal(parameterBuilder.ParameterCollection["p1"].Value, "schema");
-            Assert.Equal(parameterBuilder.ParameterCollection["p2"].Value, "name");
+            Assert.Equal(3, parameters.Count);
+            Assert.Equal(parameters["p0"].Value, "catalog");
+            Assert.Equal(parameters["p1"].Value, "schema");
+            Assert.Equal(parameters["p2"].Value, "name");
         }
 
         [Fact]
         public void Where_clause_uses_AND_to_connect_multiple_aliases_and_Exclude_filter()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameters = new EntityCommand().Parameters;
 
             Assert.Equal(
                 "NOT ((alias1.Name LIKE @p0))\r\nAND\r\nNOT ((alias2.Name LIKE @p0))",
@@ -301,16 +301,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude),
                         },
                     new[] { "alias1", "alias2" })
-                    .CreateWhereClause(parameterBuilder).ToString());
+                    .CreateWhereClause(parameters).ToString());
 
-            Assert.Equal(1, parameterBuilder.ParameterCollection.Count);
-            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "name");
+            Assert.Equal(1, parameters.Count);
+            Assert.Equal(parameters["p0"].Value, "name");
         }
 
         [Fact]
         public void Where_clause_created_when_Allow_and_Exclude_present()
         {
-            var parameterBuilder = new ParameterCollectionBuilder();
+            var parameters = new EntityCommand().Parameters;
 
             Assert.Equal(
                 "NOT ((alias.Name LIKE @p0) OR (alias.Name LIKE @p1))",
@@ -334,11 +334,11 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude)
                         },
                     new[] { "alias" })
-                    .CreateWhereClause(parameterBuilder).ToString());
+                    .CreateWhereClause(parameters).ToString());
 
-            Assert.Equal(2, parameterBuilder.ParameterCollection.Count);
-            Assert.Equal(parameterBuilder.ParameterCollection["p0"].Value, "nameAllowed");
-            Assert.Equal(parameterBuilder.ParameterCollection["p1"].Value, "nameExcluded");
+            Assert.Equal(2, parameters.Count);
+            Assert.Equal(parameters["p0"].Value, "nameAllowed");
+            Assert.Equal(parameters["p1"].Value, "nameExcluded");
         }
 
         [Fact]
@@ -354,9 +354,9 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     EntityStoreSchemaFilterObjectTypes.Table,
                     new EntityStoreSchemaFilterEntry[0],
                     new string[0])
-                    .GenerateQuery(parameterBuilder.ParameterCollection), false);
+                    .GenerateQuery(parameters), false);
 
-            Assert.Equal(0, parameterBuilder.ParameterCollection.Count);
+            Assert.Equal(0, parameters.Count);
         }
 
         [Fact]
@@ -380,7 +380,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude),
                         },
                     new string[0])
-                    .GenerateQuery(parameters, false));
+                    .GenerateQuery(parameters));
 
             Assert.Equal(0, parameters.Count);
         }
@@ -406,7 +406,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude),
                         },
                     new[] { "alias" })
-                    .GenerateQuery(parameters, false));
+                    .GenerateQuery(parameters));
 
             Assert.Equal(1, parameters.Count);
             Assert.Equal(parameters["p0"].Value, "name");
@@ -425,7 +425,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     EntityStoreSchemaFilterObjectTypes.Table,
                     new EntityStoreSchemaFilterEntry[0],
                     new string[0])
-                    .GenerateQuery(parameters, false));
+                    .GenerateQuery(parameters));
 
             Assert.Equal(0, parameters.Count);
         }
@@ -451,7 +451,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                                 EntityStoreSchemaFilterEffect.Exclude),
                         },
                     new[] { "alias" })
-                    .GenerateQuery(parameters, false));
+                    .GenerateQuery(parameters));
 
             Assert.Equal(1, parameters.Count);
             Assert.Equal(parameters["p0"].Value, "name");

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
         public void AppendComparison_creates_comparison_fragment_and_corresponding_parameter_for_non_null_value()
         {
             var parameterCollectionBuilder = new ParameterCollectionBuilder();
+            var parameters = parameterCollectionBuilder.ParameterCollection;
 
             Assert.Equal(
                 "alias.propertyName LIKE @p0",
@@ -36,15 +37,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     "Value",
                     parameterCollectionBuilder).ToString());
 
-            Assert.Equal(1, parameterCollectionBuilder.ParameterCollection.Count);
-            Assert.Equal("p0", parameterCollectionBuilder.ParameterCollection[0].ParameterName);
-            Assert.Equal("Value", parameterCollectionBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal(1, parameters.Count);
+            Assert.Equal("p0", parameters[0].ParameterName);
+            Assert.Equal("Value", parameters["p0"].Value);
         }
 
         [Fact]
         public void AppendComparison_creates_parameters_and_adds_AND_for_multiple_comparisons()
         {
             var parameterCollectionBuilder = new ParameterCollectionBuilder();
+            var parameters = parameterCollectionBuilder.ParameterCollection;
 
             var filterBuilder =
                 EntityStoreSchemaQueryGenerator.AppendComparison(
@@ -65,16 +67,17 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                 "alias1.propertyName1 LIKE @p0 AND alias2.propertyName2 LIKE @p1",
                 filterBuilder.ToString());
 
-            Assert.Equal(2, parameterCollectionBuilder.ParameterCollection.Count);
-            Assert.Equal("p0", parameterCollectionBuilder.ParameterCollection[0].ParameterName);
-            Assert.Equal("Value1", parameterCollectionBuilder.ParameterCollection["p0"].Value);
-            Assert.Equal("Value2", parameterCollectionBuilder.ParameterCollection["p1"].Value);
+            Assert.Equal(2, parameters.Count);
+            Assert.Equal("p0", parameters[0].ParameterName);
+            Assert.Equal("Value1", parameters["p0"].Value);
+            Assert.Equal("Value2", parameters["p1"].Value);
         }
 
         [Fact]
         public void AppendFilterEntry_creates_filter_for_catalog_schema_and_name_if_all_specified()
         {
             var parameterCollectionBuilder = new ParameterCollectionBuilder();
+            var parameters = parameterCollectionBuilder.ParameterCollection;
 
             Assert.Equal(
                 "(alias.CatalogName LIKE @p0 AND alias.SchemaName LIKE @p1 AND alias.Name LIKE @p2)",
@@ -84,11 +87,11 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new EntityStoreSchemaFilterEntry("catalog", "schema", "name"),
                     parameterCollectionBuilder).ToString());
 
-            Assert.Equal(3, parameterMap.Count);
-            Assert.Equal("p0", parameterCollectionBuilder.ParameterCollection[0].ParameterName);
-            Assert.Equal("catalog", parameterCollectionBuilder.ParameterCollection["p0"].Value);
-            Assert.Equal("schema", parameterCollectionBuilder.ParameterCollection["p1"].Value);
-            Assert.Equal("name", parameterCollectionBuilder.ParameterCollection["p2"].Value);
+            Assert.Equal(3, parameters.Count);
+            Assert.Equal("p0", parameters[0].ParameterName);
+            Assert.Equal("catalog", parameters["p0"].Value);
+            Assert.Equal("schema", parameters["p1"].Value);
+            Assert.Equal("name", parameters["p2"].Value);
         }
 
         [Fact]
@@ -123,6 +126,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
         public void AppendFilterEntry_uses_wildcard_parameter_value_if_schema_catalog_and_name_are_null()
         {
             var parameterCollectionBuilder = new ParameterCollectionBuilder();
+            var parameters = parameterCollectionBuilder.ParameterCollection;
 
             Assert.Equal(
                 "(alias.Name LIKE @p0)",
@@ -132,15 +136,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                     new EntityStoreSchemaFilterEntry(null, null, null),
                     parameterCollectionBuilder).ToString());
 
-            Assert.Equal(1, parameterCollectionBuilder.ParameterCollection.Count);
-            Assert.Equal("p0", parameterCollectionBuilder.ParameterCollection[0].ParameterName);
-            Assert.Equal("%", parameterCollectionBuilder.ParameterCollection["p0"].Value);
+            Assert.Equal(1, parameters.Count);
+            Assert.Equal("p0", parameters[0].ParameterName);
+            Assert.Equal("%", parameters["p0"].Value);
         }
 
         [Fact]
         public void AppendFilterEntry_uses_OR_to_connect_multiple_filters()
         {
             var parameterCollectionBuilder = new ParameterCollectionBuilder();
+            var parameters = parameterCollectionBuilder.ParameterCollection;
             var filterBuilder = new StringBuilder();
 
             EntityStoreSchemaQueryGenerator.AppendFilterEntry(
@@ -159,12 +164,12 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                 "(alias.Name LIKE @p0) OR (alias.CatalogName LIKE @p1 AND alias.SchemaName LIKE @p2)",
                 filterBuilder.ToString());
 
-            Assert.Equal(3, parameterCollectionBuilder.ParameterCollection.Count);
-            Assert.Equal("p0", parameterCollectionBuilder.ParameterCollection[0].ParameterName);
-            Assert.Equal("p1", parameterCollectionBuilder.ParameterCollection[1].ParameterName);
-            Assert.Equal("%", parameterCollectionBuilder.ParameterCollection["p0"].Value);
-            Assert.Equal("catalog", parameterCollectionBuilder.ParameterCollection["p1"].Value);
-            Assert.Equal("schema", parameterCollectionBuilder.ParameterCollection["p2"].Value);
+            Assert.Equal(3, parameters.Count);
+            Assert.Equal("p0", parameters[0].ParameterName);
+            Assert.Equal("p1", parameters[1].ParameterName);
+            Assert.Equal("%", parameters["p0"].Value);
+            Assert.Equal("catalog", parameters["p1"].Value);
+            Assert.Equal("schema", parameters["p2"].Value);
         }
 
         [Fact]


### PR DESCRIPTION
Abstracts the change we took to avoid creating duplicate parameters that contain the same value into a `ParameterCollectionBuilder` class, so that schema discovery queries can be generated with or without the optimization depending on whether the provider supports it.

This approach avoid as much as possible duplicating the code.

Added a couple of test variants that explicitly test the parameter optimization.

TO-DO: still working on setting up a machine in which everything builds, but wanted to get this out there to get feedback.