### PR TITLE
Fixing Accessibility Bugs 450208, 450771 and 460063

### DIFF
--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_11.0.xaml
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_11.0.xaml
@@ -163,12 +163,12 @@
               ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
 
       <DataGrid Grid.Column="0" Grid.Row="4" HorizontalAlignment="Stretch"
-                Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
-                CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
-                HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
-                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
-                Margin="5,10,5,5"
-                Loaded="DgEnumTypeMembers_OnLoaded">>
+              Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
+              CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
+              HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
+              Margin="5,10,5,5"
+              Loaded="DgEnumTypeMembers_OnLoaded">
         <DataGrid.RowValidationRules>
           <vm:RowDataInfoValidationRule ValidationStep="UpdatedValue" />
         </DataGrid.RowValidationRules>

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_12.0.xaml
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_12.0.xaml
@@ -163,13 +163,13 @@
               ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
 
       <DataGrid Grid.Column="0" Grid.Row="4" HorizontalAlignment="Stretch"
-                Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
-                CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
-                HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
-                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
-                Margin="5,10,5,5"
-                Loaded="DgEnumTypeMembers_OnLoaded">
-            <DataGrid.RowValidationRules>
+              Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
+              CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
+              HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
+              Margin="5,10,5,5"
+              Loaded="DgEnumTypeMembers_OnLoaded">
+        <DataGrid.RowValidationRules>
           <vm:RowDataInfoValidationRule ValidationStep="UpdatedValue" />
         </DataGrid.RowValidationRules>
         <DataGrid.Columns>

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_14.0.xaml
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_14.0.xaml
@@ -163,17 +163,17 @@
               ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
 
       <DataGrid Grid.Column="0" Grid.Row="4" HorizontalAlignment="Stretch"
-                Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
-                CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
-                HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
-                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
-                Margin="5,10,5,5"
-                Loaded="DgEnumTypeMembers_OnLoaded">>
+              Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
+              CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
+              HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
+              Margin="5,10,5,5"
+              Loaded="DgEnumTypeMembers_OnLoaded">
         <DataGrid.RowValidationRules>
           <vm:RowDataInfoValidationRule ValidationStep="UpdatedValue" />
         </DataGrid.RowValidationRules>
         <DataGrid.Columns>
-        
+
           <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}" CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}">
             <DataGridTextColumn.Binding>
               <Binding Path="Name">

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_15.0.xaml
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_15.0.xaml
@@ -163,12 +163,12 @@
               ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
 
       <DataGrid Grid.Column="0" Grid.Row="4" HorizontalAlignment="Stretch"
-                Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
-                CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
-                HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
-                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
-                Margin="5,10,5,5"
-                Loaded="DgEnumTypeMembers_OnLoaded">>
+              Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
+              CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
+              HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
+              Margin="5,10,5,5"
+              Loaded="DgEnumTypeMembers_OnLoaded">
         <DataGrid.RowValidationRules>
           <vm:RowDataInfoValidationRule ValidationStep="UpdatedValue" />
         </DataGrid.RowValidationRules>

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/DatabaseObjectTreeView.Designer.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/DatabaseObjectTreeView.Designer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
             this.treeView.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.treeView.CheckBoxes = true;
             this.treeView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.treeView.HideSelection = false;
+            this.treeView.HideSelection = true;
             this.treeView.Location = new System.Drawing.Point(0, 0);
             this.treeView.Name = "treeView";
             this.treeView.Size = new System.Drawing.Size(397, 200);

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageRuntimeConfig.Designer.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageRuntimeConfig.Designer.cs
@@ -69,20 +69,12 @@
             resources.ApplyResources(this.notificationLabel, "notificationLabel");
             this.notificationLabel.Name = "notificationLabel";
             // 
-            // tableLayoutPanel1
+            // notificationLinkLabel
             // 
-            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.notificationPanel, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.versionsPanel, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.promptLabel, 0, 0);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            // 
-            // notificationPanel
-            // 
-            resources.ApplyResources(this.notificationPanel, "notificationPanel");
-            this.notificationPanel.Controls.Add(this.notificationPictureBox, 0, 0);
-            this.notificationPanel.Controls.Add(this.tableLayoutPanel2, 1, 0);
-            this.notificationPanel.Name = "notificationPanel";
+            resources.ApplyResources(this.notificationLinkLabel, "notificationLinkLabel");
+            this.notificationLinkLabel.Name = "notificationLinkLabel";
+            this.notificationLinkLabel.TabStop = true;
+            this.notificationLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.HandleLinkClicked);
             // 
             // tableLayoutPanel2
             // 
@@ -91,12 +83,20 @@
             this.tableLayoutPanel2.Controls.Add(this.notificationLinkLabel, 0, 1);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             // 
-            // notificationLinkLabel
+            // notificationPanel
             // 
