### PR TITLE
Fixes for Accessibility Bugs 458661 & 586335

### DIFF
--- a/src/EFTools/EntityDesign/Resources.Designer.cs
+++ b/src/EFTools/EntityDesign/Resources.Designer.cs
@@ -820,6 +820,15 @@ namespace Microsoft.Data.Entity.Design {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start typing or press &apos;F2&apos; to edit.
+        /// </summary>
+        public static string EnumDialog_EnumTypeMemberHelpText {
+            get {
+                return ResourceManager.GetString("EnumDialog_EnumTypeMemberHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Member Name.
         /// </summary>
         public static string EnumDialog_EnumTypeMemberNameLabel {

--- a/src/EFTools/EntityDesign/Resources.resx
+++ b/src/EFTools/EntityDesign/Resources.resx
@@ -1552,4 +1552,7 @@ Full error message:
   <data name="EnumDialog_Error_AccName" xml:space="preserve">
     <value>Error</value>
   </data>
+  <data name="EnumDialog_EnumTypeMemberHelpText" xml:space="preserve">
+    <value>Start typing or press 'F2' to edit</value>
+  </data>
 </root>

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_11.0.xaml
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_11.0.xaml
@@ -183,25 +183,31 @@
       <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" Margin="5,2,5,2" />
 
       <ComboBox Grid.Column="0" Grid.Row="3"  HorizontalAlignment="Left" Name="cmbUnderlyingType"
-              Margin="5,0,5,5" Width="250px"
-              ItemsSource="{Binding Path=UnderlyingTypes}"
-              SelectedItem="{Binding Path=SelectedUnderlyingType,Mode=TwoWay}"
-              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" 
-              ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
+                Margin="5,0,5,5" Width="250px"
+                ItemsSource="{Binding Path=UnderlyingTypes}"
+                SelectedItem="{Binding Path=SelectedUnderlyingType,Mode=TwoWay}"
+                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" 
+                ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
 
       <DataGrid Grid.Column="0" Grid.Row="4" HorizontalAlignment="Stretch"
-              Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
-              CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
-              HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
-              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
-              Margin="5,10,5,5"
-              Loaded="DgEnumTypeMembers_OnLoaded">
+                Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
+                CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
+                HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+                VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
+                Margin="5,10,5,5"
+                CellEditEnding="dgEnumTypeMembers_CellEditEnding"
+                CurrentCellChanged="dgEnumTypeMembers_CurrentCellChanged"
+                Loaded="dgEnumTypeMembers_OnLoaded">
         <DataGrid.RowValidationRules>
           <vm:RowDataInfoValidationRule ValidationStep="UpdatedValue" />
         </DataGrid.RowValidationRules>
         <DataGrid.Columns>
 
-          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}" CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}">
+          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}"
+                              CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto"
+                              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}"
+                              AutomationProperties.HelpText="{x:Static ded:Resources.EnumDialog_EnumTypeMemberHelpText}">
             <DataGridTextColumn.Binding>
               <Binding Path="Name">
                 <Binding.ValidationRules>
@@ -211,7 +217,10 @@
             </DataGridTextColumn.Binding>
           </DataGridTextColumn>
 
-          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}" CanUserSort="False" MinWidth="200" MaxWidth="300" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}">
+                <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}"
+                                    CanUserSort="False" MinWidth="200" MaxWidth="300" Width="Auto"
+                                    AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}"
+                                    AutomationProperties.HelpText="{x:Static ded:Resources.EnumDialog_EnumTypeMemberHelpText}">
             <DataGridTextColumn.Binding>
               <Binding Path="Value">
                 <Binding.ValidationRules>

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_11.0.xaml.cs
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_11.0.xaml.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
             {
                 this.Title = EntityDesignerResources.EnumDialog_EditEnumWindowTitle;
             }
-            this.dgEnumTypeMembers.CellEditEnding += dgEnumTypeMembers_CellEditEnding;
             this.HasHelpButton = false;
         }
 
