### PR TITLE
Use DpiAwarenessContext.SystemAware when creating Tool Windows.

### DIFF
--- a/src/EFTools/EntityDesign/CodeGeneration/Generators/TextTemplatingHost.cs
+++ b/src/EFTools/EntityDesign/CodeGeneration/Generators/TextTemplatingHost.cs
@@ -4,6 +4,7 @@
     using System.CodeDom.Compiler;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -109,6 +110,7 @@
             return new TextTemplatingSession();
         }
 
+        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
         public string ProcessTemplate(string inputFile, string content, ITextTemplatingCallback callback = null)
         {
             Debug.Assert(!string.IsNullOrEmpty(inputFile), "inputFile is null or empty.");

--- a/src/EFTools/EntityDesignPackage/CustomCode/MicrosoftDataEntityDesignPackage.cs
+++ b/src/EFTools/EntityDesignPackage/CustomCode/MicrosoftDataEntityDesignPackage.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Data.Entity.Design.Package
     using Microsoft.VisualStudio.DataDesign.Interfaces;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
+    using Microsoft.VisualStudio.Utilities;
     using ModelChangeEventArgs = Microsoft.Data.Entity.Design.VisualStudio.Package.ModelChangeEventArgs;
 
     [ProvideToolWindow(typeof(EntityDesignExplorerWindow),
@@ -478,7 +479,10 @@ namespace Microsoft.Data.Entity.Design.Package
             {
                 if (_explorerWindow == null)
                 {
-                    _explorerWindow = FindToolWindow(typeof(EntityDesignExplorerWindow), 0, true) as ExplorerWindow;
+                    using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                    {
+                        _explorerWindow = FindToolWindow(typeof(EntityDesignExplorerWindow), 0, true) as ExplorerWindow;
+                    }
                 }
                 return _explorerWindow;
             }
@@ -490,7 +494,10 @@ namespace Microsoft.Data.Entity.Design.Package
             {
                 if (_mappingDetailsWindow == null)
                 {
-                    _mappingDetailsWindow = GetToolWindow(typeof(MappingDetailsWindow), true) as MappingDetailsWindow;
+                    using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                    {
+                        _mappingDetailsWindow = GetToolWindow(typeof(MappingDetailsWindow), true) as MappingDetailsWindow;
+                    }
                 }
                 return _mappingDetailsWindow;
             }

--- a/src/EFTools/EntityDesignPackage/EntityDesignPackage.csproj
+++ b/src/EFTools/EntityDesignPackage/EntityDesignPackage.csproj
@@ -55,6 +55,9 @@
   </PropertyGroup>
   <Import Project="$(RepositoryRoot)tools\EFToolsVsReferences.settings.targets" />
   <ItemGroup>
+    <Reference Condition="'$(VisualStudioVersion)' == '16.0'" Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.$(VisualStudioVersion15)" />
     <Reference Condition="'$(VisualStudioVersion)' == '16.0'" Include="Microsoft.VisualStudio.Shell.Framework" />
     <Reference Include="Microsoft.VisualStudio.Package.LanguageService.$(VisualStudioVersion15)" />
@@ -66,11 +69,15 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0" />
     <Reference Condition="'$(VisualStudioVersion)' != '11.0' AND '$(VisualStudioVersion)' != '12.0' AND '$(VisualStudioVersion)' != '14.0'"
                Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" />
+    <Reference Condition="'$(VisualStudioVersion)' == '16.0'" Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
     <Reference Include="Microsoft.VisualStudio.DataDesign.Interfaces" />
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
+    <Reference Condition="$(VisualStudioVersion)!='11.0' AND $(VisualStudioVersion)!='12.0'" Include="Microsoft.VisualStudio.Utilities" />
     <Reference Include="Accessibility" />
     <Reference Include="System" />
     <Reference Include="System.Xaml" />


### PR DESCRIPTION
Fix for internal bug 898367 and #788 - Model Browser not visible.

This only happens (for me) on some screens, and then only for some combinations of screen resolution and scale factor. It could be worked around by unchecking **Tools -> Options -> Environment -> General -> Optimize rendering for screens with different pixel densities**, but this fix should make that unnecessary.