### PR TITLE
Fix for Accessibility bug 586335. 

### DIFF
--- a/src/EFTools/EntityDesignEntityDesigner/CustomCode/Diagram/EntityTypeElementListCompartment.cs
+++ b/src/EFTools/EntityDesignEntityDesigner/CustomCode/Diagram/EntityTypeElementListCompartment.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.Data.Entity.Design.EntityDesigner.View
 {
     using System.Diagnostics;
+    using System.Globalization;
     using Microsoft.Data.Entity.Design.EntityDesigner.ViewModel;
     using Microsoft.Data.Entity.Design.Model;
     using Microsoft.Data.Entity.Design.Model.Designer;
@@ -108,10 +109,16 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.View
             {
                 if (_isScalarPropertiesCompartment)
                 {
-                    return Resources.AccHelp_EntityTypeScalarPropertyCompartment;
+                    return string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.AccHelp_EntityTypeScalarPropertyCompartment,
+                        IsExpanded ? Resources.ExpandedStateExpanded : Resources.ExpandedStateCollapsed);
                 }
 
-                return Resources.AccHelp_EntityTypeNavigationPropertyCompartment;
+                return string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.AccHelp_EntityTypeNavigationPropertyCompartment,
+                    IsExpanded ? Resources.ExpandedStateExpanded : Resources.ExpandedStateCollapsed);
             }
         }
     }

--- a/src/EFTools/EntityDesignEntityDesigner/CustomCode/Shapes/EntityTypeShape.cs
+++ b/src/EFTools/EntityDesignEntityDesigner/CustomCode/Shapes/EntityTypeShape.cs
@@ -683,7 +683,8 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.View
             {
                 return string.Format(
                     CultureInfo.CurrentCulture,
-                    Resources.AccHelp_EntityType);
+                    Resources.AccHelp_EntityType,
+                    IsExpanded ? Resources.ExpandedStateExpanded : Resources.ExpandedStateCollapsed);
             }
         }
 

--- a/src/EFTools/EntityDesignEntityDesigner/CustomCode/Utils/NodeShapeExtensions.cs
+++ b/src/EFTools/EntityDesignEntityDesigner/CustomCode/Utils/NodeShapeExtensions.cs
@@ -16,26 +16,12 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.CustomCode.Utils
         /// <param name="expanded">if true, ensure that nodeShape is expanded, if false esnure that it is collapsed</param>
         public static void EnsureExpandedState(this NodeShape nodeShape, bool expanded)
         {
-            if (expanded)
+            if (nodeShape.IsExpanded != expanded)
             {
-                if (!nodeShape.IsExpanded)
+                using (var txn = nodeShape.Store.TransactionManager.BeginTransaction())
                 {
-                    using (var txn = nodeShape.Store.TransactionManager.BeginTransaction())
-                    {
-                        nodeShape.IsExpanded = true;
-                        txn.Commit();
-                    }
-                }
-            }
-            else
-            {
-                if (nodeShape.IsExpanded)
-                {
-                    using (var txn = nodeShape.Store.TransactionManager.BeginTransaction())
-                    {
-                        nodeShape.IsExpanded = false;
-                        txn.Commit();
-                    }
+                    nodeShape.IsExpanded = expanded;
+                    txn.Commit();
                 }
             }
         }

--- a/src/EFTools/EntityDesignEntityDesigner/Properties/Resources.Designer.cs
+++ b/src/EFTools/EntityDesignEntityDesigner/Properties/Resources.Designer.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Access properties of the EntityType by using the Up and Down arrow keys. Add or remove properties by using the Insert and Delete keys. Collapse or expand using Ctrl+Up and Ctrl+Down..
+        ///   Looks up a localized string similar to Rename using the &apos;F2&apos; key. Access properties of the EntityType by using the Up and Down arrow keys. Add or remove properties by using the Insert and Delete keys. Collapse or expand using Ctrl+Up and Ctrl+Down. Current state is: {0}..
         /// </summary>
         internal static string AccHelp_EntityType {
             get {
@@ -160,7 +160,7 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Navigation Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down..
+        ///   Looks up a localized string similar to Navigation Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down. Current state is: {0}..
         /// </summary>
         internal static string AccHelp_EntityTypeNavigationPropertyCompartment {
             get {
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down..
+        ///   Looks up a localized string similar to Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down. Current state is: {0}..
         /// </summary>
         internal static string AccHelp_EntityTypeScalarPropertyCompartment {
             get {
@@ -821,6 +821,24 @@ namespace Microsoft.Data.Entity.Design.EntityDesigner.Properties {
         internal static string ErrorCode_PropertyNameInvalid {
             get {
                 return ResourceManager.GetString("ErrorCode_PropertyNameInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Collapsed.
+        /// </summary>
+        internal static string ExpandedStateCollapsed {
+            get {
+                return ResourceManager.GetString("ExpandedStateCollapsed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expanded.
+        /// </summary>
+        internal static string ExpandedStateExpanded {
+            get {
+                return ResourceManager.GetString("ExpandedStateExpanded", resourceCulture);
             }
         }
         

--- a/src/EFTools/EntityDesignEntityDesigner/Properties/Resources.resx
+++ b/src/EFTools/EntityDesignEntityDesigner/Properties/Resources.resx
@@ -522,12 +522,20 @@ The Entity Framework is not available in the target framework currently specifie
     <value>{0} is in an association with {1}</value>
   </data>
   <data name="AccHelp_EntityType" xml:space="preserve">
-    <value>Access properties of the EntityType by using the Up and Down arrow keys. Add or remove properties by using the Insert and Delete keys. Collapse or expand using Ctrl+Up and Ctrl+Down.</value>
+    <value>Rename using the 'F2' key. Access properties of the EntityType by using the Up and Down arrow keys. Add or remove properties by using the Insert and Delete keys. Collapse or expand using Ctrl+Up and Ctrl+Down. Current state is: {0}.</value>
   </data>
   <data name="AccHelp_EntityTypeNavigationPropertyCompartment" xml:space="preserve">
-    <value>Navigation Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down.</value>
+    <value>Navigation Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down. Current state is: {0}.</value>
   </data>
   <data name="AccHelp_EntityTypeScalarPropertyCompartment" xml:space="preserve">
-    <value>Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down.</value>
+    <value>Properties Compartment. Collapse or expand using Ctrl+Up and Ctrl+Down. Current state is: {0}.</value>
+  </data>
+  <data name="ExpandedStateCollapsed" xml:space="preserve">
+    <value>Collapsed</value>
+    <comment>Used with various AccHelp_ resources to make the collapsed/expanded state available to the Narrator.</comment>
+  </data>
+  <data name="ExpandedStateExpanded" xml:space="preserve">
+    <value>Expanded</value>
+    <comment>Used with various AccHelp_ resources to make the collapsed/expanded state available to the Narrator.</comment>
   </data>
 </root>


### PR DESCRIPTION
Update help text to describe the collapsed/expanded current state on the EntityTypeShape and its compartments, and add rename instructions for the EntityTypeShape.