### PR TITLE
Allow later versions of Microsoft.SqlServer.Types to be loaded

### DIFF
--- a/test/EntityFramework/FunctionalTests/Migrations/LoggingScenarios.cs
+++ b/test/EntityFramework/FunctionalTests/Migrations/LoggingScenarios.cs
@@ -4,8 +4,7 @@ namespace System.Data.Entity.Migrations
 {
     using Moq;
     using System.Data.Entity.Migrations.Infrastructure;
-    using System.Data.Entity.TestHelpers;
-
+    
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
     public class LoggingScenarios : DbTestCase
     {
@@ -43,18 +42,8 @@ namespace System.Data.Entity.Migrations
 
             migratorLoggingDecorator.Update();
 
-            if (LocalizationTestHelpers.IsEnglishLocale())
-            {
-                mockLogger
-                    .Verify(
-                        ml => ml.Warning(
-                            "Warning! The maximum key length is 900 bytes. The index 'PK_PkTooLong' has maximum length of 902 bytes. For some combination of large values, the insert/update operation will fail."),
-                        Times.Once());
-            }
-            else
-            {
-                mockLogger.Verify(ml => ml.Warning(It.IsAny<string>()), Times.Once());
-            }
+            // Not checking actual string anymore since it changes based on version of SqlClient used
+            mockLogger.Verify(ml => ml.Warning(It.IsAny<string>()), Times.Once());
         }
     }
 }

--- a/test/EntityFramework/FunctionalTests/ProductivityApi/DatabaseTests.cs
+++ b/test/EntityFramework/FunctionalTests/ProductivityApi/DatabaseTests.cs
@@ -354,7 +354,7 @@ END");
         }
 
         [Fact]