@@ -140,9 +139,19 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
             }
         }
 
-        private void DgEnumTypeMembers_OnLoaded(object sender, RoutedEventArgs e)
+        private void dgEnumTypeMembers_OnLoaded(object sender, RoutedEventArgs e)
         {
-            foreach (var row in dgEnumTypeMembers.FindDescendants<DataGridRow>().Where(r => r.IsNewItem).ToList())
+            EnsureAccessibilityValues();
+        }
+
+        private void dgEnumTypeMembers_CurrentCellChanged(object sender, EventArgs e)
+        {
+            EnsureAccessibilityValues();
+        }
+
+        private void EnsureAccessibilityValues()
+        {
+            foreach (var row in dgEnumTypeMembers.FindDescendants<DataGridRow>().ToList())
             {
                 foreach (var cell in row.FindDescendants<DataGridCell>().ToList())
                 {
@@ -151,10 +160,12 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
                         if (cell.Column.DisplayIndex == 0)
                         {
                             cell.SetValue(AutomationProperties.NameProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberNameLabel);
+                            cell.SetValue(AutomationProperties.HelpTextProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberHelpText);
                         }
                         else if (cell.Column.DisplayIndex == 1)
                         {
                             cell.SetValue(AutomationProperties.NameProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberValueLabel);
+                            cell.SetValue(AutomationProperties.HelpTextProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberHelpText);
                         }
                     }
                 }

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_12.0.xaml
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_12.0.xaml
@@ -183,25 +183,31 @@
       <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" Margin="5,2,5,2" />
 
       <ComboBox Grid.Column="0" Grid.Row="3"  HorizontalAlignment="Left" Name="cmbUnderlyingType"
-              Margin="5,0,5,5" Width="250px"
-              ItemsSource="{Binding Path=UnderlyingTypes}"
-              SelectedItem="{Binding Path=SelectedUnderlyingType,Mode=TwoWay}"
-              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" 
-              ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
+                Margin="5,0,5,5" Width="250px"
+                ItemsSource="{Binding Path=UnderlyingTypes}"
+                SelectedItem="{Binding Path=SelectedUnderlyingType,Mode=TwoWay}"
+                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" 
+                ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
 
       <DataGrid Grid.Column="0" Grid.Row="4" HorizontalAlignment="Stretch"
-              Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
-              CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
-              HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
-              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
-              Margin="5,10,5,5"
-              Loaded="DgEnumTypeMembers_OnLoaded">
+                Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
+                CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
+                HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+                VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
+                Margin="5,10,5,5"
+                CellEditEnding="dgEnumTypeMembers_CellEditEnding"
+                CurrentCellChanged="dgEnumTypeMembers_CurrentCellChanged"
+                Loaded="dgEnumTypeMembers_OnLoaded">
         <DataGrid.RowValidationRules>
           <vm:RowDataInfoValidationRule ValidationStep="UpdatedValue" />
         </DataGrid.RowValidationRules>
         <DataGrid.Columns>
 
-          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}" CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}">
+          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}"
+                              CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto"
+                              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}"
+                              AutomationProperties.HelpText="{x:Static ded:Resources.EnumDialog_EnumTypeMemberHelpText}">
             <DataGridTextColumn.Binding>
               <Binding Path="Name">
                 <Binding.ValidationRules>
@@ -211,7 +217,10 @@
             </DataGridTextColumn.Binding>
           </DataGridTextColumn>
 
-          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}" CanUserSort="False" MinWidth="200" MaxWidth="300" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}">
+                <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}"
+                                    CanUserSort="False" MinWidth="200" MaxWidth="300" Width="Auto"
+                                    AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}"
+                                    AutomationProperties.HelpText="{x:Static ded:Resources.EnumDialog_EnumTypeMemberHelpText}">
             <DataGridTextColumn.Binding>
               <Binding Path="Value">
                 <Binding.ValidationRules>

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_12.0.xaml.cs
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_12.0.xaml.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
             {
                 this.Title = EntityDesignerResources.EnumDialog_EditEnumWindowTitle;
             }
