### PR TITLE
Re-include EntityFramework.SqlServerCompact in setup

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
+        <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..</SolutionDir>
         
         <!-- Enable the restore command to run before builds -->
         <RestorePackages Condition="  '$(RestorePackages)' == '' ">false</RestorePackages>
@@ -33,7 +33,7 @@
     
     <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
         <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
-        <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
+        <NuGetToolsPath>$(SolutionDir)/.nuget</NuGetToolsPath>
         <PackagesConfig>packages.config</PackagesConfig>
     </PropertyGroup>
     
@@ -52,11 +52,8 @@
         <RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
         <NonInteractiveSwitch Condition=" '$(VisualStudioVersion)' != '' AND '$(OS)' == 'Windows_NT' ">-NonInteractive</NonInteractiveSwitch>
         
-        <PaddedSolutionDir Condition=" '$(OS)' == 'Windows_NT' AND '$(PackageRestoreOutputDir)' != ''">"$(PackageRestoreOutputDir) "</PaddedSolutionDir>
-        <PaddedSolutionDir Condition=" '$(OS)' != 'Windows_NT'  AND '$(PackageRestoreOutputDir)' != ''">"$(PackageRestoreOutputDir)"</PaddedSolutionDir>
-
-        <PaddedSolutionDir Condition=" '$(PaddedSolutionDir)' == '' AND '$(OS)' == 'Windows_NT'">"$(SolutionDir) "</PaddedSolutionDir>
-        <PaddedSolutionDir Condition=" '$(PaddedSolutionDir)' == '' AND '$(OS)' != 'Windows_NT' ">"$(SolutionDir)"</PaddedSolutionDir>
+        <PaddedSolutionDir Condition=" '$(PackageRestoreOutputDir)' != ''">"$(PackageRestoreOutputDir)"</PaddedSolutionDir>
+        <PaddedSolutionDir Condition=" '$(PaddedSolutionDir)' == '' ">"$(SolutionDir)"</PaddedSolutionDir>
 
         <!-- Commands -->
         <InstallCommandOptions>$(NonInteractiveSwitch) $(RequireConsentSwitch) $(NoCacheSwitch) $(PreReleaseSwitch) -solutionDir $(PaddedSolutionDir)</InstallCommandOptions>
@@ -135,7 +132,7 @@
 
                     Log.LogMessage("Downloading latest version of NuGet.exe...");
                     WebClient webClient = new WebClient();
-                    webClient.DownloadFile("https://www.nuget.org/nuget.exe", OutputFilename);
+                    webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", OutputFilename);
 
                     return true;
                 }

--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -52,8 +52,8 @@
         <RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
         <NonInteractiveSwitch Condition=" '$(VisualStudioVersion)' != '' AND '$(OS)' == 'Windows_NT' ">-NonInteractive</NonInteractiveSwitch>
         
-        <PaddedSolutionDir Condition=" '$(PackageRestoreOutputDir)' != ''">"$(PackageRestoreOutputDir)"</PaddedSolutionDir>
-        <PaddedSolutionDir Condition=" '$(PaddedSolutionDir)' == '' ">"$(SolutionDir)"</PaddedSolutionDir>
+        <PaddedSolutionDir Condition=" '$(PackageRestoreOutputDir)' != ''">"$(PackageRestoreOutputDir.Trim('\\'))"</PaddedSolutionDir>
+        <PaddedSolutionDir Condition=" '$(PaddedSolutionDir)' == '' ">"$(SolutionDir.Trim('\\'))"</PaddedSolutionDir>
 
         <!-- Commands -->
         <InstallCommandOptions>$(NonInteractiveSwitch) $(RequireConsentSwitch) $(NoCacheSwitch) $(PreReleaseSwitch) -solutionDir $(PaddedSolutionDir)</InstallCommandOptions>

--- a/setup/swix/files.swr
+++ b/setup/swix/files.swr
@@ -11,7 +11,7 @@ package name=eftools
 folder "InstallDir:\Common7\IDE"
   file source="$(OutputPath)\MsiRuntimeInputs\packages\EntityFramework.$(EF6NuGetPackageVersion)\lib\net45\EntityFramework.dll" vs.file.ngen=yes
   file source="$(OutputPath)\MsiRuntimeInputs\packages\EntityFramework.$(EF6NuGetPackageVersion)\lib\net45\EntityFramework.SqlServer.dll" vs.file.ngen=yes
-##LAJ  file source="$(SomePath)\EntityFramework.SqlServerCompact.dll" vs.file.ngen=yes
+  file source="$(SomePath)\EntityFramework.SqlServerCompact.dll" vs.file.ngen=yes
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.BootstrapPackage.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.DatabaseGeneration.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.dll"

--- a/src/EFTools/setup/GenerateMsiInputs/packages.config
+++ b/src/EFTools/setup/GenerateMsiInputs/packages.config
@@ -21,5 +21,5 @@
   <package id="EntityFramework.ru" version="6.2.0" />
   <package id="EntityFramework.zh-Hans" version="6.2.0" />
   <package id="EntityFramework.zh-Hant" version="6.2.0" />
-  <!-- package id="EntityFramework.SqlServerCompact" version="6.2.0" / -->
+  <package id="EntityFramework.SqlServerCompact" version="6.2.0" />
 </packages>


### PR DESCRIPTION
We were downloading an old version of NuGet.exe. So updated the download location. This allows us to re-include EntityFramework.SqlServerCompact in setup.

Addresses issue #917.