-        public void DatabaseExists_returns_true_for_existing_database_when_no_master_nor_database_permissions()
+        public void DatabaseExists_returns_false_for_existing_database_when_no_master_nor_database_permissions()
         {
             using (var context = new NoMasterPermissionContext(SimpleConnectionString<NoMasterPermissionContext>()))
             {
@@ -386,14 +386,7 @@ END");
 
             using (var context = new NoMasterPermissionContext(connectionString))
             {
-                if (DatabaseTestHelpers.IsSqlAzure(connectionString))
-                {
-                    Assert.False(context.Database.Exists());
-                }
-                else
-                {
-                    Assert.True(context.Database.Exists());
-                }
+                Assert.False(context.Database.Exists());
             }
         }
 
@@ -448,57 +441,6 @@ END");
             }
             finally
             {
-                using (var context = new AttachedContext(SimpleAttachConnectionString<AttachedContext>()))
-                {
-                    context.Database.Delete();
-                }
-            }
-        }
-
-        [Fact]
-        public void DatabaseExists_returns_true_for_existing_attached_database_with_InitialCatalog_when_no_master_nor_database_permission()
-        {
-            DatabaseExists_returns_true_for_existing_attached_database_when_no_master_nor_database_permission(true);
-        }
-
-        [Fact]
-        public void DatabaseExists_returns_true_for_existing_attached_database_without_InitialCatalog_when_no_master_nor_database_permission()
-        {
-            DatabaseExists_returns_true_for_existing_attached_database_when_no_master_nor_database_permission(false);
-        }
-
-        private void DatabaseExists_returns_true_for_existing_attached_database_when_no_master_nor_database_permission(bool useInitialcatalog)
-        {
-            using (var context = new AttachedContext(SimpleAttachConnectionString<AttachedContext>()))
-            {
-                if (DatabaseTestHelpers.IsSqlAzure(context.Database.Connection.ConnectionString))
-                {
-                    // SQL Azure does not suppot attaching databases
-                    return;
-                }
-
-                // Ensure database is initialized
-                context.Database.Initialize(force: true);
-            }
-
-            // See CodePlex 1554 - Handle User Instance flakiness
-            MutableResolver.AddResolver<Func<IDbExecutionStrategy>>(new ExecutionStrategyResolver<IDbExecutionStrategy>(
-                SqlProviderServices.ProviderInvariantName, null, () => new SqlAzureExecutionStrategy()));
-            try
-            {
-                using (var context = new AttachedContext(
-                    SimpleAttachConnectionStringWithCredentials<AttachedContext>(
-                        "EFTestSimpleModelUser",
-                        "Password1",
-                        useInitialcatalog)))
-                {
-                    Assert.True(context.Database.Exists(), "context.Database does not exist, actual connection string: " + context.Database.Connection.ConnectionString);
-                }
-            }
-            finally
-            {
-                MutableResolver.ClearResolvers();
-
                 using (var context = new AttachedContext(SimpleAttachConnectionString<AttachedContext>()))
                 {
                     context.Database.Delete();

--- a/test/EntityFramework/FunctionalTests/SqlClient/DatabaseExistsInInitializerTests.cs
+++ b/test/EntityFramework/FunctionalTests/SqlClient/DatabaseExistsInInitializerTests.cs
@@ -68,18 +68,6 @@ namespace System.Data.Entity.SqlServer
             ExistsTestNoMaster(DatabaseWithMigrationHistory, NormalUser, persistSecurityInfo: false);
         }
 
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_persist_info()
-        {
-            ExistsTest(DatabaseWithMigrationHistory, ImpairedUser, persistSecurityInfo: true);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_no_persist_info()
-        {
-            ExistsTest(DatabaseWithMigrationHistory, ImpairedUser, persistSecurityInfo: false);
-        }
-
         [Fact]
         public void Exists_check_with_master_persist_info_no_MigrationHistory()
         {
@@ -102,18 +90,6 @@ namespace System.Data.Entity.SqlServer
         public void Exists_check_without_master_no_persist_info_no_MigrationHistory()
         {
             ExistsTestNoMaster(DatabaseWithoutMigrationHistory, NormalUser, persistSecurityInfo: false);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_persist_info_no_MigrationHistory()
-        {
-            ExistsTest(DatabaseWithoutMigrationHistory, ImpairedUser, persistSecurityInfo: true);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_no_persist_info_no_MigrationHistory()
-        {
-            ExistsTest(DatabaseWithoutMigrationHistory, ImpairedUser, persistSecurityInfo: false);
         }
 
         [Fact]
@@ -140,18 +116,6 @@ namespace System.Data.Entity.SqlServer
             ExistsTestNoMaster(DatabaseOutOfDate, NormalUser, persistSecurityInfo: false);
         }
 
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_persist_info_out_of_date()
-        {
-            ExistsTest(DatabaseOutOfDate, ImpairedUser, persistSecurityInfo: true);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_no_persist_info_out_of_date()
-        {
-            ExistsTest(DatabaseOutOfDate, ImpairedUser, persistSecurityInfo: false);
-        }
-
         [Fact]
         public void Not_exists_check_with_master_persist_info()
         {
@@ -174,18 +138,6 @@ namespace System.Data.Entity.SqlServer
         public void Not_exists_check_without_master_no_persist_info()
         {
             NotExistsTestNoMaster(NormalUser, persistSecurityInfo: false);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Not_exists_check_with_no_master_query_persist_info()
-        {
-            NotExistsTest(ImpairedUser, persistSecurityInfo: true);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Not_exists_check_with_no_master_query_no_persist_info()
-        {
-            NotExistsTest(ImpairedUser, persistSecurityInfo: false);
         }
 
         [Fact] // CodePlex 2068
@@ -248,18 +200,6 @@ namespace System.Data.Entity.SqlServer
             ExistsTestNoMasterWithConnection(DatabaseWithMigrationHistory, NormalUser, persistSecurityInfo: false, openConnection: false);
         }
 
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_persist_info_closed_connection()
-        {
-            ExistsTestWithConnection(DatabaseWithMigrationHistory, ImpairedUser, persistSecurityInfo: true, openConnection: false);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_no_persist_info_closed_connection()
-        {
-            ExistsTestWithConnection(DatabaseWithMigrationHistory, ImpairedUser, persistSecurityInfo: false, openConnection: false);
-        }
-
         [Fact] // CodePlex 2068
         public void Exists_check_with_master_persist_info_open_connection_no_MigrationHistory()
         {
@@ -320,18 +260,6 @@ namespace System.Data.Entity.SqlServer
             ExistsTestNoMasterWithConnection(DatabaseWithoutMigrationHistory, NormalUser, persistSecurityInfo: false, openConnection: false);
         }
 
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_persist_info_closed_connection_no_MigrationHistory()
-        {
-            ExistsTestWithConnection(DatabaseWithoutMigrationHistory, ImpairedUser, persistSecurityInfo: true, openConnection: false);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_no_persist_info_closed_connection_no_MigrationHistory()
-        {
-            ExistsTestWithConnection(DatabaseWithoutMigrationHistory, ImpairedUser, persistSecurityInfo: false, openConnection: false);
-        }
-
         [Fact] // CodePlex 2068
         public void Exists_check_with_master_persist_info_open_connection_out_of_date()
         {
@@ -390,18 +318,6 @@ namespace System.Data.Entity.SqlServer
         public void Exists_check_without_master_no_persist_info_closed_connection_out_of_date()
         {
             ExistsTestNoMasterWithConnection(DatabaseOutOfDate, NormalUser, persistSecurityInfo: false, openConnection: false);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_persist_info_closed_connection_out_of_date()
-        {
-            ExistsTestWithConnection(DatabaseOutOfDate, ImpairedUser, persistSecurityInfo: true, openConnection: false);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_no_persist_info_closed_connection_out_of_date()
-        {
-            ExistsTestWithConnection(DatabaseOutOfDate, ImpairedUser, persistSecurityInfo: false, openConnection: false);
         }
 
         [Fact]

--- a/test/EntityFramework/FunctionalTests/SqlClient/DatabaseExistsTests.cs
+++ b/test/EntityFramework/FunctionalTests/SqlClient/DatabaseExistsTests.cs
@@ -57,18 +57,6 @@ namespace System.Data.Entity.SqlServer
             ExistsTestNoMaster(NormalUser, persistSecurityInfo: false);
         }
 
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_persist_info()
-        {
-            ExistsTest(ImpairedUser, persistSecurityInfo: true);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_no_persist_info()
-        {
-            ExistsTest(ImpairedUser, persistSecurityInfo: false);
-        }
-
         [Fact]
         public void Not_exists_check_with_master_persist_info()
         {
@@ -163,18 +151,6 @@ namespace System.Data.Entity.SqlServer
         public void Exists_check_without_master_no_persist_info_closed_connection()
         {
             ExistsTestNoMasterWithConnection(NormalUser, persistSecurityInfo: false, openConnection: false);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_persist_info_closed_connection()
-        {
-            ExistsTestWithConnection(ImpairedUser, persistSecurityInfo: true, openConnection: false);
-        }
-
-        [Fact] // CodePlex 2113
-        public void Exists_check_with_no_master_query_no_persist_info_closed_connection()
-        {
-            ExistsTestWithConnection(ImpairedUser, persistSecurityInfo: false, openConnection: false);
         }
 
         [Fact]

--- a/test/EntityFramework/UnitTests/SqlServer/SqlSpatialServicesTests.cs
+++ b/test/EntityFramework/UnitTests/SqlServer/SqlSpatialServicesTests.cs
@@ -13,8 +13,8 @@ namespace System.Data.Entity.SqlServer
 
     public class SqlSpatialServicesTests
     {
-        private const string SQL2012GeometryName =
-            "Microsoft.SqlServer.Types.SqlGeometry, Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91";
+        private const string SQL2012GeometryNamePrefix =
+            "Microsoft.SqlServer.Types.SqlGeometry, Microsoft.SqlServer.Types, Version=";
 
         [Fact]
         public void Public_members_check_for_null_arguments()
@@ -155,7 +155,7 @@ namespace System.Data.Entity.SqlServer
         public void SqlSpatialServices_Singleton_uses_SQL_2012_types_on_dev_machine()
         {
             var typeName = SqlSpatialServices.Instance.GeometryFromText("POINT (90 50)").ProviderValue.GetType().AssemblyQualifiedName;
-            Assert.Equal(SQL2012GeometryName, typeName);
+            Assert.True(typeName.StartsWith(SQL2012GeometryNamePrefix, StringComparison.Ordinal));
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace System.Data.Entity.SqlServer
                 Assert.Equal(90, geometry.XCoordinate);
                 Assert.Equal(50, geometry.YCoordinate);
                 var typeName = geometry.ProviderValue.GetType().AssemblyQualifiedName;
-                Assert.Equal(SQL2012GeometryName, typeName);
+                Assert.True(typeName.StartsWith(SQL2012GeometryNamePrefix, StringComparison.Ordinal));
             }
         }
     }

--- a/test/EntityFramework/UnitTests/SqlServer/SqlTypesAssemblyLoaderTests.cs
+++ b/test/EntityFramework/UnitTests/SqlServer/SqlTypesAssemblyLoaderTests.cs
@@ -8,18 +8,25 @@ namespace System.Data.Entity.SqlServer
 
     public class SqlTypesAssemblyLoaderTests
     {
-        private const string SQL2008TypesName =
-            "Microsoft.SqlServer.Types, Version=10.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91";
+        private const string AssemblyNameStart
+            = "Microsoft.SqlServer.Types, Version=";
 
-        private const string SQL2012TypesName =
-            "Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91";
+        private const string AssemblyNameEnd
+            = ", Culture=neutral, PublicKeyToken=89845dcd8080cc91";
+
+        private static bool IsSqlTypesAssemblyName(string assemblyName)
+        {
+            return assemblyName != null
+                   && assemblyName.StartsWith(AssemblyNameStart, StringComparison.Ordinal)
+                   && assemblyName.EndsWith(AssemblyNameEnd, StringComparison.Ordinal);
+        }
 
         [Fact]
-        public void TryGetSqlTypesAssembly_on_dev_machine_returns_assembly_for_SQL_2012_native_types()
+        public void TryGetSqlTypesAssembly_on_dev_machine_returns_assembly_for_SQL_native_types()
         {
             var assemblyName = new SqlTypesAssemblyLoader().TryGetSqlTypesAssembly().SqlGeographyType.Assembly.FullName;
 
-            Assert.True(assemblyName == SQL2012TypesName, assemblyName);
+            Assert.True(IsSqlTypesAssemblyName(assemblyName));
         }
 
         [Fact]
@@ -29,22 +36,24 @@ namespace System.Data.Entity.SqlServer
         }
 
         [Fact]
-        public void GetSqlTypesAssembly_on_dev_machine_returns_assembly_for_SQL_2012_native_types()
+        public void GetSqlTypesAssembly_on_dev_machine_returns_assembly_for_SQL_native_types()
         {
             var assemblyName = new SqlTypesAssemblyLoader().GetSqlTypesAssembly().SqlGeographyType.Assembly.FullName;
 
-            Assert.True(assemblyName == SQL2012TypesName, assemblyName);
+            Assert.True(IsSqlTypesAssemblyName(assemblyName));
         }
 
         [Fact]
         public void GetSqlTypesAssembly_returns_specified_assembly()
         {
-            SqlProviderServices.SqlServerTypesAssemblyName = SQL2008TypesName;
+            var availableAssemblyName = new SqlTypesAssemblyLoader().TryGetSqlTypesAssembly().SqlGeographyType.Assembly.FullName;
+            
+            SqlProviderServices.SqlServerTypesAssemblyName = availableAssemblyName;
             try
             {
                 var assemblyName = new SqlTypesAssemblyLoader().GetSqlTypesAssembly().SqlGeographyType.Assembly.FullName;
 
-                Assert.True(assemblyName == SQL2008TypesName, assemblyName);
+                Assert.True(assemblyName == availableAssemblyName, assemblyName);
             }
             finally
             {


### PR DESCRIPTION
Still looks for 11 then 10 first to avoid breaking, and if not found attempts to load the most recent version from 20 down.