### PR TITLE
Allow forcing DateTime parameters to DateTime or DateTime2

### DIFF
--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -13,6 +13,7 @@ namespace System.Data.Entity
     using System.Data.Entity.Utilities;
     using System.Data.Entity.Validation;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -63,7 +64,8 @@ namespace System.Data.Entity
 
         private Database _database;
 
-        
+        private ForceDateTimeTypeAttribute _forcedDateTimeTypeAttribute;
+
         /// <summary>
         /// Constructs a new context instance using conventions to create the name of the database to
         /// which a connection will be made.  The by-convention name is the full name (namespace + class name)
@@ -76,7 +78,7 @@ namespace System.Data.Entity
         {
             InitializeLazyInternalContext(new LazyInternalConnection(this, GetType().DatabaseName()));
         }
-
+        
         /// <summary>
         /// Constructs a new context instance using conventions to create the name of the database to
         /// which a connection will be made, and initializes it from the given model.
@@ -203,6 +205,20 @@ namespace System.Data.Entity
         private void DiscoverAndInitializeSets()
         {
             new DbSetDiscoveryService(this).InitializeSets();
+        }
+
+        internal DbType? ForcedDateTimeType
+        {
+            get
+            {
+                if (_forcedDateTimeTypeAttribute == null)
+                {
+                    _forcedDateTimeTypeAttribute 
+                        = GetType().GetCustomAttributes(inherit: false).OfType<ForceDateTimeTypeAttribute>().FirstOrDefault();
+                }
+                
+                return _forcedDateTimeTypeAttribute?.DateTimeType;
+            }
         }
 
         #endregion

--- a/src/EntityFramework/Infrastructure/ForceDateTimeTypeAttribute.cs
+++ b/src/EntityFramework/Infrastructure/ForceDateTimeTypeAttribute.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace System.Data.Entity.Infrastructure
+{
+    /// <summary>
+    /// Place this attribute on a type that inherits from <see cref="System.Data.Entity.DbContext"/> to
+    /// force all <see cref="System.DateTime"/> parameters to have the given <see cref="System.Data.DbType"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class ForceDateTimeTypeAttribute : Attribute
+    {
+        private readonly DbType _type;
+
+        /// <summary>
+        /// Creates a new <see cref="ForceDateTimeTypeAttribute"/> instance with the given <see cref="System.Data.DbType"/>. 
+        /// </summary>
+        /// <param name="type"> The type to force. </param>
+        public ForceDateTimeTypeAttribute(DbType type)
+        {
+            _type = type;
+        }
+
+        /// <summary>
+        /// The <see cref="System.Data.DbType"/> that will be forced for all <see cref="System.DateTime"/> parameters.
+        /// </summary>
+        public DbType DateTimeType
+        {
+            get { return _type; }
+        }
+    }
+}

--- a/src/EntityFramework/Infrastructure/Interception/DbCommandDispatcher.cs
+++ b/src/EntityFramework/Infrastructure/Interception/DbCommandDispatcher.cs
@@ -6,6 +6,7 @@ namespace System.Data.Entity.Infrastructure.Interception
     using System.Data.Common;
     using System.Data.Entity.Utilities;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -53,12 +54,30 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
 
+            ForceDateTimeTypes(command, interceptionContext);
+
             return _internalDispatcher.Dispatch(
                 command,
                 (t, c) => t.ExecuteNonQuery(),
                 new DbCommandInterceptionContext<int>(interceptionContext),
                 (i, t, c) => i.NonQueryExecuting(t, c),
                 (i, t, c) => i.NonQueryExecuted(t, c));
