### PR TITLE
Prevents the previously assigned transaction from being deleted due t…

### DIFF
--- a/src/EntityFramework/Core/Mapping/Update/Internal/DynamicUpdateCommand.cs
+++ b/src/EntityFramework/Core/Mapping/Update/Internal/DynamicUpdateCommand.cs
@@ -204,6 +204,11 @@ namespace System.Data.Entity.Core.Mapping.Update.Internal
                                            ? null
                                            : connection.CurrentTransaction.StoreTransaction);
                 command.Connection = connection.StoreConnection;
+
+                // FIX Klaus 12/09/2018: Prevents the previously assigned transaction from being deleted due to collateral effects during connection assignment.
+                command.Transaction = command.Transaction
+                                      ?? (connection.CurrentTransaction == null ? null : connection.CurrentTransaction.StoreTransaction);
+
                 if (Translator.CommandTimeout.HasValue)
                 {
                     command.CommandTimeout = Translator.CommandTimeout.Value;

--- a/src/EntityFramework/Core/Mapping/Update/Internal/DynamicUpdateCommand.cs
+++ b/src/EntityFramework/Core/Mapping/Update/Internal/DynamicUpdateCommand.cs
@@ -114,6 +114,11 @@ namespace System.Data.Entity.Core.Mapping.Update.Internal
                                            ? null
                                            : connection.CurrentTransaction.StoreTransaction);
                 command.Connection = connection.StoreConnection;
+
+                // FIX Klaus 12/09/2018: Prevents the previously assigned transaction from being deleted due to collateral effects during connection assignment.
+                command.Transaction = command.Transaction
+                                      ?? (connection.CurrentTransaction == null ? null : connection.CurrentTransaction.StoreTransaction);
+
                 if (Translator.CommandTimeout.HasValue)
                 {
                     command.CommandTimeout = Translator.CommandTimeout.Value;

--- a/src/EntityFramework/Core/Objects/ObjectContext.cs
+++ b/src/EntityFramework/Core/Objects/ObjectContext.cs
@@ -3266,7 +3266,9 @@ namespace System.Data.Entity.Core.Objects
                 // EntityConnection tracks the CurrentTransaction we don't need to pass it around
                 if (needLocalTransaction)
                 {
-                    localTransaction = connection.BeginTransaction();
+                    localTransaction = ContextOptions.DefaultIsolationLevel == null
+                        ? connection.BeginTransaction()
+                        : connection.BeginTransaction(ContextOptions.DefaultIsolationLevel.Value);
                 }
 
                 var result = func();
@@ -3348,7 +3350,9 @@ namespace System.Data.Entity.Core.Objects
                 // EntityConnection tracks the CurrentTransaction we don't need to pass it around
                 if (needLocalTransaction)
                 {
-                    localTransaction = connection.BeginTransaction();
+                    localTransaction = ContextOptions.DefaultIsolationLevel == null
+                        ? connection.BeginTransaction()
+                        : connection.BeginTransaction(ContextOptions.DefaultIsolationLevel.Value);
                 }
 
                 var result = await func().WithCurrentCulture();

--- a/src/EntityFramework/Core/Objects/ObjectContextOptions.cs
+++ b/src/EntityFramework/Core/Objects/ObjectContextOptions.cs
@@ -62,5 +62,12 @@ namespace System.Data.Entity.Core.Objects
         /// </remarks>
         /// <returns>true if the C# NullComparison behavior should be used; otherwise, false.</returns>
         public bool UseCSharpNullComparisonBehavior { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value that determines the default <see cref="IsolationLevel"/> to use for all EF-initiated transactions.
+        /// Note that this also affects the behavior of <see cref="ObjectContext.SaveChanges()"/>.
+        /// In case you want to use the default configuration of the DB driver, keep the value at null.
+        /// </summary>
+        public IsolationLevel? DefaultIsolationLevel { get; set; }
     }
 }

--- a/src/EntityFramework/Database.cs
+++ b/src/EntityFramework/Database.cs
@@ -120,7 +120,9 @@ namespace System.Data.Entity
         {
             var entityConnection = (EntityConnection)_internalContext.ObjectContext.Connection;
 
-            _dbContextTransaction = new DbContextTransaction(entityConnection);
+            _dbContextTransaction = _internalContext.DefaultIsolationLevel == null
+                ? new DbContextTransaction(entityConnection)
+                : new DbContextTransaction(entityConnection, _internalContext.DefaultIsolationLevel.Value);
             _entityTransaction = entityConnection.CurrentTransaction;
 
             return _dbContextTransaction;

--- a/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
@@ -162,6 +162,17 @@ namespace System.Data.Entity.Infrastructure
             set { _internalContext.ValidateOnSaveEnabled = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the value that determines the default <see cref="IsolationLevel"/> to use for all EF-initiated transactions.
+        /// Note that this also affects the behavior of <see cref="DbContext.SaveChanges()"/>.
+        /// In case you want to use the default configuration of the DB driver, keep the value at null.
+        /// </summary>
+        public IsolationLevel? DefaultIsolationLevel
+        {
+            get { return _internalContext.DefaultIsolationLevel; }
+            set { _internalContext.DefaultIsolationLevel = value; }
+        }
+
         #endregion
     }
 }