-            this.dgEnumTypeMembers.CellEditEnding += dgEnumTypeMembers_CellEditEnding;
             this.HasHelpButton = false;
         }
 
@@ -140,9 +139,19 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
             }
         }
 
-        private void DgEnumTypeMembers_OnLoaded(object sender, RoutedEventArgs e)
+        private void dgEnumTypeMembers_OnLoaded(object sender, RoutedEventArgs e)
         {
-            foreach (var row in dgEnumTypeMembers.FindDescendants<DataGridRow>().Where(r => r.IsNewItem).ToList())
+            EnsureAccessibilityValues();
+        }
+
+        private void dgEnumTypeMembers_CurrentCellChanged(object sender, EventArgs e)
+        {
+            EnsureAccessibilityValues();
+        }
+
+        private void EnsureAccessibilityValues()
+        {
+            foreach (var row in dgEnumTypeMembers.FindDescendants<DataGridRow>().ToList())
             {
                 foreach (var cell in row.FindDescendants<DataGridCell>().ToList())
                 {
@@ -151,10 +160,12 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
                         if (cell.Column.DisplayIndex == 0)
                         {
                             cell.SetValue(AutomationProperties.NameProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberNameLabel);
+                            cell.SetValue(AutomationProperties.HelpTextProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberHelpText);
                         }
                         else if (cell.Column.DisplayIndex == 1)
                         {
                             cell.SetValue(AutomationProperties.NameProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberValueLabel);
+                            cell.SetValue(AutomationProperties.HelpTextProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberHelpText);
                         }
                     }
                 }

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_14.0.xaml
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_14.0.xaml
@@ -183,25 +183,31 @@
       <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" Margin="5,2,5,2" />
 
       <ComboBox Grid.Column="0" Grid.Row="3"  HorizontalAlignment="Left" Name="cmbUnderlyingType"
-              Margin="5,0,5,5" Width="250px"
-              ItemsSource="{Binding Path=UnderlyingTypes}"
-              SelectedItem="{Binding Path=SelectedUnderlyingType,Mode=TwoWay}"
-              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" 
-              ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
+                Margin="5,0,5,5" Width="250px"
+                ItemsSource="{Binding Path=UnderlyingTypes}"
+                SelectedItem="{Binding Path=SelectedUnderlyingType,Mode=TwoWay}"
+                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" 
+                ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
 
       <DataGrid Grid.Column="0" Grid.Row="4" HorizontalAlignment="Stretch"
-              Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
-              CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
-              HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
-              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
-              Margin="5,10,5,5"
-              Loaded="DgEnumTypeMembers_OnLoaded">
+                Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
+                CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
+                HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+                VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
+                Margin="5,10,5,5"
+                CellEditEnding="dgEnumTypeMembers_CellEditEnding"
+                CurrentCellChanged="dgEnumTypeMembers_CurrentCellChanged"
+                Loaded="dgEnumTypeMembers_OnLoaded">
         <DataGrid.RowValidationRules>
           <vm:RowDataInfoValidationRule ValidationStep="UpdatedValue" />
         </DataGrid.RowValidationRules>
         <DataGrid.Columns>
 
-          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}" CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}">
+          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}"
+                              CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto"
+                              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}"
+                              AutomationProperties.HelpText="{x:Static ded:Resources.EnumDialog_EnumTypeMemberHelpText}">
             <DataGridTextColumn.Binding>
               <Binding Path="Name">
                 <Binding.ValidationRules>
@@ -211,7 +217,10 @@
             </DataGridTextColumn.Binding>
           </DataGridTextColumn>
 
