### PR TITLE
Increase build timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       helixRepo: aspnet/EntityFramework6
       jobs:
         - job: Windows
-          timeoutInMinutes: 150
+          timeoutInMinutes: 180
           pool:
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               name: NetCorePublic-Pool


### PR DESCRIPTION
Seems like the builds timeout after 2.5 hours see https://github.com/aspnet/AspNetCore-Internal/issues/2652. The successful builds in this repo often takes almost that long so we should just increase the limit. 