### PR TITLE
Change tab order Generate Database from Model wizard (Accessibility Bug 457898)

### DIFF
--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbGenSummary.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbGenSummary.cs
@@ -614,6 +614,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
                             {
                                 InferTablesAndDisplayDDL(ddlOutput);
                             }
+
+                            txtSaveDdlAs.Focus();
                         }
                     }, null);
         }

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbGenSummary.resx
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbGenSummary.resx
@@ -160,7 +160,7 @@
     <value>479, 273</value>
   </data>
   <data name="txtDDL.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;txtDDL.Name" xml:space="preserve">
     <value>txtDDL</value>
@@ -184,7 +184,7 @@
     <value>485, 279</value>
   </data>
   <data name="CreateDatabaseTabDDL.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="CreateDatabaseTabDDL.Text" xml:space="preserve">
     <value>DDL</value>
@@ -244,7 +244,7 @@
     <value>493, 305</value>
   </data>
   <data name="SummaryTabs.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;SummaryTabs.Name" xml:space="preserve">
     <value>SummaryTabs</value>
@@ -301,7 +301,7 @@
     <value>493, 25</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>


### PR DESCRIPTION
Fix for accessibility bug 457898. Changes the tab order on the end page of the "Generate Database from Model" wizard.
