### PR TITLE
Add paragraphs to make remarks more readable

### DIFF
--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -23,36 +23,55 @@ namespace System.Data.Entity
     /// DbContext is conceptually similar to ObjectContext.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// DbContext is usually used with a derived type that contains <see cref="DbSet{TEntity}" /> properties for
     /// the root entities of the model. These sets are automatically initialized when the
     /// instance of the derived class is created.  This behavior can be modified by applying the
     /// <see cref="SuppressDbSetInitializationAttribute" />  attribute to either the entire derived context
     /// class, or to individual properties on the class.
-    /// The Entity Data Model backing the context can be specified in several ways.  When using the Code First
+    /// </para>
+    /// <para>
+    /// The Entity Data Model backing the context can be specified in several ways.
+    /// </para>
+    /// <para>
+    /// When using the Code First
     /// approach, the <see cref="DbSet{TEntity}" /> properties on the derived context are used to build a model
     /// by convention.  The protected OnModelCreating method can be overridden to tweak this model.  More
     /// control over the model used for the Model First approach can be obtained by creating a <see cref="DbCompiledModel" />
     /// explicitly from a <see cref="DbModelBuilder" /> and passing this model to one of the DbContext constructors.
+    /// </para>
+    /// <para>
     /// When using the Database First or Model First approach the Entity Data Model can be created using the
     /// Entity Designer (or manually through creation of an EDMX file) and then this model can be specified using
     /// entity connection string or an <see cref="System.Data.Entity.Core.EntityClient.EntityConnection" /> object.
     /// The connection to the database (including the name of the database) can be specified in several ways.
+    /// </para>
+    /// <para>
     /// If the parameterless DbContext constructor is called from a derived context, then the name of the derived context
     /// is used to find a connection string in the app.config or web.config file.  If no connection string is found, then
     /// the name is passed to the DefaultConnectionFactory registered on the <see cref="Entity.Database" /> class.  The connection
     /// factory then uses the context name as the database name in a default connection string.  (This default connection
     /// string points to (localdb)\MSSQLLocalDB unless a different DefaultConnectionFactory is registered.)
+    /// </para>
+    /// <para>
     /// Instead of using the derived context name, the connection/database name can also be specified explicitly by
     /// passing the name to one of the DbContext constructors that takes a string.  The name can also be passed in
     /// the form "name=myname", in which case the name must be found in the config file or an exception will be thrown.
+    /// </para>
+    /// <para>
     /// Note that the connection found in the app.config or web.config file can be a normal database connection
     /// string (not a special Entity Framework connection string) in which case the DbContext will use Code First.
     /// However, if the connection found in the config file is a special Entity Framework connection string, then the
     /// DbContext will use Database/Model First and the model specified in the connection string will be used.
+    /// </para>
+    /// <para>
     /// An existing or explicitly created DbConnection can also be used instead of the database/connection name.
+    /// </para>
+    /// <para>
     /// A <see cref="DbModelBuilderVersionAttribute" /> can be applied to a class derived from DbContext to set the
     /// version of conventions used by the context when it creates a model. If no attribute is applied then the
     /// latest version of conventions will be used.
+    /// </para>
     /// </remarks>
     public class DbContext : IDisposable, IObjectContextAdapter
     {


### PR DESCRIPTION
Without the `para` tags the text will be collapsed into a single, huge
paragraph making it very hard to read with how much content is in there.

This change adds the `para` tags to declare paragraphs where they were
seemingly intended anyway, except for one instance where a new
paragraph/split is introduced.

https://docs.microsoft.com/en-us/dotnet/api/system.data.entity.dbcontext?view=entity-framework-6.2.0#remarks