### PR TITLE
Removed legacy support for HistoryRepository

### DIFF
--- a/src/EntityFramework/Migrations/History/HistoryRepository.cs
+++ b/src/EntityFramework/Migrations/History/HistoryRepository.cs
@@ -562,33 +562,6 @@ namespace System.Data.Entity.Migrations.History
                     tableName = HistoryContext.DefaultTableName;
                 }
 
-                using (var context = new LegacyHistoryContext(connection))
-                {
-                    var createdOnExists = false;
-
-                    try
-                    {
-                        InjectInterceptionContext(context);
-
-                        using (new TransactionScope(TransactionScopeOption.Suppress))
-                        {
-                            context.History
-                                .Select(h => h.CreatedOn)
-                                .FirstOrDefault();
-                        }
-
-                        createdOnExists = true;
-                    }
-                    catch (EntityException)
-                    {
-                    }
-
-                    if (createdOnExists)
-                    {
-                        yield return new DropColumnOperation(tableName, "CreatedOn");
-                    }
-                }
-
                 using (var context = CreateContext(connection))
                 {
                     if (!_contextKeyColumnExists)


### PR DESCRIPTION
Removed legacy support for HistoryRepository (it throws exception when uses DbMigrator.Update)