### PR TITLE
Bug 898645. Workaround NRE from runtime.

### DIFF
--- a/src/EFTools/EntityDesign/VisualStudio/VsUtils.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/VsUtils.cs
@@ -2224,7 +2224,15 @@ namespace Microsoft.Data.Entity.Design.VisualStudio
                 new ExeConfigurationFileMap { ExeConfigFilename = configurationFile },
                 ConfigurationUserLevel.None);
 
-            return new AppConfigReader(configuration).GetProviderServices(invariantName);
+            //TODO - correct the runtime to no longer throw this - see https://github.com/aspnet/EntityFramework6/issues/1121
+            try
+            {
+                return new AppConfigReader(configuration).GetProviderServices(invariantName);
+            }
+            catch (NullReferenceException)
+            {
+                return null;
+            }
         }
 
         internal static string GetProviderManifestTokenConnected(


### PR DESCRIPTION
Workaround for an issue a couple of users are seeing where we don't guard against null being returned and end up with an NRE.