### PR TITLE
Partial fix for build problems.

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -27,13 +27,13 @@
     
     <PropertyGroup Condition=" '$(OS)' == 'Windows_NT'">
         <!-- Windows specific commands -->
-        <NuGetToolsPath>$([System.IO.Path]::Combine($(SolutionDir), ".nuget"))</NuGetToolsPath>
-        <PackagesConfig>$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
+        <NuGetToolsPath>$([System.IO.Path]::Combine($(SolutionDir.Trim(' ')), ".nuget"))</NuGetToolsPath>
+        <PackagesConfig>$([System.IO.Path]::Combine($(ProjectDir.Trim(' ')), "packages.config"))</PackagesConfig>
     </PropertyGroup>
     
     <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
         <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
-        <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
+        <NuGetToolsPath>$(SolutionDir.Trim(' ')).nuget</NuGetToolsPath>
         <PackagesConfig>packages.config</PackagesConfig>
     </PropertyGroup>
     

--- a/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
+++ b/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
@@ -71,7 +71,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Design" />
-    <Reference Condition="'$(VisualStudioVersion)' == '16.0'" Include="Microsoft.VisualStudio.Threading, Version=16.0.0.0" />
+    <Reference Condition="'$(VisualStudioVersion)' == '16.0'" Include="Microsoft.VisualStudio.Threading, Version=16.3.0.0" />
     <Reference Include="vslangproj" />
     <Reference Include="vslangproj2" />
     <Reference Include="vslangproj80" />

--- a/src/Strict.ruleset
+++ b/src/Strict.ruleset
@@ -5,5 +5,6 @@
     <Rule Id="CA1062" Action="None" />
     <Rule Id="CA2243" Action="None" />
     <Rule Id="CA1809" Action="None" />
+    <Rule Id="CA1305" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Some updates to fix the build:

1. updates so the paths build on the local machine as well as on CI
2. update to 16.3 version of `Microsoft.VisualStudio.Threading`
3. ignore CA1305 - this is a new CodeAnalysis rule to which we have many exceptions. It's about if you convert an int (or long etc) to string automatically in e.g. `Debug.Assert(someCount < 2, "Actual count is " + someCount)`, they want you to provide an `IFormatProvider` every time. We have many of these - and the exact format of the string never matters - the number we're putting out would be in the single digits anyway and we don't really care about the exact format of the string even if it got into the 1000's. Simplest answer is just to disable this error.

Note: still having problems with the build after that but would like to get this much in before I go on vacation.