### PR TITLE
Add xml-docs to autogenerated migrations

### DIFF
--- a/src/Common/IEnumerableExtensions.cs
+++ b/src/Common/IEnumerableExtensions.cs
@@ -25,7 +25,7 @@ namespace System.Data.Entity.Utilities
             var uniqueString = targetString;
             var i = 0;
 
-            while (inputStrings.Any(n => String.Equals(n, uniqueString, StringComparison.Ordinal)))
+            while (inputStrings.Any(n => string.Equals(n, uniqueString, StringComparison.Ordinal)))
             {
                 uniqueString = targetString + ++i;
             }
@@ -73,7 +73,7 @@ namespace System.Data.Entity.Utilities
 
             selector = selector ?? (t => t.ToString());
 
-            return String.Join(separator, ts.Where(t => !ReferenceEquals(t, null)).Select(selector));
+            return string.Join(separator, ts.Where(t => !ReferenceEquals(t, null)).Select(selector));
         }
 
         public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource value)

--- a/src/Common/IEnumerableExtensions.cs
+++ b/src/Common/IEnumerableExtensions.cs
@@ -4,6 +4,8 @@
 namespace System.Data.Entity.SqlServer.Utilities
 #elif SQLSERVERCOMPACT
 namespace System.Data.Entity.SqlServerCompact.Utilities
+#elif EF_FUNCTIONALS
+namespace System.Data.Entity.Functionals.Utilities
 #else
 namespace System.Data.Entity.Utilities
 #endif
@@ -23,7 +25,7 @@ namespace System.Data.Entity.Utilities
             var uniqueString = targetString;
             var i = 0;
 
-            while (inputStrings.Any(n => string.Equals(n, uniqueString, StringComparison.Ordinal)))
+            while (inputStrings.Any(n => String.Equals(n, uniqueString, StringComparison.Ordinal)))
             {
                 uniqueString = targetString + ++i;
             }
@@ -71,7 +73,7 @@ namespace System.Data.Entity.Utilities
 
             selector = selector ?? (t => t.ToString());
 
-            return string.Join(separator, ts.Where(t => !ReferenceEquals(t, null)).Select(selector));
+            return String.Join(separator, ts.Where(t => !ReferenceEquals(t, null)).Select(selector));
         }
 
         public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource value)
@@ -96,6 +98,12 @@ namespace System.Data.Entity.Utilities
             }
 
             yield return value;
+        }
+
+        public static int[] FindAllIndex<T>(this T[] array, Predicate<T> match)
+        {
+            return array.Select((value, index) => match(value) ? index : -1)
+                .Where(index => index != -1).ToArray();
         }
     }
 }

--- a/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
@@ -97,6 +97,7 @@ namespace System.Data.Entity.Migrations.Design
                         @namespace, className, writer, "DbMigration", designer: false,
                         namespaces: GetNamespaces(operations));
 
+                    writer.WriteLine("/// <inheritdoc />");
                     writer.WriteLine("public override void Up()");
                     writer.WriteLine("{");
                     writer.Indent++;
@@ -111,6 +112,7 @@ namespace System.Data.Entity.Migrations.Design
 
                     writer.WriteLine();
 
+                    writer.WriteLine("/// <inheritdoc />");
                     writer.WriteLine("public override void Down()");
                     writer.WriteLine("{");
                     writer.Indent++;
@@ -262,6 +264,8 @@ namespace System.Data.Entity.Migrations.Design
             (namespaces ?? GetDefaultNamespaces(designer)).Each(n => writer.WriteLine("using " + n + ";"));
 
             writer.WriteLine();
+
+            writer.WriteLine("/// <inheritdoc cref=\"DbMigration\" />");
 
             WriteClassAttributes(writer, designer);
 

--- a/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
@@ -96,6 +96,7 @@ namespace System.Data.Entity.Migrations.Design
                         @namespace, className, writer, "Inherits DbMigration", designer: false,
                         namespaces: GetNamespaces(operations));
 
+                    writer.WriteLine("''' <inheritdoc />");
                     writer.WriteLine("Public Overrides Sub Up()");
                     writer.Indent++;
 
@@ -109,6 +110,7 @@ namespace System.Data.Entity.Migrations.Design
 
                     writer.WriteLine();
 
+                    writer.WriteLine("''' <inheritdoc />");
                     writer.WriteLine("Public Overrides Sub Down()");
                     writer.Indent++;
 
@@ -269,6 +271,11 @@ namespace System.Data.Entity.Migrations.Design
             }
 
             WriteClassAttributes(writer, designer);
+
+            if (!designer)
+            {
+                writer.WriteLine("''' <inheritdoc cref=\"DbMigration\" />");
+            }
 
             writer.Write("Public ");
 

--- a/test/EntityFramework/FunctionalTests/FunctionalTests.csproj
+++ b/test/EntityFramework/FunctionalTests/FunctionalTests.csproj
@@ -204,6 +204,9 @@
     <Compile Include="..\..\..\src\Common\PropertyInfoExtensions.cs">
       <Link>Utilities\PropertyInfoExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\src\Common\IEnumerableExtensions.cs">
+      <Link>Utilities\IEnumerableExtensions.cs</Link>
+    </Compile>
     <Compile Include="CodeFirst\CodePlex2169.cs" />
     <Compile Include="CodeFirst\ConfigurationScenarioTests.cs" />
     <Compile Include="CodeFirst\FunctionsScenarioTests.cs" />

