### PR TITLE
Allow query translator to translate new Guid(x.SomeStringField)

### DIFF
--- a/src/EntityFramework/Core/Objects/ELinq/Translator.cs
+++ b/src/EntityFramework/Core/Objects/ELinq/Translator.cs
@@ -811,6 +811,14 @@ namespace System.Data.Entity.Core.Objects.ELinq
         private sealed class NewTranslator
             : TypedTranslator<NewExpression>
         {
+            /// <summary>
+            /// List of type pairs that constructor call new XXXX(YYY yyy) could be translated to SQL CAST(yyy AS XXXXX) call
+            /// </summary>
+            private List<Tuple<Type, Type>> _castableTypes = new List<Tuple<Type, Type>>()
+            {
+                new Tuple<Type, Type>(typeof(Guid), typeof(string)),
+            };
+
             internal NewTranslator()
                 : base(ExpressionType.New)
             {
@@ -819,6 +827,13 @@ namespace System.Data.Entity.Core.Objects.ELinq
             protected override DbExpression TypedTranslate(ExpressionConverter parent, NewExpression linq)
             {
                 var memberCount = null == linq.Members ? 0 : linq.Members.Count;
+
+                if (linq.Arguments.Count == 1
+                    && _castableTypes.Any(cast => cast.Item1 == linq.Constructor.DeclaringType && cast.Item2 == linq.Arguments[0].Type))
+                {
+                    return parent.CreateCastExpression(
+                        parent.TranslateExpression(linq.Arguments[0]), linq.Constructor.DeclaringType, linq.Arguments[0].Type);
+                }
 
                 if (null == linq.Constructor
                     ||

--- a/test/EntityFramework/FunctionalTests/Query/LinqToEntities/FunctionsTests.cs
+++ b/test/EntityFramework/FunctionalTests/Query/LinqToEntities/FunctionsTests.cs
@@ -338,6 +338,26 @@ namespace System.Data.Entity.Query.LinqToEntities
         }
 
         [Fact]
+        public void GuidConstructor_translated_to_correct_function_in_database()
+        {
+            using (var context = new ArubaContext())
+            {
+                var query = context.Owners.Select(o => new Guid("4b44ce33-b60e-4afd-85ad-59d3d7c53f75"));
+                Assert.Contains("CAST('4B44CE33-B60E-4AFD-85AD-59D3D7C53F75' AS UNIQUEIDENTIFIER)", query.ToString().ToUpperInvariant());
+            }
+        }
+
+        [Fact]
+        public void GuidConvert_translated_to_correct_function_in_database()
+        {
+            using (var context = new ArubaContext())
+            {
+                var query = context.AllTypes.Select(o => new Guid(o.c13_varchar_512_));
+                Assert.Contains("CAST( [EXTENT1].[C13_VARCHAR_512_] AS UNIQUEIDENTIFIER)", query.ToString().ToUpperInvariant());
+            }
+        }
+
+        [Fact]
         public void SqlFunctions_scalar_function_translated_properly_to_sql_function()
         {
             using (var context = new ArubaContext())


### PR DESCRIPTION
Allow query translator to translate new Guid(x.SomeStringField)  to CAST(SomeStringField AS UNIQUEIDENTIFIER)

Fixes #249 
@ajcvickers said (in automatic reply, however...) that EF team could accept this kind of community contribution. 

1. Are you actually willing to accept this kind of change at all?
2. Let's discuss what other casts could be implemented here. 
3. I found correct place to make this change, haven't I?