### PR TITLE
Fixes part of #591; when 2 calls to HasIndex reference same column

### DIFF
--- a/src/EntityFramework/ModelConfiguration/Configuration/Properties/Index/IndexConfiguration.cs
+++ b/src/EntityFramework/ModelConfiguration/Configuration/Properties/Index/IndexConfiguration.cs
@@ -92,7 +92,7 @@ namespace System.Data.Entity.ModelConfiguration.Configuration.Properties.Index
         {
             DebugCheck.NotNull(edmProperty);
 
-            edmProperty.AddAnnotation(XmlConstants.IndexAnnotationWithPrefix,
+            AddAnnotationWithMerge(edmProperty,
                 new IndexAnnotation(new IndexAttribute(_name, indexOrder, _isClustered, _isUnique)));
         }
 
@@ -100,8 +100,20 @@ namespace System.Data.Entity.ModelConfiguration.Configuration.Properties.Index
         {
             DebugCheck.NotNull(entityType);
 
-            entityType.AddAnnotation(XmlConstants.IndexAnnotationWithPrefix,
+            AddAnnotationWithMerge(entityType,
                 new IndexAnnotation(new IndexAttribute(_name, _isClustered, _isUnique)));
+        }
+
+        private static void AddAnnotationWithMerge(MetadataItem metadataItem, IndexAnnotation newAnnotation)
+        {
+            var existingAnnotation = metadataItem.Annotations.GetAnnotation(XmlConstants.IndexAnnotationWithPrefix);
+
+            if (existingAnnotation != null)
+            {
+                newAnnotation = (IndexAnnotation)((IndexAnnotation)existingAnnotation).MergeWith(newAnnotation);
+            }
+
+            metadataItem.AddAnnotation(XmlConstants.IndexAnnotationWithPrefix, newAnnotation);
         }
     }
 }


### PR DESCRIPTION
I was looking at what's required to move my project from EF 6.2 to EF Core, and one big change is the move from `[Index]` attributes to calls to `.HasIndex`. So I said, let me change to `.HasIndex` first, since that syntax is available in EF 6.2. Then when I switch to EF Core, it'll be a snap - almost no code changes.

But I hit a bug that happens when you use `HasIndex` to establish two indexes that both contain the same column. This bug was previously reported in #591.

Basically, since the data is stored internally in EF by column, a second index definition displaces the first, for those columns that are in both indexes. I have updated the logic to do a merge instead, and added a test case.