### PR TITLE
Re-include EntityFramework.SqlServerCompact in setup

### DIFF
--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -114,15 +114,31 @@ steps:
 
 
 
+- task: NuGetCommand@2
+
+  displayName: 'NuGet Restore Setup Inputs Packages'
+
+  inputs:
+
+    command: custom
+
+    feedsToUse: config
+
+    externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
+
+    arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
+
+
+
 - task: BatchScript@1
 
-  displayName: 'Generate Setup Inputs'
+  displayName: 'Extract Setup Inputs Nuspecs'
 
   inputs:
 
     filename: '$(comspec)'
 
-    arguments: '/c "call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:GenerateMSIInputs"'
+    arguments: '/c "call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:ExtractNuspecs"'
 
 
 

--- a/setup/swix/files.swr
+++ b/setup/swix/files.swr
@@ -11,7 +11,7 @@ package name=eftools
 folder "InstallDir:\Common7\IDE"
   file source="$(OutputPath)\MsiRuntimeInputs\packages\EntityFramework.$(EF6NuGetPackageVersion)\lib\net45\EntityFramework.dll" vs.file.ngen=yes
   file source="$(OutputPath)\MsiRuntimeInputs\packages\EntityFramework.$(EF6NuGetPackageVersion)\lib\net45\EntityFramework.SqlServer.dll" vs.file.ngen=yes
-##LAJ  file source="$(SomePath)\EntityFramework.SqlServerCompact.dll" vs.file.ngen=yes
+  file source="$(SomePath)\EntityFramework.SqlServerCompact.dll" vs.file.ngen=yes
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.BootstrapPackage.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.DatabaseGeneration.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.dll"

--- a/setup/swix/files.swr
+++ b/setup/swix/files.swr
@@ -11,7 +11,7 @@ package name=eftools
 folder "InstallDir:\Common7\IDE"
   file source="$(OutputPath)\MsiRuntimeInputs\packages\EntityFramework.$(EF6NuGetPackageVersion)\lib\net45\EntityFramework.dll" vs.file.ngen=yes
   file source="$(OutputPath)\MsiRuntimeInputs\packages\EntityFramework.$(EF6NuGetPackageVersion)\lib\net45\EntityFramework.SqlServer.dll" vs.file.ngen=yes
-  file source="$(SomePath)\EntityFramework.SqlServerCompact.dll" vs.file.ngen=yes
+  file source="$(OutputPath)\MsiRuntimeInputs\packages\EntityFramework.SqlServerCompact.6.2.0\lib\net45\EntityFramework.SqlServerCompact.dll" vs.file.ngen=yes
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.BootstrapPackage.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.DatabaseGeneration.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.dll"

--- a/src/EFTools/setup/GenerateMsiInputs/packages.config
+++ b/src/EFTools/setup/GenerateMsiInputs/packages.config
@@ -21,5 +21,5 @@
   <package id="EntityFramework.ru" version="6.2.0" />
   <package id="EntityFramework.zh-Hans" version="6.2.0" />
   <package id="EntityFramework.zh-Hant" version="6.2.0" />
-  <!-- package id="EntityFramework.SqlServerCompact" version="6.2.0" / -->
+  <package id="EntityFramework.SqlServerCompact" version="6.2.0" />
 </packages>


### PR DESCRIPTION
Updated the way MicroBuild works to use their version of NuGet (with their credentials manager) to restore the packages needed for setup. Then keep only the part of the following MicroBuild task which extracts the nuspecs. This allows us to re-include EntityFramework.SqlServerCompact in setup.

Addresses issue #917.