### PR TITLE
Issue #561: Cast error, not enough information 

### DIFF
--- a/src/EntityFramework/Core/Common/internal/materialization/CodeGenEmitter.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/CodeGenEmitter.cs
@@ -291,6 +291,41 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
         }
 
         // <summary>
+        // Create expression that guarantees the input expression is of the specified
+        // type; no Convert is added if the expression is already of the same type.
+        // Add columnName for more cast failed information.
+        // Internal because it is called from the TranslatorResult.
+        // </summary>
+        internal static Expression Emit_EnsureType(Expression input, Type type, string columnName)
+        {
+            var result = input;
+            if (input.Type != type
+                && !typeof(IEntityWrapper).IsAssignableFrom(input.Type))
+            {
+                if (type.IsAssignableFrom(input.Type))
+                {
+                    // simple convert, just to make sure static type checks succeed
+                    result = Expression.Convert(input, type);
+                }
+                else
+                {
+                    // user is asking for the 'wrong' type... add exception handling
+                    // in case of failure
+                    try
+                    {
+                        var checkedConvertMethod = CodeGenEmitter_CheckedConvert.MakeGenericMethod(input.Type, type);
+                        result = Expression.Call(checkedConvertMethod, input);
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        throw new InvalidOperationException(Strings.Materializer_InvalidColumnCastMessage(columnName, e.Message));
+                    }
+                }
+            }
+            return result;
+        }
+
+        // <summary>
         // Uses Emit_EnsureType and then wraps the result in an IEntityWrapper instance.
         // </summary>
         // <param name="input"> The expression that creates the entity to be wrapped </param>

--- a/src/EntityFramework/Properties/Resources.cs
+++ b/src/EntityFramework/Properties/Resources.cs
@@ -7119,6 +7119,14 @@ namespace System.Data.Entity.Resources
         }
 
         // <summary>
+        // A string like "The column with the name '{0}' conversion failed, {1}"
+        // </summary>
+        internal static string Materializer_InvalidColumnCastMessage(object p0, object p1)
+        {
+            return EntityRes.GetString(EntityRes.Materializer_InvalidColumnCastMessage, p0, p1);
+        }
+
+        // <summary>
         // A string like "The specified cast from a materialized '{0}' type to a nullable '{1}' type is not valid."
         // </summary>
         internal static string Materializer_InvalidCastNullable(object p0, object p1)
@@ -16621,6 +16629,7 @@ namespace System.Data.Entity.Resources
         internal const string Materializer_PropertyIsNotNullable = "Materializer_PropertyIsNotNullable";
         internal const string Materializer_PropertyIsNotNullableWithName = "Materializer_PropertyIsNotNullableWithName";
         internal const string Materializer_SetInvalidValue = "Materializer_SetInvalidValue";
+        internal const string Materializer_InvalidColumnCastMessage = "Materializer_InvalidColumnCastMessage";
         internal const string Materializer_InvalidCastReference = "Materializer_InvalidCastReference";
         internal const string Materializer_InvalidCastNullable = "Materializer_InvalidCastNullable";
         internal const string Materializer_NullReferenceCast = "Materializer_NullReferenceCast";

--- a/src/EntityFramework/Properties/Resources.resx
+++ b/src/EntityFramework/Properties/Resources.resx
@@ -2940,6 +2940,9 @@
   <data name="Materializer_InvalidCastReference" xml:space="preserve">
     <value>The specified cast from a materialized '{0}' type to the '{1}' type is not valid.</value>
   </data>
+  <data name="Materializer_InvalidColumnCastMessage" xml:space="preserve">
+    <value>The column with the name '{0}' conversion failed, {1}</value>
+  </data>
   <data name="Materializer_InvalidCastNullable" xml:space="preserve">
     <value>The specified cast from a materialized '{0}' type to a nullable '{1}' type is not valid.</value>
   </data>


### PR DESCRIPTION
Since our database table contains too many columns, in the production environment, after the cast error from the column to the model field, it is difficult to quickly locate the problem.

so I try to fix the issue #561 , look forward to your guidance and reply, thank you.