-          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}" CanUserSort="False" MinWidth="200" MaxWidth="300" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}">
+                <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}"
+                                    CanUserSort="False" MinWidth="200" MaxWidth="300" Width="Auto"
+                                    AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}"
+                                    AutomationProperties.HelpText="{x:Static ded:Resources.EnumDialog_EnumTypeMemberHelpText}">
             <DataGridTextColumn.Binding>
               <Binding Path="Value">
                 <Binding.ValidationRules>

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_14.0.xaml.cs
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_14.0.xaml.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
             {
                 this.Title = EntityDesignerResources.EnumDialog_EditEnumWindowTitle;
             }
-            this.dgEnumTypeMembers.CellEditEnding += dgEnumTypeMembers_CellEditEnding;
             this.HasHelpButton = false;
         }
 
@@ -140,9 +139,19 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
             }
         }
 
-        private void DgEnumTypeMembers_OnLoaded(object sender, RoutedEventArgs e)
+        private void dgEnumTypeMembers_OnLoaded(object sender, RoutedEventArgs e)
         {
-            foreach (var row in dgEnumTypeMembers.FindDescendants<DataGridRow>().Where(r => r.IsNewItem).ToList())
+            EnsureAccessibilityValues();
+        }
+
+        private void dgEnumTypeMembers_CurrentCellChanged(object sender, EventArgs e)
+        {
+            EnsureAccessibilityValues();
+        }
+
+        private void EnsureAccessibilityValues()
+        {
+            foreach (var row in dgEnumTypeMembers.FindDescendants<DataGridRow>().ToList())
             {
                 foreach (var cell in row.FindDescendants<DataGridCell>().ToList())
                 {
@@ -151,10 +160,12 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
                         if (cell.Column.DisplayIndex == 0)
                         {
                             cell.SetValue(AutomationProperties.NameProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberNameLabel);
+                            cell.SetValue(AutomationProperties.HelpTextProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberHelpText);
                         }
                         else if (cell.Column.DisplayIndex == 1)
                         {
                             cell.SetValue(AutomationProperties.NameProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberValueLabel);
+                            cell.SetValue(AutomationProperties.HelpTextProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberHelpText);
                         }
                     }
                 }

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_15.0.xaml
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_15.0.xaml
@@ -183,25 +183,31 @@
       <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" Margin="5,2,5,2" />
 
       <ComboBox Grid.Column="0" Grid.Row="3"  HorizontalAlignment="Left" Name="cmbUnderlyingType"
-              Margin="5,0,5,5" Width="250px"
-              ItemsSource="{Binding Path=UnderlyingTypes}"
-              SelectedItem="{Binding Path=SelectedUnderlyingType,Mode=TwoWay}"
-              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" 
-              ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
+                Margin="5,0,5,5" Width="250px"
+                ItemsSource="{Binding Path=UnderlyingTypes}"
+                SelectedItem="{Binding Path=SelectedUnderlyingType,Mode=TwoWay}"
+                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_UnderlyingTypeLabel}" 
+                ToolTip="{x:Static ded:Resources.PropertyWindow_Description_EnumUnderlyingType}"/>
 
       <DataGrid Grid.Column="0" Grid.Row="4" HorizontalAlignment="Stretch"
-              Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
-              CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
-              HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}" VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
-              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
-              Margin="5,10,5,5"
-              Loaded="DgEnumTypeMembers_OnLoaded">
+                Name="dgEnumTypeMembers" VerticalAlignment="Stretch" ItemsSource="{Binding Path=Members}"
+                CanUserAddRows="True" CanUserDeleteRows="True" AutoGenerateColumns="False"
+                HorizontalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+                VerticalGridLinesBrush="{DynamicResource VsBrush.ThreeDFace}"
+                AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_AccEnumTypeMembers}"
+                Margin="5,10,5,5"
+                CellEditEnding="dgEnumTypeMembers_CellEditEnding"
+                CurrentCellChanged="dgEnumTypeMembers_CurrentCellChanged"
+                Loaded="dgEnumTypeMembers_OnLoaded">
         <DataGrid.RowValidationRules>
           <vm:RowDataInfoValidationRule ValidationStep="UpdatedValue" />
         </DataGrid.RowValidationRules>
         <DataGrid.Columns>
 