-            resources.ApplyResources(this.notificationLinkLabel, "notificationLinkLabel");
-            this.notificationLinkLabel.Name = "notificationLinkLabel";
-            this.notificationLinkLabel.TabStop = true;
-            this.notificationLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.HandleLinkClicked);
+            resources.ApplyResources(this.notificationPanel, "notificationPanel");
+            this.notificationPanel.Controls.Add(this.notificationPictureBox, 0, 0);
+            this.notificationPanel.Controls.Add(this.tableLayoutPanel2, 1, 0);
+            this.notificationPanel.Name = "notificationPanel";
+            // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.promptLabel, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.versionsPanel, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.notificationPanel, 0, 2);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // WizardPageRuntimeConfig
             // 
@@ -106,11 +106,11 @@
             this.Controls.SetChildIndex(this.infoPanel, 0);
             this.Controls.SetChildIndex(this.tableLayoutPanel1, 0);
             ((System.ComponentModel.ISupportInitialize)(this.notificationPictureBox)).EndInit();
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-            this.notificationPanel.ResumeLayout(false);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
+            this.notificationPanel.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageRuntimeConfig.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageRuntimeConfig.cs
@@ -67,6 +67,9 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
             Wizard.EnableButton(ButtonType.Next, _state != RuntimeConfigState.Error);
 
             base.OnActivated();
+
+            versionsPanel.Controls.OfType<RadioButton>()
+                .FirstOrDefault(b => b.Checked)?.Select();
         }
 
         public override bool OnDeactivate()

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageRuntimeConfig.resx
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageRuntimeConfig.resx
@@ -150,9 +150,6 @@
   <data name="promptLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>270, 13</value>
   </data>
-  <data name="promptLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
   <data name="promptLabel.Text" xml:space="preserve">
     <value>&amp;Which version of Entity Framework do you want to use?</value>
   </data>
@@ -164,9 +161,6 @@
   </data>
   <data name="&gt;&gt;promptLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;promptLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="versionsPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -183,9 +177,6 @@
   <data name="versionsPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="versionsPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="versionsPanel.WrapContents" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -198,9 +189,6 @@
   <data name="&gt;&gt;versionsPanel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;versionsPanel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="notificationPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -209,9 +197,6 @@
   </data>
   <data name="notificationPictureBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>16, 16</value>
-  </data>
-  <data name="notificationPictureBox.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
   </data>
   <data name="&gt;&gt;notificationPictureBox.Name" xml:space="preserve">
     <value>notificationPictureBox</value>
@@ -222,9 +207,6 @@
   <data name="&gt;&gt;notificationPictureBox.Parent" xml:space="preserve">
     <value>notificationPanel</value>
   </data>
-  <data name="&gt;&gt;notificationPictureBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="notificationLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -233,9 +215,6 @@
   </data>
   <data name="notificationLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>84, 13</value>
-  </data>
-  <data name="notificationLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
   </data>
   <data name="notificationLabel.Text" xml:space="preserve">
     <value>notificationLabel</value>
@@ -248,9 +227,6 @@
   </data>
   <data name="&gt;&gt;notificationLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
-  </data>
-  <data name="&gt;&gt;notificationLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
@@ -282,9 +258,6 @@
   <data name="notificationLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>109, 13</value>
   </data>
-  <data name="notificationLinkLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
   <data name="notificationLinkLabel.Text" xml:space="preserve">
     <value>Learn more about this</value>
   </data>
@@ -297,9 +270,6 @@
   <data name="&gt;&gt;notificationLinkLabel.Parent" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
-  <data name="&gt;&gt;notificationLinkLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
     <value>25, 3</value>
   </data>
@@ -309,9 +279,6 @@
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
     <value>466, 270</value>
   </data>
-  <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
   <data name="&gt;&gt;tableLayoutPanel2.Name" xml:space="preserve">
     <value>tableLayoutPanel2</value>
   </data>
@@ -320,9 +287,6 @@
   </data>
   <data name="&gt;&gt;tableLayoutPanel2.Parent" xml:space="preserve">
     <value>notificationPanel</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel2.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="notificationLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="notificationLinkLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
@@ -336,9 +300,6 @@
   <data name="notificationPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>494, 276</value>
   </data>
-  <data name="notificationPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
   <data name="&gt;&gt;notificationPanel.Name" xml:space="preserve">
     <value>notificationPanel</value>
   </data>
@@ -347,9 +308,6 @@
   </data>
   <data name="&gt;&gt;notificationPanel.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;notificationPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="notificationPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="notificationPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel2" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
@@ -363,9 +321,6 @@
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>500, 307</value>
   </data>
-  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
   <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
@@ -375,11 +330,8 @@
   <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="notificationPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="versionsPanel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="promptLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="promptLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="versionsPanel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="notificationPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>


### PR DESCRIPTION
Fix for:
a) 460063 - Add Enum Type XAML problems (which allows checking OK and Cancel button Narration)
b) 450208 - Tab order on "Choose your Runtime Version" wizard page
c) 450771 - multiple focus visible on two wizard pages
