### PR TITLE
Do not specify version of Microsoft.VisualStudio.Threading

### DIFF
--- a/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
+++ b/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
@@ -71,7 +71,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Design" />
-    <Reference Condition="'$(VisualStudioVersion)' == '16.0'" Include="Microsoft.VisualStudio.Threading, Version=16.3.0.0" />
+    <Reference Condition="'$(VisualStudioVersion)' == '16.0'" Include="Microsoft.VisualStudio.Threading" />
     <Reference Include="vslangproj" />
     <Reference Include="vslangproj2" />
     <Reference Include="vslangproj80" />


### PR DESCRIPTION
We should not specify which version of Microsoft.VisualStudio.Threading - but rather just pick up the latest. Fixes build break on VS2019 (as of 16.4). 