### PR TITLE
[release/6.3] Use correct pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,10 +33,10 @@ stages:
           - job: Windows
             timeoutInMinutes: 180
             pool:
-              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: NetCorePublic-Pool
                 queue: BuildPool.Windows.10.Amd64.VS2017.Open
-              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+              ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCoreInternal-Pool
                 queue: BuildPool.Windows.10.Amd64.VS2017
             variables:


### PR DESCRIPTION
Use internal pools on the internal project always.