### PR TITLE
Change dual SHA1-SHA256 signing to SHA256-only (VS2017)

### DIFF
--- a/build/sign.proj
+++ b/build/sign.proj
@@ -26,7 +26,7 @@
     </ItemGroup>
     <ItemGroup>
       <FilesToSign Include="@(LocalizedEFToolsDLLs)">
-        <Authenticode>Microsoft</Authenticode>
+        <Authenticode>Microsoft400</Authenticode>
         <StrongName>67</StrongName>
       </FilesToSign>
     </ItemGroup>


### PR DESCRIPTION
Updating VS2017 branch to change dual SHA1-SHA256 signing to SHA256-only.