-          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}" CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}">
+          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}"
+                              CanUserSort="False" MinWidth="225" MaxWidth="325" Width="Auto"
+                              AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberNameLabel}"
+                              AutomationProperties.HelpText="{x:Static ded:Resources.EnumDialog_EnumTypeMemberHelpText}">
             <DataGridTextColumn.Binding>
               <Binding Path="Name">
                 <Binding.ValidationRules>
@@ -211,7 +217,10 @@
             </DataGridTextColumn.Binding>
           </DataGridTextColumn>
 
-          <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}" CanUserSort="False" MinWidth="200" MaxWidth="300" Width="Auto" AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}">
+                <DataGridTextColumn Header="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}"
+                                    CanUserSort="False" MinWidth="200" MaxWidth="300" Width="Auto"
+                                    AutomationProperties.Name="{x:Static ded:Resources.EnumDialog_EnumTypeMemberValueLabel}"
+                                    AutomationProperties.HelpText="{x:Static ded:Resources.EnumDialog_EnumTypeMemberHelpText}">
             <DataGridTextColumn.Binding>
               <Binding Path="Value">
                 <Binding.ValidationRules>

--- a/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_15.0.xaml.cs
+++ b/src/EFTools/EntityDesign/UI/Views/Dialogs/EnumTypeDialog_15.0.xaml.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
             {
                 this.Title = EntityDesignerResources.EnumDialog_EditEnumWindowTitle;
             }
-            this.dgEnumTypeMembers.CellEditEnding += dgEnumTypeMembers_CellEditEnding;
             this.HasHelpButton = false;
         }
 
@@ -140,9 +139,19 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
             }
         }
 
