### PR TITLE
fix-561 Cast error, not enough information

### DIFF
--- a/src/EntityFramework/Core/Common/internal/materialization/CodeGenEmitter.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/CodeGenEmitter.cs
@@ -293,7 +293,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
         // <summary>
         // Create expression that guarantees the input expression is of the specified
         // type; no Convert is added if the expression is already of the same type.
-        // Add columnName for more information.
+        // Add columnName for more cast failed information.
         // Internal because it is called from the TranslatorResult.
         // </summary>
         internal static Expression Emit_EnsureType(Expression input, Type type, string columnName)

--- a/src/EntityFramework/Core/Common/internal/materialization/translator.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/translator.cs
@@ -1277,7 +1277,6 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                     }
 
                     // (type)shaper.Reader.Get???(ordinal)
-                    // add column name for more information.
                     result = CodeGenEmitter.Emit_EnsureType(result, type, columnMap.Name);
 
                     if (needsNullableCheck)

--- a/src/EntityFramework/Core/Common/internal/materialization/translator.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/translator.cs
@@ -503,7 +503,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                 {
                     result = CodeGenEmitter.Emit_EnsureType(
                         BuildExpressionToGetRecordState(columnMap, null, null, Expression.Constant(true)),
-                        arg.RequestedType, columnMap.Name);
+                        arg.RequestedType);
                 }
                 else
                 {
@@ -585,7 +585,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                 foreach (var typeChoice in columnMap.TypeChoices)
                 {
                     var typeReader = CodeGenEmitter.Emit_EnsureType(
-                        AcceptWithMappedType(this, typeChoice.Value).UnwrappedExpression, typeof(TElement), columnMap.Name);
+                        AcceptWithMappedType(this, typeChoice.Value).UnwrappedExpression, typeof(TElement));
                     var typeReaderDelegate = CreateInlineDelegate(typeReader);
                     Expression typeDelegatePair = Expression.New(
                         typeDelegatePairConstructor,
@@ -796,7 +796,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
 
                     // ((object)columnReader) ?? DBNull.Value
                     columnReaders[i] = Expression.Coalesce(
-                        CodeGenEmitter.Emit_EnsureType(columnReader, typeof(object), columnMap.Name), CodeGenEmitter.DBNull_Value);
+                        CodeGenEmitter.Emit_EnsureType(columnReader, typeof(object)), CodeGenEmitter.DBNull_Value);
                 }
                 // new object[] {columnReader0..columnReaderN}
                 Expression columnReaderArray = Expression.NewArrayInit(typeof(object), columnReaders);
@@ -815,7 +815,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                 var result = CodeGenEmitter.Emit_EnsureType(
                     Expression.New(
                         CodeGenEmitter.MaterializedDataRecord_ctor, CodeGenEmitter.Shaper_Workspace, typeUsage, columnReaderArray),
-                    arg.RequestedType, columnMap.Name);
+                    arg.RequestedType);
                 return result;
             }
 
@@ -991,7 +991,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                     result = Expression.Call(expressionToGetCoordinator, getElementsExpression);
 
                     // Perform the type check that was previously deferred so we could process POCO collections.
-                    coordinatorScratchpad.Element = CodeGenEmitter.Emit_EnsureType(coordinatorScratchpad.Element, elementType, columnMap.Name);
+                    coordinatorScratchpad.Element = CodeGenEmitter.Emit_EnsureType(coordinatorScratchpad.Element, elementType);
 
                     // When materializing specifically requested collection types, we need
                     // to transfer the results from the Enumerable to the requested collection.
@@ -1013,9 +1013,9 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                         {
                             coordinatorScratchpad.InitializeCollection = CodeGenEmitter.Emit_EnsureType(
                                 DelegateFactory.GetNewExpressionForCollectionType(typeToInstantiate),
-                                typeof(ICollection<>).MakeGenericType(innerElementType), columnMap.Name);
+                                typeof(ICollection<>).MakeGenericType(innerElementType));
                         }
-                        result = CodeGenEmitter.Emit_EnsureType(result, arg.RequestedType, columnMap.Name);
+                        result = CodeGenEmitter.Emit_EnsureType(result, arg.RequestedType);
                     }
                     else
                     {
@@ -1027,7 +1027,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                             // new CompensatingCollection<TElement>(_collectionReader)
                             var compensatingCollectionType = typeof(CompensatingCollection<>).MakeGenericType(elementType);
                             var constructorInfo = compensatingCollectionType.GetConstructors()[0];
-                            result = CodeGenEmitter.Emit_EnsureType(Expression.New(constructorInfo, result), compensatingCollectionType, columnMap.Name);
+                            result = CodeGenEmitter.Emit_EnsureType(Expression.New(constructorInfo, result), compensatingCollectionType);
                         }
                     }
                 }