--- a/src/EntityFramework/Internal/EagerInternalContext.cs
+++ b/src/EntityFramework/Internal/EagerInternalContext.cs
@@ -248,6 +248,17 @@ namespace System.Data.Entity.Internal
             set { ObjectContextInUse.ContextOptions.UseCSharpNullComparisonBehavior = !value; }
         }
 
+        // <summary>
+        // Gets or sets the value that determines the default <see cref="IsolationLevel"/> to use for all EF-initiated transactions.
+        // Note that this also affects the behavior of <see cref="DbContext.SaveChanges()"/>.
+        // In case you want to use the default configuration of the DB driver, keep the value at null.
+        // </summary>
+        public override IsolationLevel? DefaultIsolationLevel
+        {
+            get { return ObjectContextInUse.ContextOptions.DefaultIsolationLevel; }
+            set { ObjectContextInUse.ContextOptions.DefaultIsolationLevel = value; }
+        }
+
         public override int? CommandTimeout
         {
             get { return ObjectContextInUse.CommandTimeout; }

--- a/src/EntityFramework/Internal/InternalContext.cs
+++ b/src/EntityFramework/Internal/InternalContext.cs
@@ -622,6 +622,13 @@ namespace System.Data.Entity.Internal
         // </summary>
         public bool ValidateOnSaveEnabled { get; set; }
 
+        /// <summary>
+        /// Gets or sets the value that determines the default <see cref="IsolationLevel"/> to use for all EF-initiated transactions.
+        /// Note that this also affects the behavior of <see cref="DbContext.SaveChanges()"/>.
+        /// In case you want to use the default configuration of the DB driver, keep the value at null.
+        /// </summary>
+        public abstract IsolationLevel? DefaultIsolationLevel { get; set; }
+
         protected void LoadContextConfigs()
         {
             var configCommandTimeout = AppConfig.ContextConfigs.TryGetCommandTimeout(Owner.GetType());

--- a/src/EntityFramework/Internal/LazyInternalContext.cs
+++ b/src/EntityFramework/Internal/LazyInternalContext.cs
@@ -79,6 +79,9 @@ namespace System.Data.Entity.Internal
         // This flag is used to keep the user's database null comparison behavior option before the ObjectContext is initialized.  
         private bool _useDatabaseNullSemanticsFlag;
 
+        // This variable is used to keep the default isolation level option before the ObjectContext is initialized.  
+        private IsolationLevel? _defaultIsolationLevel;
+
         // This flag is used to keep the user's command timeout before the ObjectContext is initialized.  
         private int? _commandTimeout;
 
@@ -463,6 +466,7 @@ namespace System.Data.Entity.Internal
                     _objectContext.ContextOptions.LazyLoadingEnabled = _initialLazyLoadingFlag;
                     _objectContext.ContextOptions.ProxyCreationEnabled = _initialProxyCreationFlag;
                     _objectContext.ContextOptions.UseCSharpNullComparisonBehavior = !_useDatabaseNullSemanticsFlag;
+                    _objectContext.ContextOptions.DefaultIsolationLevel = _defaultIsolationLevel;
                     _objectContext.CommandTimeout = _commandTimeout;
 
                     _objectContext.ContextOptions.UseConsistentNullReferenceBehavior = true;
@@ -801,6 +805,30 @@ namespace System.Data.Entity.Internal
                 {
                     _useDatabaseNullSemanticsFlag = value;
                 }
+            }
+        }
+
+        // <summary>
+        // Gets or sets the value that determines the default <see cref="IsolationLevel"/> to use for all EF-initiated transactions.
+        // Note that this also affects the behavior of <see cref="DbContext.SaveChanges()"/>.
+        // In case you want to use the default configuration of the DB driver, keep the value at null.
+        // </summary>
+        public override IsolationLevel? DefaultIsolationLevel
+        {
+            get
+            {
+                var objectContext = ObjectContextInUse;
+                return objectContext == null
+                    ? _defaultIsolationLevel
+                    : objectContext.ContextOptions.DefaultIsolationLevel;
+            }
+            set
+            {
+                var objectContext = ObjectContextInUse;
+                if (objectContext != null)
+                    objectContext.ContextOptions.DefaultIsolationLevel = value;
+                else
+                    _defaultIsolationLevel = value;
             }
         }
 

--- a/src/EntityFramework/Internal/MockingProxies/ObjectContextProxy.cs
+++ b/src/EntityFramework/Internal/MockingProxies/ObjectContextProxy.cs
@@ -90,6 +90,7 @@ namespace System.Data.Entity.Internal.MockingProxies
                 source._objectContext.ContextOptions.UseConsistentNullReferenceBehavior;
             _objectContext.ContextOptions.UseLegacyPreserveChangesBehavior =
                 source._objectContext.ContextOptions.UseLegacyPreserveChangesBehavior;
+            _objectContext.ContextOptions.DefaultIsolationLevel = source._objectContext.ContextOptions.DefaultIsolationLevel;
             _objectContext.CommandTimeout = source._objectContext.CommandTimeout;
 
             _objectContext.InterceptionContext = source._objectContext.InterceptionContext.WithObjectContext(_objectContext);


### PR DESCRIPTION
I'm currently working with a specific DB access driver, and I have found the problem that the command object, at the moment the connection is assigned, puts null in the transaction it had previously assigned.

As I don't know the reason why the transaction is assigned before the connection, I have proceeded to review the assignment of the transaction after the assignment of the connection.