### PR TITLE
Fix for #195: Suppress schema query parameter optimization for providers that are not compatible

### DIFF
--- a/src/EFTools/EntityDesignerVersioningFacade/EntityDesignerVersioningFacade.csproj
+++ b/src/EFTools/EntityDesignerVersioningFacade/EntityDesignerVersioningFacade.csproj
@@ -93,6 +93,7 @@
     <Compile Include="ReverseEngineerDb\EntityStoreSchemaFilterEffect.cs" />
     <Compile Include="ReverseEngineerDb\EntityStoreSchemaFilterEntry.cs" />
     <Compile Include="ReverseEngineerDb\EntityStoreSchemaFilterObjectTypes.cs" />
+    <Compile Include="ReverseEngineerDb\SchemaDiscovery\ParameterCollectionBuilder.cs" />
     <Compile Include="ReverseEngineerDb\StoreSchemaConnectionFactory.cs" />
     <Compile Include="ReverseEngineerDb\ModelBuilderErrorCode.cs" />
     <Compile Include="ReverseEngineerDb\DbDatabaseMappingBuilder.cs" />

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
     using System.Data;
     using System.Data.Common;
     using System.Data.Entity.Core.EntityClient;
+    using System.Data.Entity.Core.Metadata.Edm;
     using System.Data.Entity.Infrastructure.Interception;
     using System.Data.Entity.Utilities;
     using System.Diagnostics;
@@ -240,9 +241,16 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                         CommandTimeout = 0
                     };
 
+            var optimizeParameters =
+                ((StoreItemCollection)_connection
+                    .GetMetadataWorkspace()
+                    .GetItemCollection(DataSpace.SSpace))
+                        .ProviderManifest
+                        .SupportsParameterOptimizationInSchemaQueries();
+
             command.CommandText =
                 new EntityStoreSchemaQueryGenerator(sql, orderByClause, queryTypes, filters, filterAliases)
-                    .GenerateQuery(command.Parameters);
+                    .GenerateQuery(new ParameterCollectionBuilder(command.Parameters, optimizeParameters));
 
             return command;
         }

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGenerator.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGenerator.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
     using System.Collections.Generic;
     using System.Data.Entity.Core.EntityClient;
     using System.Diagnostics;
-    using System.Globalization;
     using System.Linq;
     using System.Text;
 
@@ -27,7 +26,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             _filterAliases = filterAliases;
         }
 
-        public string GenerateQuery(EntityParameterCollection parameters)
+        public string GenerateQuery(ParameterCollectionBuilder parameters)
         {
             Debug.Assert(parameters != null, "parameters != null");
 
@@ -60,12 +59,12 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
         }
 
         // internal to allow unit testing
-        internal StringBuilder CreateWhereClause(EntityParameterCollection parameters)
+        internal StringBuilder CreateWhereClause(ParameterCollectionBuilder parameters)
         {
             Debug.Assert(parameters != null, "parameters != null");
 
             var whereClause = new StringBuilder();
-            var parameterMap = new Dictionary<string, string>(StringComparer.Ordinal);
+
             foreach (var alias in _filterAliases)
             {
                 var allows = new StringBuilder();
@@ -74,12 +73,12 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                 {
                     if (entry.Effect == EntityStoreSchemaFilterEffect.Allow)
                     {
-                        AppendFilterEntry(allows, alias, entry, parameterMap);
+                        AppendFilterEntry(allows, alias, entry, parameters);
                     }
                     else
                     {
                         Debug.Assert(entry.Effect == EntityStoreSchemaFilterEffect.Exclude, "did you add new value?");
-                        AppendFilterEntry(excludes, alias, entry, parameterMap);
+                        AppendFilterEntry(excludes, alias, entry, parameters);
                     }
                 }
 
@@ -111,31 +110,25 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                         .Append(")");
                 }
             }