@@ -1214,8 +1214,8 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                     result =
                         CodeGenEmitter.Emit_Conditional_NotDBNull(
                             Helper.IsGeographicType((PrimitiveType)columnType.EdmType)
-                                ? CodeGenEmitter.Emit_EnsureType(CodeGenEmitter.Emit_Shaper_GetGeographyColumnValue(ordinal), type, columnMap.Name)
-                                : CodeGenEmitter.Emit_EnsureType(CodeGenEmitter.Emit_Shaper_GetGeometryColumnValue(ordinal), type, columnMap.Name),
+                                ? CodeGenEmitter.Emit_EnsureType(CodeGenEmitter.Emit_Shaper_GetGeographyColumnValue(ordinal), type)
+                                : CodeGenEmitter.Emit_EnsureType(CodeGenEmitter.Emit_Shaper_GetGeometryColumnValue(ordinal), type),
                             ordinal, type);
 
                     if (!_streaming && !NullableColumns.Contains(ordinal))
@@ -1227,7 +1227,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                 {
                     result =
                         CodeGenEmitter.Emit_Conditional_NotDBNull(
-                            CodeGenEmitter.Emit_EnsureType(CodeGenEmitter.Emit_Shaper_GetHierarchyIdColumnValue(ordinal), type, columnMap.Name), ordinal,
+                            CodeGenEmitter.Emit_EnsureType(CodeGenEmitter.Emit_Shaper_GetHierarchyIdColumnValue(ordinal), type), ordinal,
                             type);
                 }
                 else

--- a/src/EntityFramework/Properties/Resources.cs
+++ b/src/EntityFramework/Properties/Resources.cs
@@ -7119,6 +7119,14 @@ namespace System.Data.Entity.Resources
         }
 
         // <summary>
+        // A string like "FieldName:{0}, {1}"
+        // </summary>
+        internal static string Materializer_InvalidColumnCastMessage(object p0, object p1)
+        {
+            return EntityRes.GetString(EntityRes.Materializer_InvalidColumnCastMessage, p0, p1);
+        }
+
+        // <summary>
         // A string like "The specified cast from a materialized '{0}' type to a nullable '{1}' type is not valid."
         // </summary>
         internal static string Materializer_InvalidCastNullable(object p0, object p1)
@@ -16621,6 +16629,7 @@ namespace System.Data.Entity.Resources
         internal const string Materializer_PropertyIsNotNullable = "Materializer_PropertyIsNotNullable";
         internal const string Materializer_PropertyIsNotNullableWithName = "Materializer_PropertyIsNotNullableWithName";
         internal const string Materializer_SetInvalidValue = "Materializer_SetInvalidValue";
+        internal const string Materializer_InvalidColumnCastMessage = "Materializer_InvalidColumnCastMessage";
         internal const string Materializer_InvalidCastReference = "Materializer_InvalidCastReference";
         internal const string Materializer_InvalidCastNullable = "Materializer_InvalidCastNullable";
         internal const string Materializer_NullReferenceCast = "Materializer_NullReferenceCast";

--- a/src/EntityFramework/Properties/Resources.cs
+++ b/src/EntityFramework/Properties/Resources.cs
@@ -7119,7 +7119,7 @@ namespace System.Data.Entity.Resources
         }
 
         // <summary>
-        // A string like "FieldName:{0}, {1}"
+        // A string like "The column with the name '{0}' conversion failed, {1}"
         // </summary>
         internal static string Materializer_InvalidColumnCastMessage(object p0, object p1)
         {

--- a/src/EntityFramework/Properties/Resources.resx
+++ b/src/EntityFramework/Properties/Resources.resx
@@ -2940,6 +2940,9 @@
   <data name="Materializer_InvalidCastReference" xml:space="preserve">
     <value>The specified cast from a materialized '{0}' type to the '{1}' type is not valid.</value>
   </data>
+  <data name="Materializer_InvalidColumnCastMessage" xml:space="preserve">
+    <value>The column with the name '{0}' conversion failed, {1}</value>
+  </data>
   <data name="Materializer_InvalidCastNullable" xml:space="preserve">
     <value>The specified cast from a materialized '{0}' type to a nullable '{1}' type is not valid.</value>
   </data>


### PR DESCRIPTION
Since our database table contains too many columns, in the production environment, after the cast error from the column to the model field, it is difficult to quickly locate the problem.

so I try to fix the issues, look forward to your guidance and reply, thank you.