--- a/test/EntityFramework/FunctionalTests/Migrations/BasicMigrationScenarios.cs
+++ b/test/EntityFramework/FunctionalTests/Migrations/BasicMigrationScenarios.cs
@@ -2,6 +2,7 @@
 
 namespace System.Data.Entity.Migrations
 {
+    using System.Data.Entity.Functionals.Utilities;
     using System.Data.Entity.Migrations.Design;
     using System.Data.Entity.Migrations.Infrastructure;
     using System.IO;
@@ -341,6 +342,56 @@ namespace System.Data.Entity.Migrations
             var generatedMigration = new MigrationScaffolder(migrator.Configuration).Scaffold("Migration_v2");
 
             Assert.Equal(2, Regex.Matches(generatedMigration.UserCode, "RenameTable").Count);
+        }
+
+        [MigrationsTheory]
+        public void Migration_should_contain_xmldocs_before_class()
+        {
+            ResetDatabase();
+
+            var migrator = CreateMigrator<ShopContext_v1>();
+
+            var generatedMigration = new MigrationScaffolder(migrator.Configuration).Scaffold("Migration_v1");
+
+            var lines = generatedMigration.UserCode
+                .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrEmpty(x)).ToArray();
+
+            var classLines = lines.FindAllIndex(x => x.StartsWith("public partial class"));
+
+            foreach (var classLineIndex in classLines)
+            {
+                // Should not be first line of file
+                Assert.NotEqual(0, classLineIndex);
+                var prevLine = lines[classLineIndex - 1];
+                Assert.Contains("<inheritdoc />", prevLine.Trim());
+            }
+        }
+
+        [MigrationsTheory]
+        public void Migration_should_contain_xmldocs_before_method()
+        {
+            ResetDatabase();
+
+            var migrator = CreateMigrator<ShopContext_v1>();
+
+            var generatedMigration = new MigrationScaffolder(migrator.Configuration).Scaffold("Migration_v1");
+
+            var lines = generatedMigration.UserCode
+                .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrEmpty(x)).ToArray();
+
+            var classLines = lines.FindAllIndex(x => x.StartsWith("public override void"));
+
+            foreach (var classLineIndex in classLines)
+            {
+                // Should not be first line of file
+                Assert.NotEqual(0, classLineIndex);
+                var prevLine = lines[classLineIndex - 1];
+                Assert.Contains("<inheritdoc />", prevLine.Trim());
+            }
         }
 
         [MigrationsTheory]

--- a/test/EntityFramework/FunctionalTests/Migrations/BasicMigrationScenarios.cs
+++ b/test/EntityFramework/FunctionalTests/Migrations/BasicMigrationScenarios.cs
@@ -353,20 +353,9 @@ namespace System.Data.Entity.Migrations
 
             var generatedMigration = new MigrationScaffolder(migrator.Configuration).Scaffold("Migration_v1");
 
-            var lines = generatedMigration.UserCode
-                .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(x => x.Trim())
-                .Where(x => !string.IsNullOrEmpty(x)).ToArray();
+            CheckSpecificLinesHasXmlDocBeforeThem(generatedMigration.UserCode, "public partial class");
 
-            var classLines = lines.FindAllIndex(x => x.StartsWith("public partial class"));
-
-            foreach (var classLineIndex in classLines)
-            {
-                // Should not be first line of file
-                Assert.NotEqual(0, classLineIndex);
-                var prevLine = lines[classLineIndex - 1];
-                Assert.Contains("<inheritdoc />", prevLine.Trim());
-            }
+            CheckSpecificLinesHasXmlDocBeforeThem(generatedMigration.UserCode, "Public Partial Class");
         }
 
         [MigrationsTheory]
@@ -378,19 +367,28 @@ namespace System.Data.Entity.Migrations
 
             var generatedMigration = new MigrationScaffolder(migrator.Configuration).Scaffold("Migration_v1");
 
-            var lines = generatedMigration.UserCode
+            CheckSpecificLinesHasXmlDocBeforeThem(generatedMigration.UserCode, "public override void");
+
+            CheckSpecificLinesHasXmlDocBeforeThem(generatedMigration.UserCode, "Public Overrides Sub");
+        }
+
+        private static void CheckSpecificLinesHasXmlDocBeforeThem(string code, string lineToAppend)
+        {
+            var lines = code
                 .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x.Trim())
-                .Where(x => !string.IsNullOrEmpty(x)).ToArray();
+                .Where(x => !string.IsNullOrEmpty(x))
+                .ToArray();
 
-            var classLines = lines.FindAllIndex(x => x.StartsWith("public override void"));
+            var classLines = lines.FindAllIndex(x => x.StartsWith(lineToAppend));
 
             foreach (var classLineIndex in classLines)
             {
                 // Should not be first line of file
                 Assert.NotEqual(0, classLineIndex);
                 var prevLine = lines[classLineIndex - 1];
-                Assert.Contains("<inheritdoc />", prevLine.Trim());
+                //Both <inheritdoc/> and <inheritdoc cref=""> should work
+                Assert.Contains("<inheritdoc ", prevLine.Trim());
             }
         }
 


### PR DESCRIPTION
It's good (or, at least, common) practice to enable XML documentation generation. If this is enabled, auto created DbMigration's will generate warnings that pollute error logs. This change will add appropriate inheritdoc's into autogenerated code.