### PR TITLE
Revert ef6.exe to .NET Core 3.0

### DIFF
--- a/src/NuGet/EntityFramework/EntityFramework.NuGet.nuspec
+++ b/src/NuGet/EntityFramework/EntityFramework.NuGet.nuspec
@@ -31,9 +31,9 @@
     <file src="../../../artifacts/bin/ef6/$Configuration$/net40/ef6.pdb" target="tools/net40/any/" />
     <file src="../../../artifacts/bin/ef6/$Configuration$/net45/ef6.exe" target="tools/net45/any/" />
     <file src="../../../artifacts/bin/ef6/$Configuration$/net45/ef6.pdb" target="tools/net45/any/" />
-    <file src="../../../artifacts/bin/ef6/$Configuration$/$DefaultNetCoreTargetFramework$/ef6.dll" target="tools/$DefaultNetCoreTargetFramework$/any/" />
-    <file src="../../../artifacts/bin/ef6/$Configuration$/$DefaultNetCoreTargetFramework$/ef6.pdb" target="tools/$DefaultNetCoreTargetFramework$/any/" />
-    <file src="../../../artifacts/bin/ef6/$Configuration$/$DefaultNetCoreTargetFramework$/ef6.runtimeconfig.json" target="tools/$DefaultNetCoreTargetFramework$/any/" />
+    <file src="../../../artifacts/bin/ef6/$Configuration$/netcoreapp3.0/ef6.dll" target="tools/netcoreapp3.0/any/" />
+    <file src="../../../artifacts/bin/ef6/$Configuration$/netcoreapp3.0/ef6.pdb" target="tools/netcoreapp3.0/any/" />
+    <file src="../../../artifacts/bin/ef6/$Configuration$/netcoreapp3.0/ef6.runtimeconfig.json" target="tools/netcoreapp3.0/any/" />
     <file src="../../../artifacts/bin/ef6/x86/$Configuration$/net40/ef6.exe" target="tools/net40/win-x86/" />
     <file src="../../../artifacts/bin/ef6/x86/$Configuration$/net40/ef6.pdb" target="tools/net40/win-x86/" />
     <file src="../../../artifacts/bin/ef6/x86/$Configuration$/net45/ef6.exe" target="tools/net45/win-x86/" />

--- a/src/NuGet/EntityFramework/build/netcoreapp3.0/EntityFramework.props
+++ b/src/NuGet/EntityFramework/build/netcoreapp3.0/EntityFramework.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+  <Import Project="..\EntityFramework.props" />
+</Project>

--- a/src/NuGet/EntityFramework/build/netcoreapp3.0/EntityFramework.targets
+++ b/src/NuGet/EntityFramework/build/netcoreapp3.0/EntityFramework.targets
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\EntityFramework.targets" />
+</Project>

--- a/src/NuGet/EntityFramework/buildTransitive/netcoreapp3.0/EntityFramework.props
+++ b/src/NuGet/EntityFramework/buildTransitive/netcoreapp3.0/EntityFramework.props
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\build\netcoreapp3.0\EntityFramework.props" />
+</Project>

--- a/src/NuGet/EntityFramework/buildTransitive/netcoreapp3.0/EntityFramework.targets
+++ b/src/NuGet/EntityFramework/buildTransitive/netcoreapp3.0/EntityFramework.targets
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\build\netcoreapp3.0\EntityFramework.targets" />
+</Project>

--- a/src/NuGet/EntityFramework/tools/EntityFramework6.psm1
+++ b/src/NuGet/EntityFramework/tools/EntityFramework6.psm1
@@ -862,7 +862,7 @@ function EF6($project, $startupProject, $workingDir, $params)
         $projectAssetsFile = GetCpsProperty $project 'ProjectAssetsFile'
         $runtimeConfig = Join-Path $targetDir ($targetName + '.runtimeconfig.json')
         $runtimeFrameworkVersion = GetCpsProperty $project 'RuntimeFrameworkVersion'
-        $efPath = Join-Path $PSScriptRoot 'netcoreapp3.1\any\ef6.dll'
+        $efPath = Join-Path $PSScriptRoot 'netcoreapp3.0\any\ef6.dll'
 
         $dotnetParams = 'exec', '--depsfile', $depsFile
 

--- a/src/ef6/ef6.csproj
+++ b/src/ef6/ef6.csproj
@@ -2,8 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework);net40;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net40;net45</TargetFrameworks>
     <RootNamespace>System.Data.Entity.Tools</RootNamespace>
+    <!--
+      This keeps ef6.exe targeting the default version of .NET Core for netcoreapp3.0,
+      which maximizes the machines on which this tool will be compatible.
+    -->
+    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' ">false</TargetLatestDotNetRuntime>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
This improves compatibility. In short, we'll compile against the lowest possible target framework and try to execute on the exact same target framework as the target project.

This also forces the *.runtimeconfig.json file to be generated on class library projects so we actually know the target framework.

Fixes #1400