### PR TITLE
Fix an issue when a property is configured in multiple indexes

### DIFF
--- a/src/EntityFramework/ModelConfiguration/Configuration/Properties/Index/IndexConfiguration.cs
+++ b/src/EntityFramework/ModelConfiguration/Configuration/Properties/Index/IndexConfiguration.cs
@@ -92,16 +92,54 @@ namespace System.Data.Entity.ModelConfiguration.Configuration.Properties.Index
         {
             DebugCheck.NotNull(edmProperty);
 
-            edmProperty.AddAnnotation(XmlConstants.IndexAnnotationWithPrefix,
-                new IndexAnnotation(new IndexAttribute(_name, indexOrder, _isClustered, _isUnique)));
+            var annotation = edmProperty.Annotations.FirstOrDefault(x => x.Name == XmlConstants.IndexAnnotationWithPrefix);
+
+            var attribute = new IndexAttribute(_name, indexOrder, _isClustered, _isUnique);
+
+            if (annotation == null)
+            {
+                edmProperty.AddAnnotation(
+                    XmlConstants.IndexAnnotationWithPrefix,
+                    new IndexAnnotation(attribute));
+            }
+            else
+            {
+                var indexAnnotation = annotation.Value as IndexAnnotation;
+
+                if (indexAnnotation != null)
+                {
+                    edmProperty.AddAnnotation(
+                        XmlConstants.IndexAnnotationWithPrefix,
+                        new IndexAnnotation(indexAnnotation.Indexes.Concat(new[] { attribute })));
+                }
+            }
         }
 
         internal void Configure(EntityType entityType)
         {
             DebugCheck.NotNull(entityType);
 
-            entityType.AddAnnotation(XmlConstants.IndexAnnotationWithPrefix,
-                new IndexAnnotation(new IndexAttribute(_name, _isClustered, _isUnique)));
+            var annotation = entityType.Annotations.FirstOrDefault(x => x.Name == XmlConstants.IndexAnnotationWithPrefix);
+
+            var attribute = new IndexAttribute(_name, _isClustered, _isUnique);
+
+            if (annotation == null)
+            {
+                entityType.AddAnnotation(
+                    XmlConstants.IndexAnnotationWithPrefix,
+                    new IndexAnnotation(attribute));
+            }
+            else
+            {
+                var indexAnnotation = annotation.Value as IndexAnnotation;
+
+                if (indexAnnotation != null)
+                {
+                    entityType.AddAnnotation(
+                        XmlConstants.IndexAnnotationWithPrefix,
+                        new IndexAnnotation(indexAnnotation.Indexes.Concat(new[] { attribute })));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This should resolve #460.

Given my current understanding, the issue appears to stem from the fact that in the `IndexConfiguration` class it simply replaces the existing `IndexAnnotation` with a new one (via the `MetadataItem.AddAnnotation` method), rather than appending the additional `IndexAttribute`(s) to the existing `IndexAnnotation` (if it exists).