-        private void DgEnumTypeMembers_OnLoaded(object sender, RoutedEventArgs e)
+        private void dgEnumTypeMembers_OnLoaded(object sender, RoutedEventArgs e)
         {
-            foreach (var row in dgEnumTypeMembers.FindDescendants<DataGridRow>().Where(r => r.IsNewItem).ToList())
+            EnsureAccessibilityValues();
+        }
+
+        private void dgEnumTypeMembers_CurrentCellChanged(object sender, EventArgs e)
+        {
+            EnsureAccessibilityValues();
+        }
+
+        private void EnsureAccessibilityValues()
+        {
+            foreach (var row in dgEnumTypeMembers.FindDescendants<DataGridRow>().ToList())
             {
                 foreach (var cell in row.FindDescendants<DataGridCell>().ToList())
                 {
@@ -151,10 +160,12 @@ namespace Microsoft.Data.Entity.Design.UI.Views.Dialogs
                         if (cell.Column.DisplayIndex == 0)
                         {
                             cell.SetValue(AutomationProperties.NameProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberNameLabel);
+                            cell.SetValue(AutomationProperties.HelpTextProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberHelpText);
                         }
                         else if (cell.Column.DisplayIndex == 1)
                         {
                             cell.SetValue(AutomationProperties.NameProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberValueLabel);
+                            cell.SetValue(AutomationProperties.HelpTextProperty, EntityDesignerResources.EnumDialog_EnumTypeMemberHelpText);
                         }
                     }
                 }

--- a/src/EFTools/EntityDesignEntityDesigner/CustomCode/Diagram/EntityTypeElementListCompartment.cs
+++ b/src/EFTools/EntityDesignEntityDesigner/CustomCode/Diagram/EntityTypeElementListCompartment.cs
@@ -9,17 +9,24 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.View
     using Microsoft.VisualStudio.Modeling;
     using Microsoft.VisualStudio.Modeling.Diagrams;
     using Diagram = Microsoft.Data.Entity.Design.Model.Designer.Diagram;
+    using Resources = Microsoft.Data.Entity.Design.EntityDesigner.Properties.Resources;
 
     [DomainObjectId("53d36908-9892-4495-8754-da5f4d7969d4")]
     internal class EntityTypeElementListCompartment : ElementListCompartment
     {
+        private bool _isScalarPropertiesCompartment;
+
         /// <summary>
         ///     EntityTypeElementListCompartment Constructor
         /// </summary>
         /// <param name="store">Store where new element is to be created.</param>
         /// <param name="propertyAssignments">List of domain property id/value pairs to set once the element is created.</param>
-        public EntityTypeElementListCompartment(Store store, params PropertyAssignment[] propertyAssignments)
-            : this(store != null ? store.DefaultPartitionForClass(DomainClassId) : null, propertyAssignments)
+        public EntityTypeElementListCompartment(Store store,
+             bool isScalarPropertiesCompartment,
+             params PropertyAssignment[] propertyAssignments)
+            : this(store != null ? store.DefaultPartitionForClass(DomainClassId) : null,
+                  isScalarPropertiesCompartment,
+                  propertyAssignments)
         {
             Initialize();
         }
@@ -29,9 +36,13 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.View
         /// </summary>
         /// <param name="partition">Partition where new element is to be created.</param>
         /// <param name="propertyAssignments">List of domain property id/value pairs to set once the element is created.</param>
-        public EntityTypeElementListCompartment(Partition partition, params PropertyAssignment[] propertyAssignments)
+        public EntityTypeElementListCompartment(Partition partition,
+             bool isScalarPropertiesCompartment,
+             params PropertyAssignment[] propertyAssignments)
             : base(partition, propertyAssignments)
         {
+            _isScalarPropertiesCompartment = isScalarPropertiesCompartment;
+
             Initialize();
         }
 
@@ -87,6 +98,44 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.View
                     {
                         itemDrawInfo.AlternateFont = true;
                     }
+                }
+            }
+        }
+
+        public override string AccessibleHelp
+        {
+            get
+            {
+                if (_isScalarPropertiesCompartment)
+                {
+                    return Resources.AccHelp_EntityTypeScalarPropertyCompartment;
+                }
+
+                return Resources.AccHelp_EntityTypeNavigationPropertyCompartment;
+            }
+        }
+
+        internal void CollapseInTransaction()
+        {
+            if (IsExpanded)
+            {
+                using (var txn = Store.TransactionManager.BeginTransaction())
+                {
+                    Collapse();
+                    txn.Commit();
+                }
+            }
+        }
+
+
+        internal void ExpandInTransaction()
+        {
+            if (!IsExpanded)
+            {
+                using (var txn = Store.TransactionManager.BeginTransaction())
+                {
+                    Expand();
+                    txn.Commit();
                 }
             }
         }

--- a/src/EFTools/EntityDesignEntityDesigner/CustomCode/Diagram/EntityTypeElementListCompartmentDescription.cs
+++ b/src/EFTools/EntityDesignEntityDesigner/CustomCode/Diagram/EntityTypeElementListCompartmentDescription.cs
@@ -7,8 +7,12 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.View
 
     internal class EntityTypeElementListCompartmentDescription : ElementListCompartmentDescription
     {
+        private bool _isScalarPropertiesCompartment;
+
         public EntityTypeElementListCompartmentDescription(
-            ListCompartmentDescription wrappedElementListCompartmentDescription, bool isDefaultCollapsed)
+            ListCompartmentDescription wrappedElementListCompartmentDescription,
+            bool isDefaultCollapsed,
+            bool isScalarPropertiesCompartment)
             : base(wrappedElementListCompartmentDescription.Name, wrappedElementListCompartmentDescription.Title,
                 wrappedElementListCompartmentDescription.TitleFillColor,
                 wrappedElementListCompartmentDescription.AllowCustomTitleFillColor,
@@ -17,6 +21,7 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.View
                 wrappedElementListCompartmentDescription.TitleFontSettings, wrappedElementListCompartmentDescription.ItemFontSettings,
                 isDefaultCollapsed)
         {
+            _isScalarPropertiesCompartment = isScalarPropertiesCompartment;
         }
 
         /// <summary>
