### PR TITLE
Fixed incorrect spelling of Debug statement in EntityEntry.cs

### DIFF
--- a/src/EntityFramework/Core/Objects/EntityEntry.cs
+++ b/src/EntityFramework/Core/Objects/EntityEntry.cs
@@ -2430,7 +2430,7 @@ namespace System.Data.Entity.Core.Objects
             EntityEntry relatedEntry,
             RelatedEnd relatedEndFrom)
         {
-            Debug.Assert(!relatedKey.IsTemporary, "the relatedKey was created by a method which returns only permaanent keys");
+            Debug.Assert(!relatedKey.IsTemporary, "the relatedKey was created by a method which returns only permanent keys");
             AddDetectedRelationship(relationships, relatedKey, relatedEndFrom);
 
             if (relatedEntry != null)


### PR DESCRIPTION
## Description
While debugging the code for another reason, I came across a minor spelling mistake, that I thought I could quickly correct.