-
-            foreach(var entry in parameterMap)
-            {
-                parameters.AddWithValue(entry.Value, entry.Key);
-            }
-
             return whereClause;
         }
 
         // internal to allow unit testing
         internal static StringBuilder AppendFilterEntry(
-            StringBuilder segment, string alias, EntityStoreSchemaFilterEntry entry, Dictionary<string, string> parameterMap)
+            StringBuilder segment, string alias, EntityStoreSchemaFilterEntry entry, ParameterCollectionBuilder parameters)
         {
             Debug.Assert(segment != null, "segment != null");
             Debug.Assert(alias != null, "alias != null");
             Debug.Assert(entry != null, "entry != null");
-            Debug.Assert(parameterMap != null, "parameters != null");
+            Debug.Assert(parameters != null, "parameters != null");
 
             var filterText = new StringBuilder();
-            AppendComparison(filterText, alias, "CatalogName", entry.Catalog, parameterMap);
-            AppendComparison(filterText, alias, "SchemaName", entry.Schema, parameterMap);
+            AppendComparison(filterText, alias, "CatalogName", entry.Catalog, parameters);
+            AppendComparison(filterText, alias, "SchemaName", entry.Schema, parameters);
             AppendComparison(
                 filterText, alias, "Name",
                 entry.Catalog == null && entry.Schema == null && entry.Name == null ? "%" : entry.Name,
-                parameterMap);
+                parameters);
             segment
                 .AppendIfNotEmpty(" OR ")
                 .Append("(")
@@ -147,30 +140,20 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
 
         // internal to allow unit testing
         internal static StringBuilder AppendComparison(
-            StringBuilder filterFragment, string alias, string propertyName, string value, Dictionary<string, string> parameterMap)
+            StringBuilder filterFragment, string alias, string propertyName, string value, ParameterCollectionBuilder parameters)
         {
             Debug.Assert(filterFragment != null, "filterFragment != null");
             Debug.Assert(alias != null, "alias != null");
             Debug.Assert(propertyName != null, "propertyName != null");
-            Debug.Assert(parameterMap != null, "parameters != null");
+            Debug.Assert(parameters != null, "parameters != null");
 
             if (value != null)
             {
-                string parameterName = null;                
-                if (!parameterMap.TryGetValue(value, out parameterName))
-                { 
-                    parameterName = GetParameterName(parameterMap.Count);
-                    parameterMap.Add(value, parameterName);
-                }
+                var parameterName = parameters.GetOrAdd(value);
                 AppendComparisonFragment(filterFragment, alias, propertyName, parameterName);
             }
 
             return filterFragment;
-        }
-
-        private static string GetParameterName(int position)
-        {
-            return "p" + position.ToString(CultureInfo.InvariantCulture);
         }
 
         private static void AppendComparisonFragment(

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/ParameterCollectionBuilder.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/ParameterCollectionBuilder.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.SchemaDiscovery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.Entity.Core.EntityClient;
+    using System.Globalization;
+
+    // Abstracts building collections of parameters for schema queries 
+    // with or without parameter value de-duplication
+    internal class ParameterCollectionBuilder
+    {
+        private EntityParameterCollection _collection;
+        private Dictionary<string, string> _map = null;
+
+        public ParameterCollectionBuilder(EntityParameterCollection collection, bool optimized)
+        {
+            _collection = collection;
+            if (optimized)
+            {
+                _map = new Dictionary<string, string>(StringComparer.Ordinal);
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                return _collection.Count;
+            }
+        }
+
+        public EntityParameter this[int index]
+        {
+            get
+            {
+                return _collection[index];
+            }
+        }
+
+        public EntityParameter this[string parameterName]
+        {
+            get
+            {
+                return _collection[parameterName];
+            }
+        }
+
+        public string GetOrAdd(string parameterValue)
+        {
+            string parameterName = null;
+            if (_map == null || !_map.TryGetValue(parameterValue, out parameterName))
+            {
+                parameterName = GetNextParameterName();
+                _collection.AddWithValue(parameterName, parameterValue);
+                if (_map != null)
+                {
+                    _map.Add(parameterValue, parameterName);
+                }
+            }
+            return parameterName;
+        }
+
+        private string GetNextParameterName()
+        {
+            return "p" + _collection.Count.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaQueryGeneratorTests.cs
@@ -349,8 +349,9 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
 
             Assert.Equal(2, parameters.Count);
             Assert.Equal("p0", parameters[0].ParameterName);
-            Assert.Equal("p0", parameters[0].ParameterName);
+            Assert.Equal("p1", parameters[1].ParameterName);
             Assert.Equal(parameters["p0"].Value, "name");
+            Assert.Equal(parameters["p1"].Value, "name");
         }
 
         [Fact]


### PR DESCRIPTION
Fix for issue #195. Suppress schema query parameter optimization for providers that are not compatible. This is a replacement for #363.