### PR TITLE
Improve TruncateTime canonical function performance

### DIFF
--- a/src/EntityFramework.SqlServer/SqlGen/SqlFunctionCallHandler.cs
+++ b/src/EntityFramework.SqlServer/SqlGen/SqlFunctionCallHandler.cs
@@ -1422,17 +1422,17 @@ namespace System.Data.Entity.SqlServer.SqlGen
 
             Debug.Assert(isDateTimeOffset || typeKind == PrimitiveTypeKind.DateTime, "Unexpected type to TruncateTime" + typeKind.ToString());
 
+            if (sqlgen.IsPreKatmai && isDateTimeOffset)
+            {
+                throw new NotSupportedException(Strings.SqlGen_CanonicalFunctionNotSupportedPriorSql10(e.Function.Name));
+            }
+
 
             var result = new SqlBuilder();
             var argumentFragment = e.Arguments[0].Accept(sqlgen);
 
             if (sqlgen.IsPreKatmai)
             {
-                if (isDateTimeOffset)
-                {
-                    throw new NotSupportedException(Strings.SqlGen_CanonicalFunctionNotSupportedPriorSql10(e.Function.Name));
-                }
-
                 result.Append("dateadd(d, datediff(d, 0, ");
                 result.Append(argumentFragment);
                 result.Append("), 0)");

--- a/src/EntityFramework.SqlServerCompact/SqlGen/SqlGenerator.cs
+++ b/src/EntityFramework.SqlServerCompact/SqlGen/SqlGenerator.cs
@@ -3144,13 +3144,10 @@ namespace System.Data.Entity.SqlServerCompact.SqlGen
 
         // <summary>
         // TruncateTime(DateTime X)
-        // TRUNCATETIME(X) => CONVERT(DATETIME, CONVERT(VARCHAR(255), expression, 102),  102)
+        // TRUNCATETIME(X) => DATEADD(d, DATEDIFF(d, 0, expression), 0)
         // </summary>
         private static ISqlFragment HandleCanonicalFunctionTruncateTime(SqlGenerator sqlgen, DbFunctionExpression e)
         {
-            //The type that we need to return is based on the argument type.
-            string typeName = "datetime";
-
             PrimitiveTypeKind typeKind;
             TypeHelpers.TryGetPrimitiveTypeKind(e.ResultType, out typeKind);
 
@@ -3160,13 +3157,10 @@ namespace System.Data.Entity.SqlServerCompact.SqlGen
             }
 
             var result = new SqlBuilder();
-            result.Append("convert (");
-            result.Append(typeName);
-            result.Append(", convert(nvarchar(255), ");
+            result.Append("dateadd(d, datediff(d, 0, ");
             result.Append(e.Arguments[0].Accept(sqlgen));
-            result.Append(", 102) ");
+            result.Append("), 0)");
 
-            result.Append(",  102)");
             return result;
         }
 

--- a/test/EntityFramework/FunctionalTests/Query/SqlCeCanonicalFunctionsTests.cs
+++ b/test/EntityFramework/FunctionalTests/Query/SqlCeCanonicalFunctionsTests.cs
@@ -516,7 +516,7 @@ namespace System.Data.Entity.Query
             using (var context = GetArubaCeContext())
             {
                 var query = context.CreateQuery<DateTime>(@"SELECT VALUE Edm.TruncateTime(A.c5_datetime) FROM ArubaCeContext.AllTypes AS A");
-                Assert.Contains("CAST(CAST([EXTENT1].[C5_DATETIME] AS DATE) AS DATETIME2) ", query.ToTraceString().ToUpperInvariant());
+                Assert.Contains("DATEADD(D, DATEDIFF(D, 0, [EXTENT1].[C5_DATETIME]), 0)", query.ToTraceString().ToUpperInvariant());
                 Assert.Equal(new DateTime(1990, 2, 2, 0, 0, 0), query.First());
             }
         }

--- a/test/EntityFramework/FunctionalTests/Query/SqlCeCanonicalFunctionsTests.cs
+++ b/test/EntityFramework/FunctionalTests/Query/SqlCeCanonicalFunctionsTests.cs
@@ -516,7 +516,7 @@ namespace System.Data.Entity.Query
             using (var context = GetArubaCeContext())
             {
                 var query = context.CreateQuery<DateTime>(@"SELECT VALUE Edm.TruncateTime(A.c5_datetime) FROM ArubaCeContext.AllTypes AS A");
-                Assert.Contains("CONVERT", query.ToTraceString().ToUpperInvariant());
+                Assert.Contains("DATEADD(D, DATEDIFF(D,", query.ToTraceString().ToUpperInvariant());
                 Assert.Equal(new DateTime(1990, 2, 2, 0, 0, 0), query.First());
             }
         }

--- a/test/EntityFramework/FunctionalTests/Query/SqlCeCanonicalFunctionsTests.cs
+++ b/test/EntityFramework/FunctionalTests/Query/SqlCeCanonicalFunctionsTests.cs
@@ -516,7 +516,7 @@ namespace System.Data.Entity.Query
             using (var context = GetArubaCeContext())
             {
                 var query = context.CreateQuery<DateTime>(@"SELECT VALUE Edm.TruncateTime(A.c5_datetime) FROM ArubaCeContext.AllTypes AS A");
-                Assert.Contains("DATEADD(D, DATEDIFF(D,", query.ToTraceString().ToUpperInvariant());
+                Assert.Contains("CAST(CAST([EXTENT1].[C5_DATETIME] AS DATE) AS DATETIME2) ", query.ToTraceString().ToUpperInvariant());
                 Assert.Equal(new DateTime(1990, 2, 2, 0, 0, 0), query.First());
             }
         }


### PR DESCRIPTION
Ported from CodePlex, taking back over from #467 .

Updates TruncateTime function from
```
TruncateTime(DateTime X)	        
    PreKatmai:    TRUNCATETIME(X) => CONVERT(DATETIME, CONVERT(VARCHAR(255), expression, 102),  102)
    Katmai:    TRUNCATETIME(X) => CONVERT(DATETIME2, CONVERT(VARCHAR(255), expression, 102),  102)
TruncateTime(DateTimeOffset X)
    TRUNCATETIME(X) => CONVERT(datetimeoffset, CONVERT(VARCHAR(255), expression,  102) + ' 00:00:00 ' +  Right(convert(varchar(255), @arg, 121), 6),  102)
```
to
```
TruncateTime(DateTime X)
PreKatmai:    TRUNCATETIME(X) => DATEADD(d, DATEDIFF(d, 0, expression), 0)
Katmai:       TRUNCATETIME(X) => CAST(CAST(expression AS DATE) as DATETIME2)

TruncateTime(DateTimeOffset X)
Katmai only: TRUNCATETIME(X) => TODATETIMEOFFSET(CAST(expression AS DATE), DATEPART(tz, expression))
```