### PR TITLE
Extra Fix for Accessibility Bug 457903

### DIFF
--- a/src/EFTools/EntityDesignPackage/CustomCode/MicrosoftDataEntityDesignCommandSet.cs
+++ b/src/EFTools/EntityDesignPackage/CustomCode/MicrosoftDataEntityDesignCommandSet.cs
@@ -1563,14 +1563,6 @@ namespace Microsoft.Data.Entity.Design.Package
                         }
                     }
                 }
-                else
-                {
-                    // Add delete command for the entity type to the queue.
-                    foreach (var efElement in toBeDeletedElements)
-                    {
-                        commands.Add(efElement.GetDeleteCommand());
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
There was 1 scenario in Accessibility Bug 457903 we missed. This fixes that.

If user deletes a C-side EntityType from the Model Browser and then selects Cancel on "Delete Unmapped Tables and Views" dialog, then should not delete anything.