@@ -25,7 +30,7 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.View
         /// <returns></returns>
         public override Compartment CreateCompartment(Partition partition)
         {
-            var compartment = new EntityTypeElementListCompartment(partition);
+            var compartment = new EntityTypeElementListCompartment(partition, _isScalarPropertiesCompartment);
             if (IsDefaultCollapsed)
             {
                 compartment.IsExpanded = false;

--- a/src/EFTools/EntityDesignEntityDesigner/Properties/Resources.Designer.cs
+++ b/src/EFTools/EntityDesignEntityDesigner/Properties/Resources.Designer.cs
@@ -151,11 +151,29 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Access properties of the EntityType by using the Up and Down arrow keys. Add or remove properties by using the Insert and Delete keys..
+        ///   Looks up a localized string similar to Access properties of the EntityType by using the Up and Down arrow keys. Add or remove properties by using the Insert and Delete keys. Collapse or expand using Ctrl+Up and Ctrl+Down..
         /// </summary>
         internal static string AccHelp_EntityType {
             get {
                 return ResourceManager.GetString("AccHelp_EntityType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Navigation Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down..
+        /// </summary>
+        internal static string AccHelp_EntityTypeNavigationPropertyCompartment {
+            get {
+                return ResourceManager.GetString("AccHelp_EntityTypeNavigationPropertyCompartment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down..
+        /// </summary>
+        internal static string AccHelp_EntityTypeScalarPropertyCompartment {
+            get {
+                return ResourceManager.GetString("AccHelp_EntityTypeScalarPropertyCompartment", resourceCulture);
             }
         }
         
@@ -169,7 +187,7 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Navigation.
+        ///   Looks up a localized string similar to Navigation Properties.
         /// </summary>
         internal static string AccName_EntityTypeNavigationPropertyCompartment {
             get {

--- a/src/EFTools/EntityDesignEntityDesigner/Properties/Resources.resx
+++ b/src/EFTools/EntityDesignEntityDesigner/Properties/Resources.resx
@@ -374,7 +374,7 @@ Add existing entities and relationships to this diagram by dragging them from th
     <comment>MSAA Name for the properties compartment of the EntityType shape.</comment>
   </data>
   <data name="AccName_EntityTypeNavigationPropertyCompartment" xml:space="preserve">
-    <value>Navigation</value>
+    <value>Navigation Properties</value>
     <comment>MSAA Name for the navigation properties compartment of the EntityType shape.</comment>
   </data>
   <data name="CompClassName_Inheritance" xml:space="preserve">
@@ -522,6 +522,12 @@ The Entity Framework is not available in the target framework currently specifie
     <value>{0} is in an association with {1}</value>
   </data>
   <data name="AccHelp_EntityType" xml:space="preserve">
-    <value>Access properties of the EntityType by using the Up and Down arrow keys. Add or remove properties by using the Insert and Delete keys.</value>
+    <value>Access properties of the EntityType by using the Up and Down arrow keys. Add or remove properties by using the Insert and Delete keys. Collapse or expand using Ctrl+Up and Ctrl+Down.</value>
+  </data>
+  <data name="AccHelp_EntityTypeNavigationPropertyCompartment" xml:space="preserve">
+    <value>Navigation Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down.</value>
+  </data>
+  <data name="AccHelp_EntityTypeScalarPropertyCompartment" xml:space="preserve">
+    <value>Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down.</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes for Accessibility bugs 458661 and 586335. 

The fix for 458661 changes the Add/Edit Enum Type Dialog so that the help text is available on every cell of the data grid as requested.

I am unable to fix 586335 the way they suggest in the bug - the underlying layer does not expose the required API. However I added handlers for Ctrl+Up and Ctrl+Down which cause the appropriate entity or entity compartment to collapse or expand. Then I added help text that should make this clear to a user. So that should provide a solution for users who use screen readers.
