### PR TITLE
Fixes System.ArgumentException when GetAncestor returns the root node

### DIFF
--- a/src/EntityFramework/Hierarchy/HierarchyId.cs
+++ b/src/EntityFramework/Hierarchy/HierarchyId.cs
@@ -97,6 +97,10 @@ namespace System.Data.Entity.Hierarchy
             {
                 return new HierarchyId(null);
             }
+            else if (GetLevel() == n)
+            {
+                return new HierarchyId(PathSeparator);
+            }
             string hierarchyStr = PathSeparator +
                                   string.Join(PathSeparator, _nodes.Take(GetLevel() - n).Select(IntArrayToStirng))
                                   + PathSeparator;

--- a/test/EntityFramework/UnitTests/Hierarchy/HierarchyIdUnitTests.cs
+++ b/test/EntityFramework/UnitTests/Hierarchy/HierarchyIdUnitTests.cs
@@ -21,6 +21,7 @@ namespace System.Data.Entity.Spatial
             Assert.Equal(new HierarchyId("/1/2.1/3/").GetAncestor(2), new HierarchyId("/1/"));
             Assert.Equal(new HierarchyId("/1/").GetAncestor(2) == null, true);
             Assert.Equal(new HierarchyId("/1/").GetAncestor(2) == new HierarchyId(null), true);
+            Assert.Equal(new HierarchyId("/1/").GetAncestor(1), new HierarchyId("/"));
             Assert.Equal(new HierarchyId("/1/").IsDescendantOf(null), true);
             Assert.Equal(new HierarchyId("/1/").IsDescendantOf(new HierarchyId(null)), true);
             Assert.Equal(new HierarchyId("/1/2/").IsDescendantOf(new HierarchyId("/")), true);


### PR DESCRIPTION
The method 'GetAncestor' throws an ArgumentException when the found ancestor is the root node, because hierarchyStr is '//', which is not a valid value.

Now this method checks if the level of the current node and the n parameter is the same, and in this case returns the root node.
Added new test case to check this behaviour