### PR TITLE
Override signing for CAB files so they use the SHA256-only cert too.

### DIFF
--- a/setup/wix/EFToolsWillowMsi.wixproj
+++ b/setup/wix/EFToolsWillowMsi.wixproj
@@ -52,11 +52,16 @@
     <Compile Include="ReferenceCounting.wxs" />
   </ItemGroup>
 
-  <!-- Sign outputs using this certificate -->
+  <!-- Sign outputs using this certificate and override CAB files to also use this cert -->
   <PropertyGroup> 
     <SetupPackageCertificate>Microsoft400</SetupPackageCertificate> 
     <SignOutput>true</SignOutput>
   </PropertyGroup> 
+  <ItemDefinitionGroup>
+    <SignCabs>
+      <Authenticode>Microsoft400</Authenticode>
+    </SignCabs>
+  </ItemDefinitionGroup>
 
   <Target Name="Build">
     <!-- Build target from WiX would have overwritten this target if wix had been installed -->


### PR DESCRIPTION
Override signing for CAB files so they use the SHA256-only cert too.