### PR TITLE
Update the Signing Certificate

### DIFF
--- a/build/sign.proj
+++ b/build/sign.proj
@@ -26,7 +26,7 @@
     </ItemGroup>
     <ItemGroup>
       <FilesToSign Include="@(LocalizedEFToolsDLLs)">
-        <Authenticode>Microsoft</Authenticode>
+        <Authenticode>Microsoft400</Authenticode>
         <StrongName>67</StrongName>
       </FilesToSign>
     </ItemGroup>


### PR DESCRIPTION
Previous cert was SHA1 and SHA256. Going forward MicroBuild will support SHA256 exclusively. So changing cert.