### PR TITLE
ObjectMaterializedEventArgs constructor maked public.

### DIFF
--- a/src/EntityFramework/Core/Objects/ObjectMaterializedEventArgs.cs
+++ b/src/EntityFramework/Core/Objects/ObjectMaterializedEventArgs.cs
@@ -18,7 +18,7 @@ namespace System.Data.Entity.Core.Objects
         // Constructs new arguments for the ObjectMaterialized event.
         // </summary>
         // <param name="entity"> The object that has been materialized. </param>
-        internal ObjectMaterializedEventArgs(object entity)
+        public ObjectMaterializedEventArgs(object entity)
         {
             _entity = entity;
         }


### PR DESCRIPTION
The reason of this change is unit testing ObjectMaterialized event handler. While ObjectMaterializedEventArgs has a internal constructor, it's impossible to instantiate this class into Unit Test that was written for a ObjectMaterialized event handler of the ObjectContext.