### PR TITLE
Update ObjectStateManager to handle 1:Many relationships in O(n)

### DIFF
--- a/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
@@ -309,7 +309,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
 
                 if (
                     !ObjectStateManager.TryUpdateExistingRelationships(
-                        Context, MergeOption, associationSet, sourceMember, sourceKey, sourceRelationships, wrappedEntity, targetMember, targetKey,
+                        Context, MergeOption, associationSet, sourceMember, sourceRelationships, wrappedEntity, targetMember, targetKey,
                          /*setIsLoaded*/ true, out newEntryState))
                 {
                     // Try to find a state entry for the target key
@@ -331,7 +331,6 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                                 MergeOption,
                                 associationSet,
                                 targetMember,
-                                targetKey,
                                 targetRelationships,
                                 targetEntry.WrappedEntity,
                                 sourceMember,

--- a/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
@@ -303,10 +303,13 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
 
                 var manager = Context.ObjectStateManager;
                 EntityState newEntryState;
-                // If there is an existing relationship entry, update it based on its current state and the MergeOption, otherwise add a new one            
+                // If there is an existing relationship entry, update it based on its current state and the MergeOption, otherwise add a new one        
+
+                var sourceRelationships = ObjectStateManager.GetRelationshipLookup(Context.ObjectStateManager, associationSet, sourceMember, sourceKey);
+
                 if (
                     !ObjectStateManager.TryUpdateExistingRelationships(
-                        Context, MergeOption, associationSet, sourceMember, sourceKey, wrappedEntity, targetMember, targetKey,
+                        Context, MergeOption, associationSet, sourceMember, sourceKey, sourceRelationships, wrappedEntity, targetMember, targetKey,
                          /*setIsLoaded*/ true, out newEntryState))
                 {
                     // Try to find a state entry for the target key
@@ -318,6 +321,9 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                     {
                         case RelationshipMultiplicity.ZeroOrOne:
                         case RelationshipMultiplicity.One:
+
+                            var targetRelationships = ObjectStateManager.GetRelationshipLookup(Context.ObjectStateManager, associationSet, targetMember, targetKey);
+
                             // devnote: targetEntry can be a key entry (targetEntry.Entity == null), 
                             // but it that case this parameter won't be used in TryUpdateExistingRelationships
                             needNewRelationship = !ObjectStateManager.TryUpdateExistingRelationships(
@@ -326,6 +332,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                                 associationSet,
                                 targetMember,
                                 targetKey,
+                                targetRelationships,
                                 targetEntry.WrappedEntity,
                                 sourceMember,
                                 sourceKey,

--- a/src/EntityFramework/Core/Objects/ObjectStateManager.cs
+++ b/src/EntityFramework/Core/Objects/ObjectStateManager.cs
@@ -1019,7 +1019,7 @@ namespace System.Data.Entity.Core.Objects
 
                             if (
                                 !TryUpdateExistingRelationships(
-                                    context, mergeOption, associationSet, sourceMember, sourceKey, sourceKeyRelationshipsLazy.Value, wrappedSource, targetMember, targetKey,
+                                    context, mergeOption, associationSet, sourceMember, sourceKeyRelationshipsLazy.Value, wrappedSource, targetMember, targetKey,
                                     setIsLoaded, out newEntryState))
                             {
                                 var needNewRelationship = true;
@@ -1038,7 +1038,7 @@ namespace System.Data.Entity.Core.Objects
                                         needNewRelationship =
                                             !TryUpdateExistingRelationships(
                                                 context, mergeOption, associationSet, targetMember,
-                                                targetKey, targetKeyRelationships, wrappedTarget, sourceMember, sourceKey, setIsLoaded, out newEntryState);
+                                                targetKeyRelationships, wrappedTarget, sourceMember, sourceKey, setIsLoaded, out newEntryState);
                                         break;
                                     case RelationshipMultiplicity.Many:
                                         // we always need a new relationship with Many-To-Many, if there was no exact match between these two entities, so do nothing                                
@@ -1179,7 +1179,7 @@ namespace System.Data.Entity.Core.Objects
         // <param name="mergeOption"> MergeOption to use when updating existing relationships </param>
         // <param name="associationSet"> AssociationSet for the relationship we are looking for </param>
         // <param name="sourceMember"> AssociationEndMember for the source role of the relationship </param>
-        // <param name="sourceKey"> EntityKey for the source entity in the relationship (passed here so we don't have to look it up again) </param>
+        // <param name="relationshipLookup"> Lookup for the source entity's relationships to find matching relationship entries by target key (passed here for performance reasons) </param>
         // <param name="wrappedSource"> Source entity in the relationship </param>
         // <param name="targetMember"> AssociationEndMember for the target role of the relationship </param>
         // <param name="targetKey"> EntityKey for the target entity in the relationship </param>
@@ -1189,7 +1189,7 @@ namespace System.Data.Entity.Core.Objects
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         internal static bool TryUpdateExistingRelationships(
             ObjectContext context, MergeOption mergeOption, AssociationSet associationSet, AssociationEndMember sourceMember,
-            EntityKey sourceKey, ILookup<EntityKey, RelationshipEntry> relationshipLookup, IEntityWrapper wrappedSource, AssociationEndMember targetMember, EntityKey targetKey, bool setIsLoaded,
+            ILookup<EntityKey, RelationshipEntry> relationshipLookup, IEntityWrapper wrappedSource, AssociationEndMember targetMember, EntityKey targetKey, bool setIsLoaded,
             out EntityState newEntryState)
         {
             Debug.Assert(mergeOption != MergeOption.NoTracking, "Existing relationships should not be updated with NoTracking");
@@ -1225,7 +1225,6 @@ namespace System.Data.Entity.Core.Objects
             }
 
 
-            // We found an existing relationship where the reference side is different on the server than what the client has.
 
             // This relationship is between the same source entity and a different target, so we may need to take steps to fix up the 
             // relationship to ensure that the client state is correct based on the requested MergeOption. 
@@ -1239,6 +1238,7 @@ namespace System.Data.Entity.Core.Objects
                 case RelationshipMultiplicity.ZeroOrOne:
                     foreach (var relationshipEntry in relationshipLookup.Where(g => g.Key != targetKey).SelectMany(re => re))
                     {
+                        // We found an existing relationship where the reference side is different on the server than what the client has.
                         switch (mergeOption)
                         {
                             case MergeOption.AppendOnly:


### PR DESCRIPTION
# Problem
A performance issue exists when loading 1:Many relationships via its navigation property.

## Details
When accessing a 1:Many navigation property, the underlying code fetches the collection and calls `ObjectStateManager`'s `UpdateRelationships` with all of the fetched entities.  

`UpdateRelationships` then calls `TryUpdateExistingRelationships` to attempt to perform "fix-up" on existing relationships.  This is particularly helpful for 1:1 relationships that stem off of the entities that were newly loaded and needs to continue to happen; however, when the relationship is 1:Many, there is nothing to update on the relationship.

This is evidenced by the code at L1278 of ObjectStateManager.cs on the previous side of the diff:
```C#
                            case RelationshipMultiplicity.Many:
                                // do nothing because its okay for this source entity to have multiple different targets, so there is nothing for us to fixup
                                break;
```

The performance problem comes when looking at `UpdateRelationships` and `TryUpdateExistingRelationships` together, in `UpdateRelationships` in the scope of a 1:Many set of targets.  There is an outer loop of `foreach (var someTarget in targets)`, where `targets` is the set of newly loaded entities.  Inside this loop, we call `TryUpdateExistingRelationships` for each of the `targets`, but using the same source member and key.

Inside `TryUpdateExistingRelationships`, we fetch the source member and key's relationship entries and loop through them via `foreach (var relationshipEntry in manager.FindRelationshipsByKey(sourceKey))`.  For a 1:Many relationship target member, we only execute logic if when we find a source entry that matches the target key via `if (relationshipEntry.IsSameAssociationSetAndRole(associationSet, sourceMember, sourceKey))`.

Given that the source entity has N child entities (`targets`), it will have a relationship entry for each of the N child entities.  Because we first loop through the N `targets`, then we loop through the N relationship entries, we can assign the complexity of this process as O(n^2).  This means that when there are, for instance, 40,000 entities being loaded by the navigation property, we are executing the same code (`if (targetKey == relationshipEntry.RelationshipWrapper.GetOtherEntityKey(sourceKey)) { ... } else { ... }`) 1,600,000,000 times.

# Solution
In order to eliminate the O(n^2) complexity of the process for 1:Many relationships, we have to update the `TryUpdateExistingRelationships` to allow us to provide a pre-computed lookup for a source member's relationship entries such that we can find the applicable entries for a given target key.  Since we use the same source member in the outside loop of `UpdateRelationships`, we can create the lookup in O(n) time that will have a O(1) complexity for finding the associated target key.

## Assumptions
The only assumption made is that the `sourceKeyRelationshipsLazy.Value` does not need to be updated when we call `AddEntityToCollectionOrReference` and/or `manager.AddNewRelation`.  While we are technically adding to the set of relationship entries that the source member has, I don't believe that the entry will logically be used.

## Final Code-related Note
This update does not cause the code to become O(n) in all cases, only for the logical case of 1:Many relationships where the source member is the one side of the entry and the target is the Many side of the relationship.

## Maintainer Note
This change was done during the course of business for my employer.  I have submitted an updated CLA, releasing this change to the EF6 project.


Brandon Dahler