+        }
+
+        private static void ForceDateTimeTypes(DbCommand command, DbCommandInterceptionContext interceptionContext)
+        {
+            var forcedDateTimeType = interceptionContext.ForcedDateTimeType;
+            if (forcedDateTimeType.HasValue)
+            {
+                foreach (DbParameter parameter in command.Parameters)
+                {
+                    if (parameter.DbType == DbType.DateTime
+                        || parameter.DbType == DbType.DateTime2)
+                    {
+                        parameter.DbType = forcedDateTimeType.Value;
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -79,6 +98,8 @@ namespace System.Data.Entity.Infrastructure.Interception
         {
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
+
+            ForceDateTimeTypes(command, interceptionContext);
 
             return _internalDispatcher.Dispatch(
                 command,
@@ -107,6 +128,8 @@ namespace System.Data.Entity.Infrastructure.Interception
         {
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
+
+            ForceDateTimeTypes(command, interceptionContext);
 
             return _internalDispatcher.Dispatch(
                 command,
@@ -138,6 +161,8 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
 
+            ForceDateTimeTypes(command, interceptionContext);
+
             return _internalDispatcher.DispatchAsync(
                 command,
                 (t, c, ct) => t.ExecuteNonQueryAsync(ct),
@@ -168,6 +193,8 @@ namespace System.Data.Entity.Infrastructure.Interception
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
 
+            ForceDateTimeTypes(command, interceptionContext);
+
             return _internalDispatcher.DispatchAsync(
                 command,
                 (t, c, ct) => t.ExecuteScalarAsync(ct),
@@ -197,6 +224,8 @@ namespace System.Data.Entity.Infrastructure.Interception
         {
             Check.NotNull(command, "command");
             Check.NotNull(interceptionContext, "interceptionContext");
+
+            ForceDateTimeTypes(command, interceptionContext);
 
             return _internalDispatcher.DispatchAsync(
                 command,

--- a/src/EntityFramework/Infrastructure/Interception/DbCommandInterceptionContext.cs
+++ b/src/EntityFramework/Infrastructure/Interception/DbCommandInterceptionContext.cs
@@ -46,7 +46,7 @@ namespace System.Data.Entity.Infrastructure.Interception
                 _commandBehavior = asThisType._commandBehavior;
             }
         }
-
+        
         /// <summary>
         /// The <see cref="CommandBehavior" /> that will be used or has been used to execute the command with a
         /// <see cref="DbDataReader" />. This property is only used for <see cref="DbCommand.ExecuteReader(System.Data.CommandBehavior)" />

--- a/test/EntityFramework/FunctionalTests/Interception/BlogContext.cs
+++ b/test/EntityFramework/FunctionalTests/Interception/BlogContext.cs
@@ -29,7 +29,8 @@ namespace System.Data.Entity.Interception
             blog.Posts.Add(
                 new Post
                 {
-                    Title = "Throw it away..."
+                    Title = "Throw it away...",
+                    Spacetime = new DateTime(1915, 11, 25)
                 });
 
             ExtendedSqlAzureExecutionStrategy.ExecuteNew(
@@ -75,6 +76,8 @@ namespace System.Data.Entity.Interception
             public string Title { get; set; }
 
             public virtual ICollection<Post> Posts { get; set; }
+
+            public DateTime TimeDilation { get; set; }
         }
 
         public class Post
@@ -84,6 +87,8 @@ namespace System.Data.Entity.Interception
 
             public int BlogId { get; set; }
             public virtual Blog Blog { get; set; }
+            
+            public DateTime Spacetime { get; set; }
         }
 
         public class BlogInitializer : DropCreateDatabaseAlways<BlogContext>
@@ -94,9 +99,11 @@ namespace System.Data.Entity.Interception
                     new Post
                         {
                             Title = "Wrap it up...",
+                            Spacetime = new DateTime(1915, 11, 25),
                             Blog = new Blog
                                 {
-                                    Title = "Half a Unicorn"
+                                    Title = "Half a Unicorn",
+                                    TimeDilation = new DateTime(1905, 6, 30)
                                 }
                         });
             }

--- a/test/EntityFramework/FunctionalTests/Interception/CommitFailureTests.cs
+++ b/test/EntityFramework/FunctionalTests/Interception/CommitFailureTests.cs
@@ -178,7 +178,7 @@ namespace System.Data.Entity.Interception
                         });
 
                     failingTransactionInterceptor.ShouldFailTimes = 1;
-                    context.Blogs.Add(new BlogContext.Blog());
+                    context.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
                     verifySaveChanges(() => context.SaveChanges());
 
                     var expectedCommitCount = useTransactionHandler
@@ -329,7 +329,7 @@ namespace System.Data.Entity.Interception
                     failingCommandInterceptor.FailAfter = 1;
                     failingCommandInterceptor.ShouldFailTimes = queryFailures;
 
-                    context.Blogs.Add(new BlogContext.Blog());
+                    context.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
 
                     runAndVerify(context);
 
@@ -428,7 +428,7 @@ namespace System.Data.Entity.Interception
 
                     for (var i = 0; i < transactionHandler.PruningLimit; i++)
                     {
-                        context.Blogs.Add(new BlogContext.Blog());
+                        context.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
                         context.SaveChanges();
                     }
 
@@ -440,10 +440,10 @@ namespace System.Data.Entity.Interception
                         failingTransactionInterceptor.ShouldRollBack = false;
                     }
 
-                    context.Blogs.Add(new BlogContext.Blog());
+                    context.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
                     context.SaveChanges();
 
-                    context.Blogs.Add(new BlogContext.Blog());
+                    context.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
                     context.SaveChanges();
 
                     AssertTransactionHistoryCount(context, 1);
@@ -679,7 +679,7 @@ namespace System.Data.Entity.Interception
                     context.Database.Delete();
                     Assert.Equal(1, context.Blogs.Count());
 
-                    context.Blogs.Add(new BlogContext.Blog());
+                    context.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
 
                     context.SaveChanges();
 
@@ -790,7 +790,7 @@ namespace System.Data.Entity.Interception
                             Assert.Equal(1, context.Blogs.Count());
                         });
 
-                    context.Blogs.Add(new BlogContext.Blog());
+                    context.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
 
                     ExtendedSqlAzureExecutionStrategy.ExecuteNew(
                         () =>
@@ -802,7 +802,7 @@ namespace System.Data.Entity.Interception
                                     using (var innerTransaction = innerContext.Database.BeginTransaction())
                                     {
                                         Assert.Equal(1, innerContext.Blogs.Count());
-                                        innerContext.Blogs.Add(new BlogContext.Blog());
+                                        innerContext.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
                                         innerContext.SaveChanges();
                                         innerTransaction.Commit();
                                     }
@@ -853,7 +853,7 @@ namespace System.Data.Entity.Interception
 
                 using (var context = new BlogContextCommit())
                 {
-                    context.Blogs.Add(new BlogContext.Blog());
+                    context.Blogs.Add(new BlogContext.Blog { TimeDilation = new DateTime(1905, 6, 30) });
 
                     Assert.Throws<EntityException>(() => context.SaveChanges());
 

--- a/test/EntityFramework/FunctionalTests/Interception/DatabaseLogFormatterTests.cs
+++ b/test/EntityFramework/FunctionalTests/Interception/DatabaseLogFormatterTests.cs
@@ -63,7 +63,7 @@ namespace System.Data.Entity.Interception
             const int selectCount = 5;
             const int updateCount = 1;
             const int asyncCount = 2;
-            const int paramCount = 4;
+            const int paramCount = 5;
             const int imALoggerCount = 1;
             const int transactionCount = 2;
             const int connectionCount = 4;
@@ -187,7 +187,7 @@ namespace System.Data.Entity.Interception
             Assert.Equal(3, logLines.Length);
 
             Assert.Equal(
-                "Context 'BlogContextNoInit' is executing command 'SELECT TOP (2) [c].[Id] AS [Id], [c].[Title] AS [Title] FROM [dbo].[Blogs] AS [c]'",
+                "Context 'BlogContextNoInit' is executing command 'SELECT TOP (2) [c].[Id] AS [Id], [c].[Title] AS [Title], [c].[TimeDilation] AS [TimeDilation] FROM [dbo].[Blogs] AS [c]'",
                 logLines[0]);
 
             Assert.Equal(


### PR DESCRIPTION
Fixes #578

Introduces an attribute which can be placed on a `DbContext`:

```C#
[ForceDateTimeType(DbType.DateTime)]
public class BloggingContext : DbContext
{
}
```
that will then cause all parameters used with this context type to be forced to the given DateTime type.